### PR TITLE
[BTAT-274] Added in-year estimate timestamp (date)

### DIFF
--- a/app/controllers/predicates/AuthenticationPredicate.scala
+++ b/app/controllers/predicates/AuthenticationPredicate.scala
@@ -24,7 +24,7 @@ import controllers.BaseController
 import play.api.i18n.MessagesApi
 import play.api.mvc.{AnyContent, Request, Result}
 import play.api.{Configuration, Environment, Logger}
-import uk.gov.hmrc.auth.core.Retrievals.authorisedEnrolments
+import uk.gov.hmrc.auth.core.Retrievals._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.frontend.Redirects
 
@@ -58,9 +58,12 @@ class AuthenticationPredicate @Inject()(val authorisedFunctions: AuthorisedFunct
       case _: BearerTokenExpired =>
         Logger.debug("[AuthenticationPredicate][async] Bearer Token Timed Out.")
         Future.successful(Redirect(controllers.timeout.routes.SessionTimeoutController.timeout()))
-      case _ =>
+      case _: AuthorisationException =>
         Logger.debug("[AuthenticationPredicate][async] Unauthorised request. Redirect to Sign In.")
         Future.successful(Redirect(controllers.routes.SignInController.signIn()))
+      case _ =>
+        Logger.debug("[AuthenticationPredicate][async] Unexpected Error Caught. Show ISE.")
+        Future.successful(showInternalServerError)
     }
   }
 

--- a/app/utils/ImplicitDateFormatter.scala
+++ b/app/utils/ImplicitDateFormatter.scala
@@ -17,6 +17,7 @@
 package utils
 
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle._
 import java.util.Locale._
@@ -27,10 +28,15 @@ trait ImplicitDateFormatter {
 
   implicit class localDate(s: String) {
     def toLocalDate: LocalDate = LocalDate.parse(s, DateTimeFormatter.ofPattern("uuuu-M-d"))
+    def toLocalDateTime: LocalDateTime = LocalDateTime.parse(s, DateTimeFormatter.ISO_DATE_TIME)
   }
 
   implicit class longDate(d: LocalDate) {
     def toLongDate: String = d.getDayOfMonth + " " + d.getMonth.getDisplayName(FULL, UK) + " " + d.getYear
+  }
+
+  implicit class longDateTime(dt: LocalDateTime) {
+    def toLongDateTime: String = dt.getDayOfMonth + " " + dt.getMonth.getDisplayName(FULL, UK) + " " + dt.getYear
   }
 }
 

--- a/app/views/estimatedTaxLiability.scala.html
+++ b/app/views/estimatedTaxLiability.scala.html
@@ -54,7 +54,7 @@
 }
 
 @main_template(
-    title = messages("estimated_tax_liability.title"),
+    title = renderTitle(taxYear),
     bodyClasses = None,
     scriptElem = None,
     appConfig = appConfig,

--- a/app/views/estimatedTaxLiability.scala.html
+++ b/app/views/estimatedTaxLiability.scala.html
@@ -71,9 +71,9 @@
 
         <p>
             <span class="bold-medium" id="in-year-estimate">@calcModel.calcAmount.toCurrency</span>
-            <br>@messages("estimated_tax_liability.estimated-date", calcModel.calcTimestamp.toLocalDateTime.toLongDateTime)
+            <br>
+            <span id="in-year-estimate-date">@Html(messages("estimated_tax_liability.estimated-date", calcModel.calcTimestamp.toLocalDateTime.toLongDateTime))</span>
         </p>
-        <p></p>
 
         @if(calcModel.breakdownNonEmpty){
             @defining(calcModel.calcDataModel.get) { breakdown =>

--- a/app/views/estimatedTaxLiability.scala.html
+++ b/app/views/estimatedTaxLiability.scala.html
@@ -161,6 +161,10 @@
             }
         }
 
+        <p id="changes">
+            @messages("estimated_tax_liability.estimated-tax.changes")
+        </p>
+
         <p id="payment">
             @messages(s"estimated_tax_liability.estimated-tax.payment")
             <span id="pyt-due-date">@renderPaymentDueDate(taxYear)</span>.

--- a/app/views/estimatedTaxLiability.scala.html
+++ b/app/views/estimatedTaxLiability.scala.html
@@ -16,6 +16,7 @@
 
 @import views.html.templates.main_template
 @import utils.ImplicitCurrencyFormatter._
+@import utils.ImplicitDateFormatter._
 @import views.helpers.TaxYearRenderHelper._
 @import models.CalculationDataResponseModel
 
@@ -68,12 +69,11 @@
 
         <p id="p1" class="panel-indent">@messages("estimated_tax_liability.estimated-tax.p1")</p>
 
-        <p><span class="bold-medium" id="in-year-estimate">@calcModel.calcAmount.toCurrency</span></p>
-
-        <p id="payment">
-            @messages(s"estimated_tax_liability.estimated-tax.payment")
-            <span id="pyt-due-date">@renderPaymentDueDate(taxYear)</span>.
+        <p>
+            <span class="bold-medium" id="in-year-estimate">@calcModel.calcAmount.toCurrency</span>
+            <br>@messages("estimated_tax_liability.estimated-date", calcModel.calcTimestamp.toLocalDateTime.toLongDateTime)
         </p>
+        <p></p>
 
         @if(calcModel.breakdownNonEmpty){
             @defining(calcModel.calcDataModel.get) { breakdown =>
@@ -160,5 +160,10 @@
             </details>
             }
         }
+
+        <p id="payment">
+            @messages(s"estimated_tax_liability.estimated-tax.payment")
+            <span id="pyt-due-date">@renderPaymentDueDate(taxYear)</span>.
+        </p>
     </section>
  }

--- a/app/views/helpers/ObSecHelper.scala.html
+++ b/app/views/helpers/ObSecHelper.scala.html
@@ -32,12 +32,12 @@
             <tbody>
                 @model.get.obligations.zipWithIndex.map { case (obligation: ObligationModel, index: Int) =>
                     <tr class="obligation">
-                        <td>
+                        <td class="no-border-bottom">
                             <p>
                                 <span id="@{id}-ob-@{index + 1}-start">@obligation.start.toLongDate</span> to <span id="@{id}-ob-@{index+1}-end">@obligation.end.toLongDate</span>
                             </p>
                         </td>
-                        <td id="@{id}-ob-@{index+1}-status">
+                        <td id="@{id}-ob-@{index+1}-status" class="no-border-bottom">
                             @ObligationStatusHelper.statusHtml(obligation.getObligationStatus)
                         </td>
                     </tr>

--- a/app/views/helpers/ObSecHelper.scala.html
+++ b/app/views/helpers/ObSecHelper.scala.html
@@ -25,8 +25,8 @@
         <table>
             <thead>
                 <tr>
-                    <th>@Messages("obligations.accountingPeriod")</th>
-                    <th>@Messages("obligations.reportDueDate")</th>
+                    <th id="@{id}-period-heading">@Messages("obligations.accountingPeriod")</th>
+                    <th id="@{id}-status-heading">@Messages("obligations.reportDueDate")</th>
                 </tr>
             </thead>
             <tbody>

--- a/app/views/helpers/TaxYearRenderHelper.scala
+++ b/app/views/helpers/TaxYearRenderHelper.scala
@@ -25,6 +25,10 @@ object TaxYearRenderHelper {
     messages("estimated_tax_liability.tax-year", s"${taxYear - 1}", s"$taxYear")
   }
 
+  def renderTitle(taxYear: Int)(implicit messages: Messages): String = {
+    messages("estimated_tax_liability.title", s"${taxYear - 1}", s"$taxYear")
+  }
+
   def renderPaymentDueDate(taxYear: Int): String = {
     s"${taxYear + 1}-01-31".toLocalDate.toLongDate
   }

--- a/conf/messages
+++ b/conf/messages
@@ -45,7 +45,7 @@ timeout.signIn                                                  = To view your q
 ## Sidebar ##
 sidebar.quarterly_reporting_reference.h3                        = Income Tax reference:
 sidebar.view_estimated_liability.h3                             = Estimates
-sidebar.view_estimated_liability.link                           = View your estimated tax amount
+sidebar.view_estimated_liability.link                           = View your tax estimate
 sidebar.view_obligations.h3                                     = Deadlines
 sidebar.view_obligations.link                                   = View report deadlines
 sidebar.self_assessment.h3                                      = Previous tax years

--- a/conf/messages
+++ b/conf/messages
@@ -26,7 +26,7 @@ estimated_tax_liability.estimated-date                          = Estimate up to
 obligations.title                                               = Your Income Tax reports
 obligations.heading                                             = Your Income Tax reports
 obligations.info                                                = You must submit a report once every quarter using your accounting software.
-obligations.accountingPeriod                                    = Accounting period
+obligations.accountingPeriod                                    = Report period
 obligations.reportDueDate                                       = Report due date
 
 obligations.bi.subheading                                       = Business income

--- a/conf/messages
+++ b/conf/messages
@@ -19,7 +19,7 @@ estimated_tax_liability.calc-breakdown.income-tax               = Income Tax
 estimated_tax_liability.calc-breakdown.tax-rate                 = {0} at {1}%
 estimated_tax_liability.calc-breakdown.national-insurance       = National Insurance
 estimated_tax_liability.calc-breakdown.total-estimate           = Your Income Tax and National Insurance estimate
-estimated_tax_liability.estimated-date                          = Estimate up to your {0} submission
+estimated_tax_liability.estimated-date                          = Estimate up to your <span id="calc-date">{0}</span> submission
 
 ## Obligations Page ##
 obligations.title                                               = Your Income Tax reports

--- a/conf/messages
+++ b/conf/messages
@@ -5,7 +5,7 @@ base.phase                                                      = BETA
 base.sign-out                                                   = Sign out
 
 ## Estimated Tax Liability Page ##
-estimated_tax_liability.title                                   = 2017/18 - Business Tax Account
+estimated_tax_liability.title                                   = {0} to {1} tax year Your current tax estimate
 estimated_tax_liability.heading                                 = Your current tax estimate
 estimated_tax_liability.tax-year                                = {0} to {1} tax year
 estimated_tax_liability.estimated-tax.p1                        = We''ve calculated this estimate using the figures and dates you''ve reported in your accounting software. The amount includes both your Income Tax and National Insurance.
@@ -23,12 +23,11 @@ estimated_tax_liability.calc-breakdown.total-estimate           = Your Income Ta
 estimated_tax_liability.estimated-date                          = Estimate up to your <span id="calc-date">{0}</span> submission
 
 ## Obligations Page ##
-obligations.title                                               = Your Income Tax reports
-obligations.heading                                             = Your Income Tax reports
+obligations.title                                               = Your report deadlines
+obligations.heading                                             = Your report deadlines
 obligations.info                                                = You must submit a report once every quarter using your accounting software.
 obligations.accountingPeriod                                    = Report period
 obligations.reportDueDate                                       = Report due date
-
 obligations.bi.subheading                                       = Business income
 obligations.pi.subheading                                       = Property income
 

--- a/conf/messages
+++ b/conf/messages
@@ -9,6 +9,7 @@ estimated_tax_liability.title                                   = 2017/18 - Busi
 estimated_tax_liability.heading                                 = Your current tax estimate
 estimated_tax_liability.tax-year                                = {0} to {1} tax year
 estimated_tax_liability.estimated-tax.p1                        = We''ve calculated this estimate using the figures and dates you''ve reported in your accounting software. The amount includes both your Income Tax and National Insurance.
+estimated_tax_liability.estimated-tax.changes                   = Your estimate could change if you have any income or expenses that you''ve not reported through your software.
 estimated_tax_liability.estimated-tax.payment                   = You must pay any tax you owe for the whole tax year by
 estimated_tax_liability.calc-breakdown.link                     = View your estimate breakdown
 estimated_tax_liability.calc-breakdown.business-profit          = Business profit

--- a/conf/messages
+++ b/conf/messages
@@ -19,6 +19,7 @@ estimated_tax_liability.calc-breakdown.income-tax               = Income Tax
 estimated_tax_liability.calc-breakdown.tax-rate                 = {0} at {1}%
 estimated_tax_liability.calc-breakdown.national-insurance       = National Insurance
 estimated_tax_liability.calc-breakdown.total-estimate           = Your Income Tax and National Insurance estimate
+estimated_tax_liability.estimated-date                          = Estimate up to your {0} submission
 
 ## Obligations Page ##
 obligations.title                                               = Your Income Tax reports

--- a/public/stylesheets/itvc.css
+++ b/public/stylesheets/itvc.css
@@ -1,13 +1,10 @@
 /*Estimated Tax Liabilities*/
 
-#tax-year {
-    color: #6f777b;
-}
 .itvc-table td {
      font-size: inherit;
  }
 
-.no-border-bottom td{
+.no-border-bottom {
     border-bottom: 0px;
 }
 

--- a/test/assets/Messages.scala
+++ b/test/assets/Messages.scala
@@ -61,7 +61,7 @@ object Messages {
     val reportsHeading = "Deadlines"
     val reportsLink = "View report deadlines"
     val estimatesHeading = "Estimates"
-    val estimatesLink = "View your estimated tax amount"
+    val estimatesLink = "View your tax estimate"
     val selfAssessmentHeading = "Previous tax years"
     val selfAssessmentLink = "View annual returns"
   }

--- a/test/assets/Messages.scala
+++ b/test/assets/Messages.scala
@@ -16,8 +16,6 @@
 
 package assets
 
-import play.twirl.api.Html
-
 object Messages {
 
   // Estimated Tax Liability Page Messages
@@ -30,6 +28,7 @@ object Messages {
       val p1 = "We've calculated this estimate using the figures and dates you've reported in your accounting software. " +
         "The amount includes both your Income Tax and National Insurance."
       val calcDate: String => String = date => s"""Estimate up to your <span id="calc-date">$date</span> submission"""
+      val changes = "Your estimate could change if you have any income or expenses that you've not reported through your software."
       val payment = "You must pay any tax you owe for the whole tax year by 31 January 2019."
       val toDate = "Estimate to date"
     }

--- a/test/assets/Messages.scala
+++ b/test/assets/Messages.scala
@@ -16,6 +16,8 @@
 
 package assets
 
+import play.twirl.api.Html
+
 object Messages {
 
   // Estimated Tax Liability Page Messages
@@ -27,6 +29,7 @@ object Messages {
       val h2 = "2017/18 - Business Tax Account"
       val p1 = "We've calculated this estimate using the figures and dates you've reported in your accounting software. " +
         "The amount includes both your Income Tax and National Insurance."
+      val calcDate: String => String = date => s"""Estimate up to your <span id="calc-date">$date</span> submission"""
       val payment = "You must pay any tax you owe for the whole tax year by 31 January 2019."
       val toDate = "Estimate to date"
     }

--- a/test/assets/Messages.scala
+++ b/test/assets/Messages.scala
@@ -20,9 +20,9 @@ object Messages {
 
   // Estimated Tax Liability Page Messages
   object EstimatedTaxLiability {
-    val title = "2017/18 - Business Tax Account"
     val pageHeading = "Your current tax estimate"
     val taxYear = "2017 to 2018 tax year"
+    val title = taxYear + " " + pageHeading
     object EstimateTax {
       val h2 = "2017/18 - Business Tax Account"
       val p1 = "We've calculated this estimate using the figures and dates you've reported in your accounting software. " +
@@ -36,7 +36,7 @@ object Messages {
 
   //Obligations Page Messages
   object Obligations {
-    val title = "Your Income Tax reports"
+    val title = "Your report deadlines"
     val info  = "You must submit a report once every quarter using your accounting software."
     val businessHeading = "Business income"
     val propertyHeading = "Property income"

--- a/test/assets/Messages.scala
+++ b/test/assets/Messages.scala
@@ -40,6 +40,8 @@ object Messages {
     val info  = "You must submit a report once every quarter using your accounting software."
     val businessHeading = "Business income"
     val propertyHeading = "Property income"
+    val periodHeading = "Report period"
+    val statusHeading = "Report due date"
   }
 
   // Timeout Messages

--- a/test/views/EstimatedTaxLiabilityViewSpec.scala
+++ b/test/views/EstimatedTaxLiabilityViewSpec.scala
@@ -31,6 +31,7 @@ import assets.TestConstants.PropertyIncome._
 import assets.TestConstants.BusinessDetails._
 import auth.MtdItUser
 import models.IncomeSourcesModel
+import play.twirl.api.Html
 
 class EstimatedTaxLiabilityViewSpec extends TestSupport {
 
@@ -70,6 +71,14 @@ class EstimatedTaxLiabilityViewSpec extends TestSupport {
 
       s"has the correct Estimated Tax Amount of '$testAmount'" in {
         estimateSection.getElementById("in-year-estimate").text shouldBe testAmountOutput
+      }
+
+      s"has a calculation date paragraph with '${messages.EstimateTax.calcDate("6 July 2017")}'" in {
+        estimateSection.getElementById("in-year-estimate-date").html() shouldBe messages.EstimateTax.calcDate("6 July 2017")
+      }
+
+      s"has a calculation date of the 6 July 2017" in {
+        estimateSection.getElementById("calc-date").text shouldBe "6 July 2017"
       }
 
       s"has a payment paragraph with '${messages.EstimateTax.payment}'" in {

--- a/test/views/EstimatedTaxLiabilityViewSpec.scala
+++ b/test/views/EstimatedTaxLiabilityViewSpec.scala
@@ -77,6 +77,10 @@ class EstimatedTaxLiabilityViewSpec extends TestSupport {
         estimateSection.getElementById("in-year-estimate-date").html() shouldBe messages.EstimateTax.calcDate("6 July 2017")
       }
 
+      s"has a paragraph to warn them that their estimate might change" in {
+        estimateSection.getElementById("changes").text shouldBe messages.EstimateTax.changes
+      }
+
       s"has a calculation date of the 6 July 2017" in {
         estimateSection.getElementById("calc-date").text shouldBe "6 July 2017"
       }

--- a/test/views/ObligationsViewSpec.scala
+++ b/test/views/ObligationsViewSpec.scala
@@ -57,6 +57,14 @@ class ObligationsViewSpec extends TestSupport{
 
     "have a table containing the obligations" should {
 
+      "contain the heading for Report period" in {
+        document.getElementById("bi-period-heading").text() shouldBe "Report period"
+      }
+
+      "contain the heading for Status" in {
+        document.getElementById("bi-status-heading").text() shouldBe "Report due date"
+      }
+
       "contain the first row and have the start date as '1 January 2017' and status 'Received'" in {
         document.getElementById("bi-ob-1-start").text() shouldBe "1 January 2017"
         document.getElementById("bi-ob-1-status").text() shouldBe "Received"


### PR DESCRIPTION
Also added some content changes for v0.10.0 of proto from BTAT-268.

- Corrected obligation table styling
- Update the Estimated Tax Liability title and heading
- Updated 'Accounting period' to 'Report period'
- Added the sentence to warn users that their estimate may change

**Note**
There is also a minor fix to the authentication predicate to catch unexpected errors and throw ISE. Any auth errors will return to sign-in unless it is for an insufficient enrolments exception or timed out bearer token.