### PR TITLE
[BTAT-258] Update controller to redirect to earliest Tax Year estimate

### DIFF
--- a/app/controllers/EstimatedTaxLiabilityController.scala
+++ b/app/controllers/EstimatedTaxLiabilityController.scala
@@ -21,7 +21,7 @@ import javax.inject.{Inject, Singleton}
 import auth.MtdItUser
 import config.AppConfig
 import controllers.predicates.AsyncActionPredicate
-import models.{LastTaxCalculation, LastTaxCalculationError}
+import models.{BusinessIncomeModel, LastTaxCalculation, LastTaxCalculationError}
 import play.api.Logger
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, Request, Result}
@@ -37,27 +37,42 @@ class EstimatedTaxLiabilityController @Inject()(implicit val config: AppConfig,
                                                 val estimatedTaxLiabilityService: EstimatedTaxLiabilityService
                                                ) extends BaseController {
 
-  val getEstimatedTaxLiability: Action[AnyContent] = actionPredicate.async {
-    implicit request =>
-      implicit user =>
-        implicit sources =>
-          (sources.businessDetails, sources.propertyDetails) match {
-            case (Some(business), _) => getAndRenderEstimatedLiability(business.accountingPeriod.determineTaxYear)
-            case (_, Some(property)) => getAndRenderEstimatedLiability(property.accountingPeriod.determineTaxYear)
-            case (_, _) =>
-              Logger.debug("[EstimatedTaxLiabilityController][getEstimatedTaxLiability] No Income Sources.")
-              Future.successful(showInternalServerError)
+  val redirectToEarliestEstimatedTaxLiability: Action[AnyContent] = actionPredicate.async {
+    implicit request => implicit user => implicit sources =>
+      (sources.businessDetails, sources.propertyDetails) match {
+        case (Some(business), Some(property)) =>
+          if (property.accountingPeriod.determineTaxYear < business.accountingPeriod.determineTaxYear) {
+            redirectToYear(property.accountingPeriod.determineTaxYear)
+          } else {
+            redirectToYear(business.accountingPeriod.determineTaxYear)
           }
+        case (Some(business), None) => redirectToYear(business.accountingPeriod.determineTaxYear)
+        case (None, Some(property)) => redirectToYear(property.accountingPeriod.determineTaxYear)
+        case (_, _) =>
+          Logger.debug("[EstimatedTaxLiabilityController][redirectToEarliestEstimatedTaxLiability] No Income Sources.")
+          Future.successful(showInternalServerError)
+      }
   }
 
-  private def getAndRenderEstimatedLiability(taxYear: Int)(implicit hc: HeaderCarrier, request: Request[AnyContent], user: MtdItUser): Future[Result] = {
-    Logger.debug(s"[EstimatedTaxLiabilityController][getEstimatedTaxLiability] Calling Estimated Tax Liability Service with NINO: ${user.nino}")
+  val getEstimatedTaxLiability: Int => Action[AnyContent] = taxYear => actionPredicate.async {
+    implicit request => implicit user => implicit sources =>
+      getAndRenderEstimatedLiability(taxYear)
+  }
+
+  private[EstimatedTaxLiabilityController] def redirectToYear(year: Int): Future[Result] =
+    Future.successful(Redirect(controllers.routes.EstimatedTaxLiabilityController.getEstimatedTaxLiability(year)))
+
+  private[EstimatedTaxLiabilityController] def getAndRenderEstimatedLiability(taxYear: Int)(implicit hc: HeaderCarrier,
+                                                                                            request: Request[AnyContent],
+                                                                                            user: MtdItUser): Future[Result] = {
+    Logger.debug(s"[EstimatedTaxLiabilityController][redirectToEarliestEstimatedTaxLiability] Calling Estimated Tax Liability Service with NINO: ${user.nino}")
     estimatedTaxLiabilityService.getLastEstimatedTaxCalculation(user.nino, taxYear) map {
       case success: LastTaxCalculation =>
-        Logger.debug(s"[EstimatedTaxLiabilityController][getEstimatedTaxLiability] Success Response: $success")
+        Logger.debug(s"[EstimatedTaxLiabilityController][redirectToEarliestEstimatedTaxLiability] Success Response: $success")
         Ok(views.html.estimatedTaxLiability(success.calcAmount, taxYear))
       case failure: LastTaxCalculationError =>
-        Logger.warn(s"[EstimatedTaxLiabilityController][getEstimatedTaxLiability] Error Response: Status=${failure.status}, Message=${failure.message}")
+        Logger.warn(s"[EstimatedTaxLiabilityController][redirectToEarliestEstimatedTaxLiability] " +
+          s"Error Response: Status=${failure.status}, Message=${failure.message}")
         showInternalServerError
     }
   }

--- a/app/views/obligations.scala.html
+++ b/app/views/obligations.scala.html
@@ -35,7 +35,7 @@
             <h3 id="estimates-heading">@messages("sidebar.view_estimated_liability.h3")</h3>
             <ul>
                 <li class="font-xsmall">
-                    <a id="estimates-link" href="@{controllers.routes.EstimatedTaxLiabilityController.getEstimatedTaxLiability().url}">@messages("sidebar.view_estimated_liability.link")</a>
+                    <a id="estimates-link" href="@{controllers.routes.EstimatedTaxLiabilityController.redirectToEarliestEstimatedTaxLiability().url}">@messages("sidebar.view_estimated_liability.link")</a>
                 </li>
             </ul>
         </div>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,22 +1,23 @@
 # microservice specific routes
-GET        /assets/*file                controllers.Assets.at(path="/public", file)
+GET        /assets/*file                            controllers.Assets.at(path="/public", file)
 
 #Estimated Tax Liability
-GET         /estimated-tax-liability    controllers.EstimatedTaxLiabilityController.getEstimatedTaxLiability
+GET         /estimated-tax-liability                controllers.EstimatedTaxLiabilityController.redirectToEarliestEstimatedTaxLiability
+GET         /estimated-tax-liability/:taxYear       controllers.EstimatedTaxLiabilityController.getEstimatedTaxLiability(taxYear: Int)
 
 #Obligations
-GET         /obligations                controllers.ObligationsController.getObligations
+GET         /obligations                            controllers.ObligationsController.getObligations
 
 #Feedback Routes
-GET         /feedback                   controllers.feedback.FeedbackController.show
-POST        /feedback                   controllers.feedback.FeedbackController.submit
-GET         /thankyou                   controllers.feedback.FeedbackController.thankyou
+GET         /feedback                               controllers.feedback.FeedbackController.show
+POST        /feedback                               controllers.feedback.FeedbackController.submit
+GET         /thankyou                               controllers.feedback.FeedbackController.thankyou
 
 #Timeout Routes
-GET         /session-timeout            controllers.timeout.SessionTimeoutController.timeout
+GET         /session-timeout                        controllers.timeout.SessionTimeoutController.timeout
 
 #Sign Out Routes
-GET         /sign-out                   controllers.SignOutController.signOut
+GET         /sign-out                               controllers.SignOutController.signOut
 
 #Sign In Routes
-GET         /sign-in                    controllers.SignInController.signIn
+GET         /sign-in                                controllers.SignInController.signIn

--- a/it/controllers/EstimatedTaxLiabilityControllerISpec.scala
+++ b/it/controllers/EstimatedTaxLiabilityControllerISpec.scala
@@ -23,7 +23,7 @@ import play.api.http.Status._
 
 class EstimatedTaxLiabilityControllerISpec extends ComponentSpecBase {
 
-  "Calling the EstimatedTaxLiabilityController" when {
+  "Calling the EstimatedTaxLiabilityController.getEstimatedTaxLiability(year)" when {
 
     "authorised with an active enrolment" should {
 
@@ -39,8 +39,8 @@ class EstimatedTaxLiabilityControllerISpec extends ComponentSpecBase {
         And("I wiremock stub a successful Business Details response")
         SelfAssessmentStub.stubGetBusinessDetails(testNino, GetBusinessDetails.successResponse(testSelfEmploymentId))
 
-        When("I call GET /check-your-income-tax-and-expenses/estimated-tax-liability")
-        val res = IncomeTaxViewChangeFrontend.getEstimatedTaxLiability
+        When(s"I call GET /check-your-income-tax-and-expenses/estimated-tax-liability/$testYear")
+        val res = IncomeTaxViewChangeFrontend.getEstimatedTaxLiability(testYear)
 
         And("I verify the Business Details response has been wiremocked")
         SelfAssessmentStub.verifyGetBusinessDetails(testNino)
@@ -70,7 +70,7 @@ class EstimatedTaxLiabilityControllerISpec extends ComponentSpecBase {
         AuthStub.stubUnauthorised()
 
         When("I call GET /check-your-income-tax-and-expenses/estimated-tax-liability")
-        val res = IncomeTaxViewChangeFrontend.getEstimatedTaxLiability
+        val res = IncomeTaxViewChangeFrontend.getEstimatedTaxLiability(testYear)
 
         res should have(
 

--- a/it/helpers/ComponentSpecBase.scala
+++ b/it/helpers/ComponentSpecBase.scala
@@ -57,7 +57,7 @@ trait ComponentSpecBase extends TestSuite with CustomMatchers
   object IncomeTaxViewChangeFrontend {
     def get(uri: String): WSResponse = await(buildClient(uri).get())
 
-    def getEstimatedTaxLiability: WSResponse = get(s"/estimated-tax-liability")
+    def getEstimatedTaxLiability(year: String): WSResponse = get(s"/estimated-tax-liability/$year")
     def getObligations: WSResponse = get(s"/obligations")
   }
 }

--- a/test/assets/TestConstants.scala
+++ b/test/assets/TestConstants.scala
@@ -34,7 +34,7 @@ object TestConstants extends ImplicitDateFormatter {
 
   object BusinessDetails {
 
-    val testBusinessAccountingPeriod = AccountingPeriodModel(start = "2017-1-1", end = "2017-12-31")
+    val testBusinessAccountingPeriod = AccountingPeriodModel(start = "2017-6-1", end = "2018-5-30")
     val testTradeName = "business"
 
     val business1 = BusinessModel(
@@ -124,6 +124,8 @@ object TestConstants extends ImplicitDateFormatter {
     val businessListErrorJson = Json.parse(businessErrorString)
 
     val businessIncomeModel = BusinessIncomeModel(testSelfEmploymentId, testBusinessAccountingPeriod, testTradeName)
+    val businessIncomeModelAlignedTaxYear =
+      BusinessIncomeModel(testSelfEmploymentId, AccountingPeriodModel(start = "2017-4-6", end = "2018-4-5"), testTradeName)
   }
 
   object PropertyIncome {

--- a/test/connectors/LastTaxCalculationConnectorSpec.scala
+++ b/test/connectors/LastTaxCalculationConnectorSpec.scala
@@ -36,7 +36,7 @@ class LastTaxCalculationConnectorSpec extends TestSupport with MockHttp {
 
   object TestLastTaxCalculationConnector extends LastTaxCalculationConnector(mockHttpGet)
 
-  "EstimatedTaxLiabilityConnector.getEstimatedTaxLiability" should {
+  "EstimatedTaxLiabilityConnector.redirectToEarliestEstimatedTaxLiability" should {
 
     lazy val testUrl = TestLastTaxCalculationConnector.getEstimatedTaxLiabilityUrl(testNino, testYear.toString)
     def result: Future[LastTaxCalculationResponseModel] = TestLastTaxCalculationConnector.getLastEstimatedTax(testNino, testYear)

--- a/test/mocks/controllers/predicates/MockIncomeSourceDetailsPredicate.scala
+++ b/test/mocks/controllers/predicates/MockIncomeSourceDetailsPredicate.scala
@@ -32,6 +32,7 @@ trait MockIncomeSourceDetailsPredicate extends TestSupport with MockIncomeSource
   object BusinessIncome extends incomeSourceDetailsBuilder(BusinessIncomeOnly)
   object PropertyIncome extends incomeSourceDetailsBuilder(PropertyIncomeOnly)
   object BothIncome extends incomeSourceDetailsBuilder(BothBusinessAndPropertyIncome)
+  object BothIncomeAlignedTaxYear extends incomeSourceDetailsBuilder(BothBusinessAndPropertyIncomeAlignedTaxYear)
   object NoIncome extends incomeSourceDetailsBuilder(NoIncomeSources)
 
 

--- a/test/mocks/services/MockIncomeSourceDetailsService.scala
+++ b/test/mocks/services/MockIncomeSourceDetailsService.scala
@@ -16,7 +16,7 @@
 
 package mocks.services
 
-import assets.TestConstants.BusinessDetails.businessIncomeModel
+import assets.TestConstants.BusinessDetails.{businessIncomeModel, businessIncomeModelAlignedTaxYear}
 import assets.TestConstants.PropertyIncome.propertyIncomeModel
 import connectors.{BusinessDetailsConnector, PropertyDetailsConnector}
 import models.IncomeSourcesModel
@@ -50,6 +50,14 @@ trait MockIncomeSourceDetailsService extends MockitoSugar {
       Future.successful(IncomeSourcesModel(
         propertyDetails = Some(propertyIncomeModel),
         businessDetails = Some(businessIncomeModel)
+      ))
+  }
+
+  object BothBusinessAndPropertyIncomeAlignedTaxYear extends IncomeSourceDetailsService(mock[BusinessDetailsConnector], mock[PropertyDetailsConnector]) {
+    override def getIncomeSourceDetails(nino: String)(implicit hc: HeaderCarrier): Future[IncomeSourcesModel] =
+      Future.successful(IncomeSourcesModel(
+        propertyDetails = Some(propertyIncomeModel),
+        businessDetails = Some(businessIncomeModelAlignedTaxYear)
       ))
   }
 

--- a/test/models/BusinessListResponseModelSpec.scala
+++ b/test/models/BusinessListResponseModelSpec.scala
@@ -33,7 +33,7 @@ class BusinessListResponseModelSpec extends UnitSpec with Matchers {
       }
 
       "when calling the method to detrmine the Tax Year to which the accounting periods" in {
-        businessesSuccessModel.business.head.accountingPeriod.determineTaxYear shouldBe 2018
+        businessesSuccessModel.business.head.accountingPeriod.determineTaxYear shouldBe 2019
       }
     }
 
@@ -44,7 +44,7 @@ class BusinessListResponseModelSpec extends UnitSpec with Matchers {
       }
 
       "when calling the method to detrmine the Tax Year to which the accounting periods" in {
-        businessesSuccessModel.business.head.accountingPeriod.determineTaxYear shouldBe 2018
+        businessesSuccessModel.business.head.accountingPeriod.determineTaxYear shouldBe 2019
       }
     }
 

--- a/test/routes/RoutesSpec.scala
+++ b/test/routes/RoutesSpec.scala
@@ -37,9 +37,15 @@ class RoutesSpec extends TestSupport {
   }
 
   //Estimated Tax Liability
-  "The URL for the EstimatedTaxLiabilityController.getEstimatedTaxLiability action" should {
+  "The URL for the EstimatedTaxLiabilityController.redirectToEarliestEstimatedTaxLiability action" should {
     s"be equal to $contextRoute/estimated-tax-liability" in {
-      controllers.routes.EstimatedTaxLiabilityController.getEstimatedTaxLiability().url shouldBe s"$contextRoute/estimated-tax-liability"
+      controllers.routes.EstimatedTaxLiabilityController.redirectToEarliestEstimatedTaxLiability().url shouldBe s"$contextRoute/estimated-tax-liability"
+    }
+  }
+
+  "The URL for the EstimatedTaxLiabilityController.redirectToEarliestEstimatedTaxLiability(year) action" should {
+    s"be equal to $contextRoute/estimated-tax-liability/2018" in {
+      controllers.routes.EstimatedTaxLiabilityController.getEstimatedTaxLiability(2018).url shouldBe s"$contextRoute/estimated-tax-liability/2018"
     }
   }
 }

--- a/test/views/ObligationsViewSpec.scala
+++ b/test/views/ObligationsViewSpec.scala
@@ -84,8 +84,8 @@ class ObligationsViewSpec extends TestSupport{
 
       "has a link to view your estimates" which {
 
-        s"has the correct href to '${controllers.routes.EstimatedTaxLiabilityController.getEstimatedTaxLiability().url}'" in {
-          sidebarSection.getElementById("estimates-link").attr("href") shouldBe controllers.routes.EstimatedTaxLiabilityController.getEstimatedTaxLiability().url
+        s"has the correct href to '${controllers.routes.EstimatedTaxLiabilityController.redirectToEarliestEstimatedTaxLiability().url}'" in {
+          sidebarSection.getElementById("estimates-link").attr("href") shouldBe controllers.routes.EstimatedTaxLiabilityController.redirectToEarliestEstimatedTaxLiability().url
         }
 
         s"has the correct link wording of '${sidebarMessages.estimatesLink}'" in {


### PR DESCRIPTION
Routing is determined by the Accounting Period End Date of Income Source Models returned.

I.e., the earliest Tax Year will be the redirect URL route.