### PR TITLE
add-test-only-stub-view: Added testOnly route views to add data to Dynamic Stub

### DIFF
--- a/app/testOnly/TestOnlyAppConfig.scala
+++ b/app/testOnly/TestOnlyAppConfig.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly
+
+import javax.inject.{Inject, Singleton}
+
+import config.FrontendAppConfig
+import play.api.Configuration
+
+@Singleton
+class TestOnlyAppConfig @Inject()(config: Configuration) extends FrontendAppConfig(config) {
+
+  lazy val dynamicStubUrl: String = baseUrl("itvc-dynamic-stub")
+
+}

--- a/app/testOnly/connectors/DynamicStubConnector.scala
+++ b/app/testOnly/connectors/DynamicStubConnector.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//$COVERAGE-OFF$Disabling scoverage on this test only connector as it is only required by our acceptance test
+
+package testOnly.connectors
+
+import javax.inject.{Inject, Singleton}
+
+import connectors.RawResponseReads
+import testOnly.TestOnlyAppConfig
+import testOnly.models.{DataModel, SchemaModel}
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpPost, HttpResponse}
+
+import scala.concurrent.Future
+
+@Singleton
+class DynamicStubConnector @Inject()(val appConfig: TestOnlyAppConfig,
+                                     val http: HttpPost) extends RawResponseReads {
+
+  def addSchema(schemaModel: SchemaModel)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
+    lazy val url = s"${appConfig.dynamicStubUrl}/setup/schema"
+    http.POST[SchemaModel, HttpResponse](url, schemaModel)
+  }
+
+  def addData(dataModel: DataModel)(implicit headerCarrier: HeaderCarrier): Future[HttpResponse] = {
+    lazy val url = s"${appConfig.dynamicStubUrl}/setup/data"
+    http.POST[DataModel, HttpResponse](url, dataModel)
+  }
+
+}
+
+// $COVERAGE-ON$

--- a/app/testOnly/connectors/DynamicStubConnector.scala
+++ b/app/testOnly/connectors/DynamicStubConnector.scala
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-//$COVERAGE-OFF$Disabling scoverage on this test only connector as it is only required by our acceptance test
-
 package testOnly.connectors
 
 import javax.inject.{Inject, Singleton}
@@ -42,5 +40,3 @@ class DynamicStubConnector @Inject()(val appConfig: TestOnlyAppConfig,
   }
 
 }
-
-// $COVERAGE-ON$

--- a/app/testOnly/controllers/StubDataController.scala
+++ b/app/testOnly/controllers/StubDataController.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.controllers
+
+import javax.inject.{Inject, Singleton}
+
+import com.fasterxml.jackson.core.JsonParseException
+import config.FrontendAppConfig
+import controllers.BaseController
+import play.api.data.Form
+import play.api.i18n.MessagesApi
+import play.api.mvc._
+import play.api.{Configuration, Environment}
+import testOnly.connectors.DynamicStubConnector
+import testOnly.forms.{StubDataForm, StubSchemaForm}
+import testOnly.models.{DataModel, SchemaModel}
+import uk.gov.hmrc.auth.frontend.Redirects
+import uk.gov.hmrc.play.http.HeaderCarrier
+
+import scala.concurrent.Future
+import scala.util.Try
+
+@Singleton
+class StubDataController @Inject()(implicit val appConfig: FrontendAppConfig,
+                                     override val config: Configuration,
+                                     override val env: Environment,
+                                     implicit val messagesApi: MessagesApi,
+                                     val dynamicStubConnector: DynamicStubConnector
+                                    ) extends BaseController with Redirects {
+
+  val show: Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(view(StubDataForm.stubDataForm)))
+  }
+
+  val submit: Action[AnyContent] = Action.async {
+    implicit request =>
+      StubDataForm.stubDataForm.bindFromRequest.fold(
+        formWithErrors => Future.successful(BadRequest(view(formWithErrors))),
+        schema => {
+          dynamicStubConnector.addData(schema).map(
+            response => response.status match {
+              case OK => Ok(view(StubDataForm.stubDataForm, showSuccess = true))
+              case _ => InternalServerError(view(StubDataForm.stubDataForm.fill(schema), errorResponse = Some(response.body)))
+            }
+          )
+        }
+      )
+  }
+
+  private def view(form: Form[DataModel],
+                   showSuccess: Boolean = false,
+                   errorResponse: Option[String] = None
+                  )(implicit request: Request[AnyContent]) =
+    testOnly.views.html.stubDataView(
+      form,
+      testOnly.controllers.routes.StubDataController.submit(),
+      showSuccess,
+      errorResponse
+    )
+}

--- a/app/testOnly/controllers/StubSchemaController.scala
+++ b/app/testOnly/controllers/StubSchemaController.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.controllers
+
+import javax.inject.{Inject, Singleton}
+
+import com.fasterxml.jackson.core.JsonParseException
+import config.FrontendAppConfig
+import controllers.BaseController
+import play.api.data.Form
+import play.api.i18n.MessagesApi
+import play.api.mvc._
+import play.api.{Configuration, Environment}
+import testOnly.connectors.DynamicStubConnector
+import testOnly.forms.StubSchemaForm
+import testOnly.models.SchemaModel
+import uk.gov.hmrc.auth.frontend.Redirects
+import uk.gov.hmrc.play.http.HeaderCarrier
+
+import scala.concurrent.Future
+import scala.util.Try
+
+@Singleton
+class StubSchemaController @Inject()(implicit val appConfig: FrontendAppConfig,
+                                     override val config: Configuration,
+                                     override val env: Environment,
+                                     implicit val messagesApi: MessagesApi,
+                                     val dynamicStubConnector: DynamicStubConnector
+                                  ) extends BaseController with Redirects {
+
+  val show: Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(view(StubSchemaForm.stubSchemaForm)))
+  }
+
+  val submit: Action[AnyContent] = Action.async {
+    implicit request =>
+      StubSchemaForm.stubSchemaForm.bindFromRequest.fold(
+        formWithErrors => Future.successful(BadRequest(view(formWithErrors))),
+        schema => {
+          dynamicStubConnector.addSchema(schema).map(
+            response => response.status match {
+              case OK => Ok(view(StubSchemaForm.stubSchemaForm, showSuccess = true))
+              case _ => InternalServerError(view(StubSchemaForm.stubSchemaForm.fill(schema), errorMessage = Some(response.body)))
+            }
+          )
+        }
+      )
+  }
+
+  private def view(form: Form[SchemaModel], showSuccess: Boolean = false, errorMessage: Option[String] = None)(implicit request: Request[AnyContent]) =
+    testOnly.views.html.stubSchemaView(
+      form,
+      testOnly.controllers.routes.StubSchemaController.submit(),
+      showSuccess,
+      errorMessage
+    )
+}

--- a/app/testOnly/forms/StubDataForm.scala
+++ b/app/testOnly/forms/StubDataForm.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.forms
+
+import play.api.data.Form
+import play.api.data.Forms._
+import play.api.libs.json.{JsValue, Json}
+import testOnly.forms.validation.Constraints._
+import testOnly.models.DataModel
+
+object StubDataForm {
+
+  val url = "_id"
+  val schemaName = "schemaId"
+  val method = "method"
+  val status = "status"
+  val response = "response"
+
+  val stubDataForm = Form(
+    mapping(
+      url -> text.verifying(nonEmpty("You must supply the URL to mock the response for")),
+      schemaName -> text.verifying(nonEmpty("You must supply a Schema Name to validate against")),
+      method -> text.verifying(nonEmpty("You must specify the Http Method of the request being stubbed")),
+      status -> text.verifying(isNumeric).transform[Int](_.toInt,_.toString),
+      response -> optional(text).verifying(oValidJson).transform[Option[JsValue]](x => x.fold[Option[JsValue]](None)(value => Some(Json.parse(value))),
+        y => y.fold[Option[String]](None)(json => Some(json.toString())))
+    )(DataModel.apply)(DataModel.unapply)
+  )
+}

--- a/app/testOnly/forms/StubSchemaForm.scala
+++ b/app/testOnly/forms/StubSchemaForm.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.forms
+
+import play.api.data.Form
+import play.api.data.Forms._
+import play.api.libs.json.{JsValue, Json}
+import testOnly.models.SchemaModel
+import testOnly.forms.validation.Constraints._
+import testOnly.forms.validation.utils.ConstraintUtil._
+
+object StubSchemaForm {
+
+  val id = "_id"
+  val url = "url"
+  val method = "method"
+  val responseSchema = "responseSchema"
+
+  val stubSchemaForm = Form(
+    mapping(
+      id -> text.verifying(nonEmpty("Schema Name is Mandatory")),
+      url -> text.verifying(nonEmpty("URL Regex is Mandatory")),
+      method -> text.verifying(nonEmpty("Method is Mandatory")),
+      responseSchema -> text.verifying(nonEmpty("Schema Definition is Mandatory") andThen validJson).transform[JsValue](s => Json.parse(s), j => j.toString())
+    )(SchemaModel.apply)(SchemaModel.unapply)
+  )
+}

--- a/app/testOnly/forms/validation/Constraints.scala
+++ b/app/testOnly/forms/validation/Constraints.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.forms.validation
+
+import play.api.data.validation.{Constraint, Valid}
+import play.api.libs.json.Json
+import testOnly.forms.validation.utils.ConstraintUtil._
+
+import scala.util.{Failure, Success, Try}
+
+object Constraints {
+
+  def nonEmpty(msg: String): Constraint[String] = constraint[String](
+    x => if (x.isEmpty) ErrorMessageFactory.error(msg) else Valid
+  )
+
+  val validJson: Constraint[String] = constraint[String](
+    x => Try {Json.parse(x)} match {
+      case Success(_) => Valid
+      case Failure(_) => ErrorMessageFactory.error("Invalid Json Format")
+    }
+  )
+
+  val oValidJson: Constraint[Option[String]] = constraint[Option[String]](
+    x => x.isEmpty match {
+      case true => Valid
+      case false => Try {
+        Json.parse(x.get)
+      } match {
+        case Success(_) => Valid
+        case Failure(_) => ErrorMessageFactory.error("Invalid Json Format")
+      }
+    }
+  )
+
+  val isNumeric: Constraint[String] = constraint[String](
+    x => Try {x.toInt} match {
+      case Success(_) => Valid
+      case Failure(_) => ErrorMessageFactory.error("Invalid Numeric")
+    }
+  )
+}

--- a/app/testOnly/forms/validation/ErrorMessageFactory.scala
+++ b/app/testOnly/forms/validation/ErrorMessageFactory.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.forms.validation
+
+import testOnly.forms.validation.models.{FieldError, SummaryError, TargetIds}
+import play.api.data.validation.Invalid
+
+object ErrorMessageFactory {
+
+  val FieldErrorLoc = 0
+  val SummaryErrorLoc = 1
+  val TargetIdsLoc = 2
+
+  def error(errKey: String, errArgs: String*): Invalid = {
+    val fieldError = FieldError(errKey, errArgs)
+    val summaryError = SummaryError(errKey, errArgs)
+    error(fieldError, summaryError)
+  }
+
+  /**
+    * Designed for creating cross field validation error messages
+    *
+    * @param targetIds which fields this message is designated for
+    * @param errKey
+    * @param errArgs
+    * @return
+    */
+  def error(targetIds: TargetIds, errKey: String, errArgs: String*): Invalid = {
+    val fieldError = FieldError(errKey, errArgs)
+    val summaryError = SummaryError(errKey, errArgs)
+    error(targetIds, fieldError, summaryError)
+  }
+
+  def error(fieldError: FieldError, summaryError: SummaryError): Invalid =
+    Invalid("", fieldError, summaryError)
+
+  /**
+    * Designed for creating cross field validation error messages
+    *
+    * @param targetIds which fields this message is designated for
+    * @param fieldError
+    * @param summaryError
+    * @return
+    */
+  def error(targetIds: TargetIds, fieldError: FieldError, summaryError: SummaryError): Invalid =
+    Invalid("", fieldError, summaryError, targetIds)
+
+}

--- a/app/testOnly/forms/validation/ErrorMessageHelper.scala
+++ b/app/testOnly/forms/validation/ErrorMessageHelper.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.forms.validation
+
+import testOnly.forms.validation.models.{FieldError, SummaryError, TargetIds}
+import play.api.data.{Field, Form, FormError}
+
+
+object ErrorMessageHelper {
+
+  import ErrorMessageFactory.{SummaryErrorLoc, TargetIdsLoc}
+
+  @inline private def filterFieldError(errors: Seq[FormError]): Option[FieldError] =
+    errors match {
+      case Nil => None
+      case _ =>
+        val args = errors.head.args
+        if (args.isEmpty) None else Some(args.head.asInstanceOf[FieldError])
+    }
+
+  def getFieldError(form: Form[_], fieldName: String): Option[FieldError] = {
+    val err = form.errors.filter(err => {
+      if (err.key == fieldName) true // if the error is from the field itself
+      else {
+        // or if it's a cross validation error designated for the field
+        val args = err.args
+        err.args.size match {
+          case 3 => val targets = args(TargetIdsLoc).asInstanceOf[TargetIds]
+            targets.anchor == fieldName || targets.otherIds.contains(fieldName)
+          case _ => false
+        }
+      }
+    })
+    filterFieldError(err)
+  }
+
+  def getFieldError(field: Field): Option[FieldError] = {
+    val err = field.errors
+    filterFieldError(err)
+  }
+
+  def getFieldError(field: Field, parentForm: Form[_]): Option[FieldError] =
+    getFieldError(parentForm, field.name)
+
+  def getFieldError(field: Field, parentForm: Option[Form[_]] = None): Option[FieldError] =
+    parentForm match {
+      case Some(form) => getFieldError(field, form)
+      case _ => getFieldError(field)
+    }
+
+  /**
+    *
+    * @param form
+    * @return (String,SummaryError) where the String is the anchor and SummaryError describes the error message
+    */
+  def getSummaryErrors(form: Form[_]): Seq[(String, SummaryError)] = {
+    val err = form.errors
+    err.map(e => {
+      e.args.size match {
+        case 3 =>
+          // cross validation error message
+          (e.args(TargetIdsLoc).asInstanceOf[TargetIds].anchor, e.args(SummaryErrorLoc).asInstanceOf[SummaryError])
+        case 2 =>
+          // error message for the field itself
+          (e.key, e.args(SummaryErrorLoc).asInstanceOf[SummaryError])
+      }
+    })
+  }
+
+}

--- a/app/testOnly/forms/validation/models/ErrorMessage.scala
+++ b/app/testOnly/forms/validation/models/ErrorMessage.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.forms.validation.models
+
+import play.api.i18n.Messages
+
+
+trait ErrorMessage {
+
+  def messageKey: String
+
+  def messageArgs: Seq[String]
+
+  def toText(implicit messages: Messages): String = messages.apply(messageKey, messageArgs: _*)
+
+}

--- a/app/testOnly/forms/validation/models/FieldError.scala
+++ b/app/testOnly/forms/validation/models/FieldError.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.forms.validation.models
+
+case class FieldError(messageKey: String, messageArgs: Seq[String] = Seq()) extends ErrorMessage

--- a/app/testOnly/forms/validation/models/SummaryError.scala
+++ b/app/testOnly/forms/validation/models/SummaryError.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.forms.validation.models
+
+case class SummaryError(messageKey: String, messageArgs: Seq[String] = Seq()) extends ErrorMessage

--- a/app/testOnly/forms/validation/models/TargetIds.scala
+++ b/app/testOnly/forms/validation/models/TargetIds.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.forms.validation.models
+
+case class TargetIds(anchor: String, otherIds: String*)

--- a/app/testOnly/forms/validation/utils/ConstraintUtil.scala
+++ b/app/testOnly/forms/validation/utils/ConstraintUtil.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.forms.validation.utils
+
+import play.api.data.validation.{Constraint, Valid, ValidationResult}
+
+
+object ConstraintUtil {
+
+  def constraint[A](f: A => ValidationResult): Constraint[A] = Constraint[A]("")(f)
+
+  implicit class ConstraintUtil[A](cons: Constraint[A]) {
+
+    def andThen(newCons: Constraint[A]): Constraint[A] =
+      constraint((data: A) =>
+        cons.apply(data) match {
+          case Valid => newCons.apply(data)
+          case r => r
+        }
+      )
+
+  }
+
+}

--- a/app/testOnly/forms/validation/utils/MappingUtil.scala
+++ b/app/testOnly/forms/validation/utils/MappingUtil.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.forms.validation.utils
+
+import play.api.data.Forms._
+import play.api.data._
+
+object MappingUtil {
+
+  val oText: Mapping[Option[String]] = optional(text)
+
+  implicit class OTextUtil(mapping: Mapping[Option[String]]) {
+    def toText: Mapping[String] =
+      mapping.transform(
+        x => x.fold("")(x => x),
+        x => Some(x)
+      )
+
+    def toBoolean: Mapping[Boolean] = mapping.transform(
+      {
+        case Some("true") => true
+        case _ => false
+      },
+      x => Some(x.toString)
+    )
+  }
+
+}

--- a/app/testOnly/forms/validation/utils/Patterns.scala
+++ b/app/testOnly/forms/validation/utils/Patterns.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.forms.validation.utils
+
+object Patterns {
+
+  // ISO 8859-1 standard
+  // ASCII range {32 to 126} + {160 to 255} all values inclusive
+  val iso8859_1Regex = """^([\x20-\x7E\xA0-\xFF])*$"""
+
+  val emailRegex = """(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)"""
+
+  def validText(text: String): Boolean = text matches iso8859_1Regex
+
+  def validEmail(text: String): Boolean = text matches emailRegex
+
+}

--- a/app/testOnly/models/DataModel.scala
+++ b/app/testOnly/models/DataModel.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.models
+
+import play.api.libs.json.{JsValue, Json, OFormat}
+
+case class DataModel(
+                        _id: String,                  // URL of the Request
+                        schemaId: String,             // Name of the Schema to Validate Against
+                        method: String,               // HttpMethod Type
+                        status: Int,                  // Response Status
+                        response: Option[JsValue]     // Response Body
+                      )
+
+object DataModel {
+  implicit val formats: OFormat[DataModel] = Json.format[DataModel]
+}

--- a/app/testOnly/models/SchemaModel.scala
+++ b/app/testOnly/models/SchemaModel.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.models
+
+import play.api.libs.json.{JsValue, Json, OFormat}
+
+case class SchemaModel(
+                        _id: String,              // Name of the Schema
+                        url: String,              // URL Regex
+                        method: String,           // Http Method Type
+                        responseSchema: JsValue   // Response Schema to validate against
+                       )
+
+object SchemaModel {
+  implicit val formats: OFormat[SchemaModel] = Json.format[SchemaModel]
+}

--- a/app/testOnly/views/helpers/continueButton.scala.html
+++ b/app/testOnly/views/helpers/continueButton.scala.html
@@ -1,0 +1,19 @@
+@*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(alternativeText: Option[String] = None)(implicit messages: Messages)
+
+<button formnovalidate class="button" type="submit" id="continue-button">@alternativeText.fold(Messages("base.continue"))(x => x)</button>

--- a/app/testOnly/views/helpers/dropdownHelper.scala.html
+++ b/app/testOnly/views/helpers/dropdownHelper.scala.html
@@ -1,0 +1,56 @@
+@*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.data.Form
+@import play.api.data.Field
+@(field: Field,
+        label: Option[String] = None,
+        parentForm: Option[Form[_]] = None,
+        maxLength: Option[Int] = None,
+        labelClass: Option[String] = None,
+        isNumeric: Boolean = false,
+        formHint: Option[Seq[String]] = None,
+        values: Seq[String]
+)(implicit messages: Messages)
+
+@import testOnly.forms.validation.ErrorMessageHelper._
+
+@hintText(hint: String) = {
+    <span class="form-hint">
+    @hint
+    </span>
+}
+
+@hasError = @{
+    val fieldError = getFieldError(field, parentForm)
+    fieldError match {
+        case Some(_) => true
+        case _ => false
+    }
+}
+
+<div class="form-group form-field@if(hasError) { form-field--error}">
+    <label class='form-label @labelClass.fold("")(x => x)' for=@field.name>
+        @label.fold(Html(""))(label => Html(label))
+        @formHint.fold(Nil: Seq[Html])(_.map(hintText))
+    </label>
+    @fieldErrorHelper(field, parentForm)
+    <select style="margin:0" name=@field.name id=@field.name>
+        @for(value <- values) {
+            <option value="@value">@value</option>
+        }
+    </select>
+</div>

--- a/app/testOnly/views/helpers/fieldErrorHelper.scala.html
+++ b/app/testOnly/views/helpers/fieldErrorHelper.scala.html
@@ -1,0 +1,32 @@
+@*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.data.Form
+@import play.api.data.Field
+@import testOnly.forms.validation.ErrorMessageHelper._
+
+@(field: Field, parentForm: Option[Form[_]] = None)(implicit messages: Messages)
+
+    @error = @{
+        getFieldError(field, parentForm)
+    }
+
+    @error match {
+        case Some(err) => {
+            <span class="error-notification" role="tooltip" id="error-message-@field.name">@err.toText</span>
+        }
+        case _ => {}
+    }

--- a/app/testOnly/views/helpers/inputHelper.scala.html
+++ b/app/testOnly/views/helpers/inputHelper.scala.html
@@ -1,0 +1,55 @@
+@*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.data.Form
+@import play.api.data.Field
+@(field: Field,
+        label: Option[String] = None,
+        parentForm: Option[Form[_]] = None,
+        maxLength: Option[Int] = None,
+        labelClass: Option[String] = None,
+        isNumeric: Boolean = false,
+        formHint: Option[Seq[String]] = None
+)(implicit messages: Messages)
+
+@import testOnly.forms.validation.ErrorMessageHelper._
+
+@hintText(hint: String) = {
+    <span class="form-hint">
+    @hint
+    </span>
+}
+
+@hasError = @{
+    val fieldError = getFieldError(field, parentForm)
+    fieldError match {
+        case Some(_) => true
+        case _ => false
+    }
+}
+
+<div class="form-group form-field@if(hasError) { form-field--error}">
+    <label class='form-label @labelClass.fold("")(x => x)' for=@field.name>
+        @label.fold(Html(""))(label => Html(label))
+        @formHint.fold(Nil: Seq[Html])(_.map(hintText))
+    </label>
+    @fieldErrorHelper(field, parentForm)
+    <input name=@field.name class="input--fullwidth" id=@field.name type="text"
+        @maxLength.fold(Html(""))(max => Html(s"maxlength=$max"))
+        value="@field.value.fold("")(v => v)"
+        @if(isNumeric){pattern="[0-9]*" inputmode="numeric"}
+    >
+</div>

--- a/app/testOnly/views/helpers/summaryErrorHelper.scala.html
+++ b/app/testOnly/views/helpers/summaryErrorHelper.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.data.Form
+@import play.api.data._
+
+@(form: Form[_])(implicit messages: Messages)
+
+@import testOnly.forms.validation.ErrorMessageHelper._
+@import testOnly.forms.validation.models._
+
+@errors = @{
+    getSummaryErrors(form)
+}
+
+@errMsg(err: (String, SummaryError)) = {
+    <li role="tooltip" data-metrics="itsa:error:@err._2.toText"><a href="#@err._1">@err._2.toText</a></li>
+}
+
+@if(form.hasErrors) {
+
+    <div class="flash error-summary error-summary--show"
+         id="error-summary-display"
+         role="alert"
+         aria-labelledby="error-summary-heading"
+         tabindex="-1">
+        <h2 id="error-summary-heading" class="h3-heading">Errors</h2>
+        <ul>
+            @errors.map(errMsg)
+        </ul>
+    </div>
+
+}

--- a/app/testOnly/views/helpers/textAreaHelper.scala.html
+++ b/app/testOnly/views/helpers/textAreaHelper.scala.html
@@ -1,0 +1,55 @@
+@*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.data.Form
+@import play.api.data.Field
+@(field: Field,
+        label: Option[String] = None,
+        parentForm: Option[Form[_]] = None,
+        maxLength: Option[Int] = None,
+        labelClass: Option[String] = None,
+        isNumeric: Boolean = false,
+        formHint: Option[Seq[String]] = None
+)(implicit messages: Messages)
+
+@import testOnly.forms.validation.ErrorMessageHelper._
+
+@hintText(hint: String) = {
+<span class="form-hint" xmlns="http://www.w3.org/1999/html">
+    @hint
+    </span>
+}
+
+@hasError = @{
+    val fieldError = getFieldError(field, parentForm)
+    fieldError match {
+        case Some(_) => true
+        case _ => false
+    }
+}
+
+<div class="form-group form-field@if(hasError) { form-field--error}">
+    <label class='form-label @labelClass.fold("")(x => x)' for=@field.name>
+        @label.fold(Html(""))(label => Html(label))
+        @formHint.fold(Nil: Seq[Html])(_.map(hintText))
+    </label>
+    @fieldErrorHelper(field, parentForm)
+    <textarea name=@field.name class="textarea--fullwidth" id=@field.name rows="15"
+        @maxLength.fold(Html(""))(max => Html(s"maxlength=$max"))
+        value="@field.value.fold("")(v => v)"
+        @if(isNumeric){pattern="[0-9]*" inputmode="numeric"}
+    ></textarea>
+</div>

--- a/app/testOnly/views/stubDataView.scala.html
+++ b/app/testOnly/views/stubDataView.scala.html
@@ -1,0 +1,104 @@
+@*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import testOnly.views.html.templates.stub_template
+@import testOnly.models.DataModel
+@import testOnly.forms.StubDataForm._
+@import testOnly.views.html.helpers._
+@import uk.gov.hmrc.play.views.html.helpers.form
+
+@(stubDataForm: Form[DataModel], postAction: Call, showSuccess: Boolean, errorResponse: Option[String])(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
+
+@stub_template(title = "Stub ITVC Test Data", bodyClasses = None, appConfig = appConfig) {
+
+    @summaryErrorHelper(stubDataForm)
+
+    <h1 class="heading-large">Add Test Data Responses to Dynamic Stub</h1>
+
+    @if(showSuccess){
+        <div class="alert alert--success" role="alert">
+            <p class="alert__message">Successfully added new Test Data Response to Dynamic Stub. You can add another below.</p>
+        </div>
+    }
+
+    @if(errorResponse.nonEmpty){
+        <div class="alert alert--important" role="alert">
+            <p class="alert__message">Error! Your Test Data has not been added to the Dynamic Stub.</p>
+            <p>@errorResponse.get</p>
+        </div>
+    }
+
+    @form(action = postAction) {
+
+        <div class="form-group">
+            <div class="form-field-group">
+                @inputHelper(
+                    field = stubDataForm(schemaName),
+                    label = Some("Name of the Schema (Or API) you wish to add Test Data for"),
+                    formHint = Some(Seq("The definition must exist in MongoDB")),
+                    labelClass = Some("form-label"),
+                    parentForm = Some(stubDataForm)
+                )
+            </div>
+        </div>
+
+        <div class="grid-layout grid-layout--no-gutter">
+
+            <div class="grid-layout__column grid-layout__column--1-4">
+                @dropdownHelper(
+                    field = stubDataForm(method),
+                    label = Some("Request Status"),
+                    labelClass = Some("form-label"),
+                    parentForm = Some(stubDataForm),
+                    values = Seq("GET")
+                )
+            </div>
+            <div class="form-group">
+                @inputHelper(
+                    field = stubDataForm(url),
+                    label = Some("Request URL"),
+                    labelClass = Some("form-label"),
+                    parentForm = Some(stubDataForm)
+                )
+            </div>
+        </div>
+
+        <div class="form-group">
+            <div class="form-field-group">
+                @inputHelper(
+                    field = stubDataForm(status),
+                    label = Some("Response Status (Integer, E.g. 200)"),
+                    labelClass = Some("form-label"),
+                    parentForm = Some(stubDataForm),
+                    isNumeric = true
+                )
+            </div>
+        </div>
+
+        <div class="form-group">
+            <div class="form-field-group">
+                @textAreaHelper(
+                    field = stubDataForm(response),
+                    label = Some("Json Response Body"),
+                    labelClass = Some("form-label"),
+                    parentForm = Some(stubDataForm)
+                )
+            </div>
+        </div>
+
+        @continueButton(Some("Add Data to Dynamic Stub"))
+    }
+}

--- a/app/testOnly/views/stubSchemaView.scala.html
+++ b/app/testOnly/views/stubSchemaView.scala.html
@@ -1,0 +1,93 @@
+@*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import testOnly.views.html.templates.stub_template
+@import testOnly.models.SchemaModel
+@import testOnly.forms.StubSchemaForm._
+@import testOnly.views.html.helpers._
+@import uk.gov.hmrc.play.views.html.helpers.form
+
+@(stubSchemaForm: Form[SchemaModel], postAction: Call, showSuccess: Boolean, errorMessage: Option[String])(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
+
+@stub_template(title = "ITVC Stub Schemas", bodyClasses = None, appConfig = appConfig) {
+
+    @summaryErrorHelper(stubSchemaForm)
+
+    <h1 class="heading-large">Add Schema Definition to Dynamic Stub</h1>
+
+    @if(showSuccess){
+        <div class="alert alert--success" role="alert">
+            <p class="alert__message">Successfully added new Schema Definition to Dynamic Stub. You can add another below.</p>
+        </div>
+    }
+
+    @if(errorMessage.nonEmpty){
+        <div class="alert alert--important" role="alert">
+            <p class="alert__message">Error! Your Schema Definition has not been added to the Dynamic Stub.</p>
+            <p>@errorMessage.get</p>
+        </div>
+    }
+
+    @form(action = postAction) {
+
+        <div class="form-group">
+           <div class="form-field-group">
+                @inputHelper(
+                    field = stubSchemaForm(id),
+                    label = Some("Name of the Schema (Or API) you wish to create a stub endpoint for"),
+                    formHint = Some(Seq("You'll need to use this when adding stub responses")),
+                    labelClass = Some("form-label"),
+                    parentForm = Some(stubSchemaForm)
+                )
+           </div>
+        </div>
+
+        <div class="grid-layout grid-layout--no-gutter">
+
+            <div class="grid-layout__column grid-layout__column--1-4">
+                @dropdownHelper(
+                    field = stubSchemaForm(method),
+                    label = Some("Http Method of Request"),
+                    labelClass = Some("form-label"),
+                    parentForm = Some(stubSchemaForm),
+                    values = Seq("GET")
+                )
+            </div>
+            <div class="form-group">
+                @inputHelper(
+                    field = stubSchemaForm(url),
+                    label = Some("Regex for URL of request to match against"),
+                    formHint = Some(Seq("""For example, ^\/person\/(.*)\/lastname$""")),
+                    labelClass = Some("form-label"),
+                    parentForm = Some(stubSchemaForm)
+                )
+            </div>
+        </div>
+
+        <div class="form-group">
+            <div class="form-field-group">
+                @textAreaHelper(
+                field = stubSchemaForm(responseSchema),
+                label = Some("Json Schema Definition"),
+                labelClass = Some("form-label"),
+                parentForm = Some(stubSchemaForm)
+                )
+            </div>
+        </div>
+
+        @continueButton(Some("Add Schema to Dynamic Stub"))
+    }
+}

--- a/app/testOnly/views/templates/stub_template.scala.html
+++ b/app/testOnly/views/templates/stub_template.scala.html
@@ -1,0 +1,51 @@
+@*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.AppConfig
+@import templates.govuk_wrapper
+
+@(title: String,
+  sidebarLinks: Option[Html] = None,
+  contentHeader: Option[Html] = None,
+  bodyClasses: Option[String] = None,
+  mainClass: Option[String] = None,
+  scriptElem: Option[Html] = None,
+  appConfig: AppConfig,
+  showLogout: Boolean = true)(mainContent: Html)(implicit request : Request[_], messages: Messages)
+
+@import uk.gov.hmrc.play.views.html.layouts
+
+
+@serviceInfoContent = {}
+
+@sidebar = {
+    @if(sidebarLinks.isDefined) {
+        @layouts.sidebar(sidebarLinks.get, Some("sidebar"))
+    }
+}
+
+
+@govuk_wrapper(appConfig = appConfig,
+               title = title,
+               mainClass = mainClass,
+               bodyClasses = bodyClasses,
+               sidebar = sidebar,
+               contentHeader = contentHeader,
+               mainContent = mainContent,
+               serviceInfoContent = serviceInfoContent,
+               scriptElem = scriptElem,
+               showLogout = showLogout
+)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -85,6 +85,11 @@ microservice {
         host = localhost
         port = 9020
       }
+
+      itvc-dynamic-stub {
+        host = localhost
+        port = 9084
+      }
     }
 }
 

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -10,4 +10,13 @@
 # Failing to follow this rule may result in test routes deployed in production.
 
 # Add all the application routes to the prod.routes file
-->         /                          prod.Routes
+
+
+GET         /test-only/itvc/stub-schema    @testOnly.controllers.StubSchemaController.show
+POST        /test-only/itvc/stub-schema    @testOnly.controllers.StubSchemaController.submit
+
+GET         /test-only/itvc/stub-data      @testOnly.controllers.StubDataController.show
+POST        /test-only/itvc/stub-data      @testOnly.controllers.StubDataController.submit
+
+
+->         /                            prod.Routes


### PR DESCRIPTION
This PR adds testOnly routes, views, controller, connectors, form, models et al. which enables you to populate the dynamic stub with test data via an easily accessible view.

TestOnly routes are not deployed to production - they are only for the benefit of the team - hence no Unit Tests. 

TestOnly is excluded from scoverage