### PR TITLE
BTAT-94: Added Session Timeout Route, Controller, View and Tests

### DIFF
--- a/app/controllers/SessionTimeoutController.scala
+++ b/app/controllers/SessionTimeoutController.scala
@@ -16,10 +16,19 @@
 
 package controllers
 
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
+import config.AppConfig
+import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 
-class SessionTimeoutController @Inject() extends FrontendController {
-  val timeout: Action[AnyContent] = TODO
+import scala.concurrent.Future
+
+@Singleton
+class SessionTimeoutController @Inject()(implicit val config: AppConfig,
+                                          val messagesApi: MessagesApi
+                                        ) extends FrontendController with I18nSupport {
+  val timeout: Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(views.html.timeout.timeout()))
+  }
 }

--- a/app/controllers/SessionTimeoutController.scala
+++ b/app/controllers/SessionTimeoutController.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import com.google.inject.Inject
+import play.api.mvc._
+import uk.gov.hmrc.play.frontend.controller.FrontendController
+
+class SessionTimeoutController @Inject() extends FrontendController {
+  val timeout: Action[AnyContent] = TODO
+}

--- a/app/views/timeout/timeout.scala.html
+++ b/app/views/timeout/timeout.scala.html
@@ -1,4 +1,4 @@
-/*
+@*
  * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,22 +12,16 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ *@
 
-package controllers
+@import views.html.main_template
+@import config.AppConfig
 
-import com.google.inject.Inject
-import config.AppConfig
-import play.api.Play.current
-import play.api.i18n.Messages.Implicits._
-import play.api.mvc._
-import uk.gov.hmrc.play.frontend.controller.FrontendController
+@()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
-import scala.concurrent.Future
+@main_template(title = messages("timeout.title"), bodyClasses = None, appConfig = appConfig) {
 
+ <h1>@Messages("timeout.heading")</h1>
+ <p id="sign-in">@Html(Messages("timeout.signIn", controllers.routes.HelloWorld.helloWorld().url))</p>
 
-class HelloWorld @Inject()(implicit val config: AppConfig) extends FrontendController {
-  val helloWorld = Action.async { implicit request =>
-    Future.successful(Ok(views.html.helloworld.hello_world(config)))
-  }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -7,3 +7,6 @@ GET         /                           controllers.HelloWorld.helloWorld
 GET         /feedback                   controllers.FeedbackController.show
 POST        /feedback                   controllers.FeedbackController.submit
 GET         /thankyou                   controllers.FeedbackController.thankyou
+
+#Timeout Routes
+GET         /session-timeout            controllers.SessionTimeoutController.timeout

--- a/conf/messages
+++ b/conf/messages
@@ -1,5 +1,10 @@
 #Base
-base.back = Back
-base.service_name = Check your income tax and expenses
+base.back                                                       = Back
+base.service_name                                               = Check your income tax and expenses
 
-base.phase = BETA
+base.phase                                                      = BETA
+
+## Timeout page ##
+timeout.title                                                   = Your session has timed out
+timeout.heading                                                 = Your session has timed out
+timeout.signIn                                                  = To view your quarterly reporting details, you''ll have to <a id="sign-in-link" href="{0}" rel="external">sign in</a> using your Government Gateway ID.

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -20,7 +20,7 @@ object FrontendBuild extends Build with MicroService {
   val govTemplateVersion        = "5.2.0"
   val playHealthVersion         = "2.1.0"
   val playUiVersion             = "7.2.1"
-
+  val scalaTestPlusVersion = "2.0.0"
   val hmrcTestVesrion           = "2.3.0"
   val scalatestVersion          = "3.0.0"
   val pegdownVersion            = "1.6.0"
@@ -41,6 +41,7 @@ object FrontendBuild extends Build with MicroService {
   def test(scope: String = "test") = Seq(
     "uk.gov.hmrc" %% "hmrctest" % hmrcTestVesrion % scope,
     "org.scalatest" %% "scalatest" % scalatestVersion % scope,
+    "org.scalatestplus.play" %% "scalatestplus-play" % scalaTestPlusVersion % scope,
     "org.pegdown" % "pegdown" % pegdownVersion % scope,
     "org.jsoup" % "jsoup" % jsoupVersion % scope,
     "com.typesafe.play" %% "play-test" % PlayVersion.current % scope

--- a/test/assets/Messages.scala
+++ b/test/assets/Messages.scala
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-package controllers
+package assets
 
-import com.google.inject.Inject
-import config.AppConfig
-import play.api.Play.current
-import play.api.i18n.Messages.Implicits._
-import play.api.mvc._
-import uk.gov.hmrc.play.frontend.controller.FrontendController
+object Messages {
 
-import scala.concurrent.Future
-
-
-class HelloWorld @Inject()(implicit val config: AppConfig) extends FrontendController {
-  val helloWorld = Action.async { implicit request =>
-    Future.successful(Ok(views.html.helloworld.hello_world(config)))
+  // Timeout Messages
+  object Timeout {
+    val title = "Your session has timed out"
+    val heading = "Your session has timed out"
+    val signIn = "To view your quarterly reporting details, you'll have to sign in using your Government Gateway ID."
   }
 }

--- a/test/controllers/SessionTimeoutControllerSpec.scala
+++ b/test/controllers/SessionTimeoutControllerSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import play.api.http.Status
+import play.api.test.FakeRequest
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+class SessionTimeoutControllerSpec extends  UnitSpec with WithFakeApplication{
+
+  object TestSessionTimeoutController extends SessionTimeoutController
+
+  "Calling the timeout action of the SessionTimeoutController" should {
+
+    lazy val result = TestSessionTimeoutController.timeout(FakeRequest())
+
+    "return NOT_IMPLEMENTED (501)" in {
+      status(result) shouldBe Status.NOT_IMPLEMENTED
+    }
+  }
+}

--- a/test/controllers/SessionTimeoutControllerSpec.scala
+++ b/test/controllers/SessionTimeoutControllerSpec.scala
@@ -18,18 +18,37 @@ package controllers
 
 import play.api.http.Status
 import play.api.test.FakeRequest
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import play.api.test.Helpers._
+import assets.Messages.{Timeout => messages}
+import config.MockAppConfig
+import org.jsoup.Jsoup
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.i18n.MessagesApi
 
-class SessionTimeoutControllerSpec extends  UnitSpec with WithFakeApplication{
+class SessionTimeoutControllerSpec extends PlaySpec with GuiceOneServerPerSuite {
 
-  object TestSessionTimeoutController extends SessionTimeoutController
+  object TestSessionTimeoutController extends SessionTimeoutController()(
+    MockAppConfig,
+    app.injector.instanceOf[MessagesApi]
+  )
 
   "Calling the timeout action of the SessionTimeoutController" should {
 
     lazy val result = TestSessionTimeoutController.timeout(FakeRequest())
+    lazy val document = Jsoup.parse(contentAsString(result))
 
-    "return NOT_IMPLEMENTED (501)" in {
-      status(result) shouldBe Status.NOT_IMPLEMENTED
+    "return OK (200)" in {
+      status(result) mustBe Status.OK
+    }
+
+    "return HTML" in {
+      contentType(result) mustBe Some("text/html")
+      charset(result) mustBe Some("utf-8")
+    }
+
+    s"have the title '${messages.title}'" in {
+      document.title() mustBe messages.title
     }
   }
 }

--- a/test/routes/RoutesSpec.scala
+++ b/test/routes/RoutesSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package routes
+
+import org.scalatestplus.play.{OneAppPerTest, PlaySpec}
+
+class RoutesSpec extends PlaySpec with OneAppPerTest {
+
+  val contextRoute: String = "/check-your-income-tax-and-expenses"
+
+  // Timeout routes
+  "The URL for the SessionTimeoutController.timeout action" should {
+    s"be equal to $contextRoute/session-timeout" in {
+      controllers.routes.SessionTimeoutController.timeout().url must be(s"$contextRoute/session-timeout")
+    }
+  }
+}

--- a/test/views/SessionTimeoutViewSpec.scala
+++ b/test/views/SessionTimeoutViewSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import assets.Messages.{Timeout => messages}
+import config.MockAppConfig
+import org.jsoup.Jsoup
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.i18n.Messages.Implicits._
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+class SessionTimeoutViewSpec extends PlaySpec with GuiceOneServerPerSuite {
+
+  lazy val page = views.html.timeout.timeout()(FakeRequest(), applicationMessages, MockAppConfig)
+  lazy val document = Jsoup.parse(contentAsString(page))
+
+  "The Session timeout view" should {
+
+    s"have the title '${messages.title}'" in {
+      document.title() mustBe messages.title
+    }
+
+    s"have the H1 '${messages.heading}'" in {
+      document.getElementsByTag("H1").text() mustBe messages.heading
+    }
+
+    s"have a paragraph" which {
+
+      "has the text" in {
+        document.getElementById("sign-in").text() mustBe messages.signIn
+      }
+
+      // TODO: Update with the Home Controller route which will re-direct to Sign-In
+      "has a link to sign-in page" in {
+        document.getElementById("sign-in-link").attr("href") mustBe controllers.routes.HelloWorld.helloWorld().url
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
**Note**
At the moment, the sign-in button re-directs to the HellWorld page. This will need to be re-wired to re-direct the user to either the GG sign in page or to our HomeController (which will in turn re-direct to GG sign-in once the authentication piece has been implemented).