### PR TITLE
[BTAT-298] Corrected calls to self-assessment-api microservice

### DIFF
--- a/app/connectors/BusinessDetailsConnector.scala
+++ b/app/connectors/BusinessDetailsConnector.scala
@@ -32,13 +32,13 @@ import scala.concurrent.Future
 class BusinessDetailsConnector @Inject()(val http: HttpGet) extends ServicesConfig with RawResponseReads {
 
   lazy val businessListUrl: String = baseUrl("self-assessment-api")
-  lazy val getBusinessListUrl: String => String = nino => s"$businessListUrl/self-assessment/ni/$nino/self-employments"
+  lazy val getBusinessListUrl: String => String = nino => s"$businessListUrl/ni/$nino/self-employments"
 
   def getBusinessList(nino: String)(implicit headerCarrier: HeaderCarrier): Future[BusinessListResponseModel] = {
 
     val url = getBusinessListUrl(nino)
 
-    http.GET[HttpResponse](url) flatMap {
+    http.GET[HttpResponse](url)(httpReads, headerCarrier.withExtraHeaders("Accept" -> "application/vnd.hmrc.1.0+json")) flatMap {
       response =>
         response.status match {
           case OK => Logger.debug(s"[BusinessDetailsConnector][getBusinessList] - RESPONSE status: ${response.status}, body: ${response.body}")

--- a/app/connectors/BusinessObligationDataConnector.scala
+++ b/app/connectors/BusinessObligationDataConnector.scala
@@ -32,13 +32,14 @@ import scala.concurrent.Future
 class BusinessObligationDataConnector @Inject()(val http: HttpGet) extends ServicesConfig with RawResponseReads {
 
   lazy val obligationDataUrl: String = baseUrl("self-assessment-api")
-  lazy val getObligationDataUrl: (String, String) => String = (nino, selfEmploymentId) => s"$obligationDataUrl/self-assessment/ni/$nino/self-employments/$selfEmploymentId"
+  lazy val getObligationDataUrl: (String, String) => String = (nino, selfEmploymentId) =>
+    s"$obligationDataUrl/ni/$nino/self-employments/$selfEmploymentId/obligations"
 
   def getBusinessObligationData(nino: String, selfEmploymentId: String)(implicit headerCarrier: HeaderCarrier): Future[ObligationsResponseModel] = {
 
     val url = getObligationDataUrl(nino, selfEmploymentId)
 
-    http.GET[HttpResponse](url) flatMap {
+    http.GET[HttpResponse](url)(httpReads, headerCarrier.withExtraHeaders("Accept" -> "application/vnd.hmrc.1.0+json")) flatMap {
       response =>
         response.status match {
           case OK => Logger.debug(s"[BusinessObligationDataConnector][getObligationData] - RESPONSE status: ${response.status}, body: ${response.body}")

--- a/app/connectors/PropertyDetailsConnector.scala
+++ b/app/connectors/PropertyDetailsConnector.scala
@@ -33,7 +33,7 @@ import scala.concurrent.Future
 class PropertyDetailsConnector @Inject()(val http: HttpGet) extends ServicesConfig with RawResponseReads with ImplicitDateFormatter {
 
   lazy val apiContextRoute: String = baseUrl("self-assessment-api")
-  lazy val getPropertyDetailsUrl: String => String = nino => s"$apiContextRoute/self-assessment/ni/$nino/uk-properties"
+  lazy val getPropertyDetailsUrl: String => String = nino => s"$apiContextRoute/ni/$nino/uk-properties"
 
   // TODO: For MVP the only accounting period for Property is 2017/18. This needs to be enhanced post-MVP
   val defaultSuccessResponse = PropertyDetailsModel(AccountingPeriodModel("2017-04-06", "2018-04-05"))
@@ -42,7 +42,7 @@ class PropertyDetailsConnector @Inject()(val http: HttpGet) extends ServicesConf
 
     val url = getPropertyDetailsUrl(nino)
 
-    http.GET[HttpResponse](url) flatMap {
+    http.GET[HttpResponse](url)(httpReads, headerCarrier.withExtraHeaders("Accept" -> "application/vnd.hmrc.1.0+json")) flatMap {
       response =>
         response.status match {
           case OK =>

--- a/app/connectors/PropertyObligationDataConnector.scala
+++ b/app/connectors/PropertyObligationDataConnector.scala
@@ -32,13 +32,13 @@ import scala.concurrent.Future
 class PropertyObligationDataConnector @Inject()(val http: HttpGet) extends ServicesConfig with RawResponseReads {
 
   lazy val propertyDataUrl: String = baseUrl("self-assessment-api")
-  lazy val getPropertyDataUrl: String => String = nino => s"$propertyDataUrl/self-assessment/ni/$nino/uk-properties/obligations"
+  lazy val getPropertyDataUrl: String => String = nino => s"$propertyDataUrl/ni/$nino/uk-properties/obligations"
 
   def getPropertyObligationData(nino: String)(implicit headerCarrier: HeaderCarrier): Future[ObligationsResponseModel] = {
 
     val url = getPropertyDataUrl(nino)
 
-    http.GET[HttpResponse](url) flatMap {
+    http.GET[HttpResponse](url)(httpReads, headerCarrier.withExtraHeaders("Accept" -> "application/vnd.hmrc.1.0+json")) flatMap {
       response =>
         response.status match {
           case OK =>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -59,7 +59,7 @@
 
     <logger name="play.core.netty.utils.ServerCookieDecoder" level="WARN"/>
 
-    <logger name="connector" level="TRACE">
+    <logger name="connector" level="WARN">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/it/helpers/WiremockHelper.scala
+++ b/it/helpers/WiremockHelper.scala
@@ -38,6 +38,10 @@ object WiremockHelper extends Eventually with IntegrationPatience {
      verify(getRequestedFor(urlEqualTo(uri)))
   }
 
+  def verifyGetWithHeader(uri: String, headerKey: String, headerValue: String): Unit = {
+    verify(getRequestedFor(urlEqualTo(uri)).withHeader(headerKey, equalTo(headerValue)))
+  }
+
   def stubGet(url: String, status: Integer, body: String): StubMapping =
     stubFor(get(urlMatching(url))
       .willReturn(

--- a/it/helpers/servicemocks/SelfAssessmentStub.scala
+++ b/it/helpers/servicemocks/SelfAssessmentStub.scala
@@ -23,9 +23,9 @@ import play.api.libs.json.{JsValue, Json}
 
 object SelfAssessmentStub {
 
-  val businessDetailsUrl: String => String = nino => s"/self-assessment/ni/$nino/self-employments"
-  val obligationsDataUrl: (String, String) => String = (nino, selfEmploymentId) => s"/self-assessment/ni/$nino/self-employments/$selfEmploymentId"
-  val propertyObligationsUrl: String => String = nino => s"/self-assessment/ni/$nino/uk-properties/obligations"
+  val businessDetailsUrl: String => String = nino => s"/ni/$nino/self-employments"
+  val obligationsDataUrl: (String, String) => String = (nino, selfEmploymentId) => s"/ni/$nino/self-employments/$selfEmploymentId/obligations"
+  val propertyObligationsUrl: String => String = nino => s"/ni/$nino/uk-properties/obligations"
 
   def stubGetBusinessDetails(nino: String, businessDetails: JsValue) : Unit = {
     WiremockHelper.stubGet(businessDetailsUrl(nino), Status.OK, businessDetails.toString())
@@ -47,11 +47,11 @@ object SelfAssessmentStub {
   }
 
   def verifyGetObligations(nino: String, selfEmploymentId: String): Unit = {
-    WiremockHelper.verifyGet(obligationsDataUrl(nino, selfEmploymentId))
+    WiremockHelper.verifyGetWithHeader(obligationsDataUrl(nino, selfEmploymentId), "Accept", "application/vnd.hmrc.1.0+json")
   }
 
   def verifyGetBusinessDetails(nino: String): Unit = {
-    WiremockHelper.verifyGet(businessDetailsUrl(nino))
+    WiremockHelper.verifyGetWithHeader(businessDetailsUrl(nino), "Accept", "application/vnd.hmrc.1.0+json")
   }
 }
 


### PR DESCRIPTION
This fixes issue #74 

**Important**
Their is an associated PR on the itvc-dynamic-stub to correct the URL endpoint:
[BTAT-298 Stub PR](https://github.tools.tax.service.gov.uk/HMRC/itvc-dynamic-stub/pull/13)