### PR TITLE
[BTAT-118] - Added EstimatedTaxLiability service to call connector and translate JSON to model

### DIFF
--- a/app/connectors/EstimatedTaxLiabilityConnector.scala
+++ b/app/connectors/EstimatedTaxLiabilityConnector.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import javax.inject.{Inject, Singleton}
+
+import models.{ConnectorResponseModel, ErrorResponse, SuccessResponse}
+import play.api.Logger
+import play.api.http.Status._
+import uk.gov.hmrc.play.config.ServicesConfig
+import uk.gov.hmrc.play.http.{HeaderCarrier, _}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+@Singleton
+class EstimatedTaxLiabilityConnector @Inject()(val http: HttpGet) extends ServicesConfig with RawResponseReads {
+
+  lazy val protectedMicroserviceUrl: String = baseUrl("income-tax-view-change")
+  lazy val getEstimatedTaxLiabilityUrl: String => String = mtditid => s"$protectedMicroserviceUrl/income-tax-view-change/estimated-tax-liability/$mtditid"
+
+  def getEstimatedTaxLiability(mtditid: String)(implicit headerCarrier: HeaderCarrier): Future[ConnectorResponseModel] = {
+
+    val url = getEstimatedTaxLiabilityUrl(mtditid)
+    Logger.debug(s"[EstimatedTaxLiabilityConnector][getEstimatedTaxLiability] - GET $url")
+
+    http.GET[HttpResponse](url) flatMap {
+      response =>
+        response.status match {
+          case OK =>
+            Logger.debug(s"[EstimatedTaxLiabilityConnector][getEstimatedTaxLiability] - RESPONSE status: ${response.status}, body: ${response.body}")
+            Future.successful(SuccessResponse(response.json))
+          case _ =>
+            Logger.warn(s"[EstimatedTaxLiabilityConnector][getEstimatedTaxLiability] - RESPONSE status: ${response.status}, body: ${response.body}")
+            Future.successful(ErrorResponse(response.status, response.body))
+        }
+    }
+  }
+}

--- a/app/connectors/RawResponseReads.scala
+++ b/app/connectors/RawResponseReads.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import uk.gov.hmrc.play.http.{HttpReads, HttpResponse}
+
+trait RawResponseReads {
+
+  implicit val httpReads: HttpReads[HttpResponse] = new HttpReads[HttpResponse] {
+    override def read(method: String, url: String, response: HttpResponse) = response
+  }
+
+}

--- a/app/models/ConnectorResponseModel.scala
+++ b/app/models/ConnectorResponseModel.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.JsValue
+
+sealed trait ConnectorResponseModel
+case class SuccessResponse(json: JsValue) extends ConnectorResponseModel
+case class ErrorResponse(status: Int, message: String) extends ConnectorResponseModel

--- a/app/models/EstimatedTaxLiabilityResponseModel.scala
+++ b/app/models/EstimatedTaxLiabilityResponseModel.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.Json
+
+sealed trait EstimatedTaxLiabilityResponseModel
+
+case class EstimatedTaxLiability(total: BigDecimal,
+                                 nic2: BigDecimal,
+                                 nic4: BigDecimal,
+                                 incomeTax: BigDecimal) extends EstimatedTaxLiabilityResponseModel
+
+case class EstimatedTaxLiabilityError(status: Int, message: String) extends EstimatedTaxLiabilityResponseModel
+
+
+object EstimatedTaxLiability {
+  implicit val format = Json.format[EstimatedTaxLiability]
+}
+
+object EstimatedTaxLiabilityError {
+  implicit val format = Json.format[EstimatedTaxLiabilityError]
+}

--- a/app/services/EstimatedTaxLiabilityService.scala
+++ b/app/services/EstimatedTaxLiabilityService.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import javax.inject.{Inject, Singleton}
+
+import connectors.EstimatedTaxLiabilityConnector
+import models._
+import play.api.Logger
+import uk.gov.hmrc.play.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+@Singleton
+class EstimatedTaxLiabilityService @Inject()(val estimatedTaxLiabilityConnector: EstimatedTaxLiabilityConnector) {
+
+  def getEstimatedTaxLiability(mtditid: String)(implicit headerCarrier: HeaderCarrier): Future[EstimatedTaxLiabilityResponseModel] = {
+    Logger.debug("[EstimatedTaxLiabilityService][getEstimateTaxLiability] - Requesting Estimate Liability from Backend via Connector")
+    estimatedTaxLiabilityConnector.getEstimatedTaxLiability(mtditid).map[EstimatedTaxLiabilityResponseModel] {
+      case success: SuccessResponse =>
+        Logger.debug(s"[EstimatedTaxLiabilityService][getEstimateTaxLiability] - Retrieved Estimated Tax Liability: ${success.json}")
+        success.json.as[EstimatedTaxLiability]
+      case error: ErrorResponse =>
+        Logger.debug(s"[EstimatedTaxLiabilityService][getEstimateTaxLiability] - Error Response Status: ${error.status}, Message: ${error.message}")
+        EstimatedTaxLiabilityError(error.status, error.message)
+    }
+  }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -62,6 +62,11 @@ microservice {
         host = localhost
         port = 9250
       }
+
+      income-tax-view-change {
+        host = localhost
+        port = 9082
+      }
     }
 }
 

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -44,7 +44,8 @@ object FrontendBuild extends Build with MicroService {
     "org.scalatestplus.play" %% "scalatestplus-play" % scalaTestPlusVersion % scope,
     "org.pegdown" % "pegdown" % pegdownVersion % scope,
     "org.jsoup" % "jsoup" % jsoupVersion % scope,
-    "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
+    "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
+    "org.mockito" % "mockito-core" % "2.7.17" % scope
   )
 
 }

--- a/test/connectors/EstimatedTaxLiabilityConnectorSpec.scala
+++ b/test/connectors/EstimatedTaxLiabilityConnectorSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import models.{ErrorResponse, SuccessResponse}
+import play.api.libs.json.Json
+import play.mvc.Http.Status
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+
+class EstimatedTaxLiabilityConnectorSpec extends UnitSpec with WithFakeApplication with MockHttp {
+
+  implicit val hc = HeaderCarrier()
+
+  val testMtditid = "XAITSA0000123456"
+
+  val successResponse = HttpResponse(Status.OK, Some(Json.parse("{}")))
+  val badResponse = HttpResponse(Status.BAD_REQUEST, responseString = Some("Error Message"))
+
+  object TestEstimatedTaxLiabilityConnector extends EstimatedTaxLiabilityConnector(mockHttpGet)
+
+  "EstimatedTaxLiabilityConnector.getEstimatedTaxLiability" should {
+
+    "return a SuccessResponse with JSON in case of sucess" in {
+      setupMockHttpGet(TestEstimatedTaxLiabilityConnector.getEstimatedTaxLiabilityUrl(testMtditid))(successResponse)
+      val result = TestEstimatedTaxLiabilityConnector.getEstimatedTaxLiability(testMtditid)
+      await(result) shouldBe SuccessResponse(Json.parse("{}"))
+    }
+
+    "return ErrorResponse model in case of failure" in {
+      setupMockHttpGet(TestEstimatedTaxLiabilityConnector.getEstimatedTaxLiabilityUrl(testMtditid))(badResponse)
+      val result = TestEstimatedTaxLiabilityConnector.getEstimatedTaxLiability(testMtditid)
+      await(result) shouldBe ErrorResponse(Status.BAD_REQUEST, "Error Message")
+    }
+  }
+}

--- a/test/connectors/MockHttp.scala
+++ b/test/connectors/MockHttp.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.mockito.MockitoSugar
+import uk.gov.hmrc.play.http.{HttpGet, HttpResponse}
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.Future
+
+
+trait MockHttp extends UnitSpec with MockitoSugar with BeforeAndAfterEach {
+
+  val mockHttpGet: HttpGet = mock[HttpGet]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockHttpGet)
+  }
+
+  def setupMockHttpGet(url: String)(response: HttpResponse): Unit =
+    when(mockHttpGet.GET[HttpResponse](ArgumentMatchers.eq(url))(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(response))
+}

--- a/test/services/EstimatedTaxLiabilityServiceSpec.scala
+++ b/test/services/EstimatedTaxLiabilityServiceSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import models.{ErrorResponse, EstimatedTaxLiability, EstimatedTaxLiabilityError, SuccessResponse}
+import play.api.libs.json.Json
+import play.mvc.Http.Status
+import uk.gov.hmrc.play.http.HeaderCarrier
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+
+class EstimatedTaxLiabilityServiceSpec extends UnitSpec with WithFakeApplication with MockFinancialDataConnector {
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  val mtditid = "1234"
+
+  object TestEstimatedTaxLiabilityService extends EstimatedTaxLiabilityService(mockEstimatedTaxLiabilityConnector)
+
+  "The EstimatedTaxLiabilityService.getEstimatedTaxLiability method" when {
+
+    "a successful response is returned from the EstimatedTaxLiabilityConnector" should {
+
+      val estimatedTaxLiabilityResponse = SuccessResponse(Json.parse(
+        """
+          |{
+          |  "total":"1000",
+          |  "nic2":"200",
+          |  "nic4":"500",
+          |  "incomeTax":"300"
+          |}
+        """.stripMargin
+      ))
+
+      "return a correctly formatted EstimateTaxLiability model" in {
+        setupMockFinancialDataResult(mtditid)(estimatedTaxLiabilityResponse)
+        await(TestEstimatedTaxLiabilityService.getEstimatedTaxLiability(mtditid)) shouldBe EstimatedTaxLiability(1000.0,200.0,500.0,300.0)
+      }
+    }
+
+    "an Error Response is returned from the FinancialDataConnector" should {
+
+      "return a correctly formatted EstimateTaxLiability model" in {
+        val financialDataError = ErrorResponse(Status.INTERNAL_SERVER_ERROR, "Error Message")
+        setupMockFinancialDataResult(mtditid)(financialDataError)
+        await(TestEstimatedTaxLiabilityService.getEstimatedTaxLiability(mtditid)) shouldBe
+          EstimatedTaxLiabilityError(Status.INTERNAL_SERVER_ERROR, "Error Message")
+      }
+    }
+  }
+}

--- a/test/services/MockFinancialDataConnector.scala
+++ b/test/services/MockFinancialDataConnector.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.EstimatedTaxLiabilityConnector
+import models.ConnectorResponseModel
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.mockito.MockitoSugar
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.Future
+
+
+trait MockFinancialDataConnector extends UnitSpec with MockitoSugar with BeforeAndAfterEach {
+
+  val mockEstimatedTaxLiabilityConnector: EstimatedTaxLiabilityConnector = mock[EstimatedTaxLiabilityConnector]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockEstimatedTaxLiabilityConnector)
+  }
+
+  def setupMockFinancialDataResult(mtditid: String)(response: ConnectorResponseModel): Unit =
+    when(mockEstimatedTaxLiabilityConnector.getEstimatedTaxLiability(ArgumentMatchers.eq(mtditid))(ArgumentMatchers.any()))
+      .thenReturn(Future.successful(response))
+}


### PR DESCRIPTION
**Notes:**

- This was branched off BTAT-115, please merge #13 prior to this.
- The connector converts the JSON response to the EstimatedTaxLiability model using the implicit format on the model (read & writes).
- If the connector responds with an error then it propagates the response to the calling method. (i.e. the controller).