### PR TITLE
[BTAT-351] Added the not-enrolled view and handling

### DIFF
--- a/app/config/frontendAppConfig.scala
+++ b/app/config/frontendAppConfig.scala
@@ -41,6 +41,7 @@ trait AppConfig {
   val businessTaxAccount: String
   val btaManageAccountUrl: String
   val btaMessagesUrl: String
+  val signUpUrl: String
 }
 
 @Singleton
@@ -84,4 +85,7 @@ class FrontendAppConfig @Inject()(configuration: Configuration) extends AppConfi
   override lazy val businessTaxAccount: String = loadConfig("business-tax-account.url")
   override lazy val btaManageAccountUrl: String = s"$businessTaxAccount/manage-account"
   override lazy val btaMessagesUrl: String = s"$businessTaxAccount/messages"
+
+  //Subscription Service
+  override lazy val signUpUrl: String = loadConfig("mtd-subscription-service.url")
 }

--- a/app/controllers/notEnrolled/NotEnrolledController.scala
+++ b/app/controllers/notEnrolled/NotEnrolledController.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.notEnrolled
+
+import com.google.inject.{Inject, Singleton}
+import config.AppConfig
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc._
+import uk.gov.hmrc.play.frontend.controller.FrontendController
+
+import scala.concurrent.Future
+
+@Singleton
+class NotEnrolledController @Inject()(implicit val config: AppConfig,
+                                      val messagesApi: MessagesApi) extends FrontendController with I18nSupport {
+  val show: Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(views.html.notEnrolled.notEnrolled()))
+  }
+}

--- a/app/controllers/predicates/AuthenticationPredicate.scala
+++ b/app/controllers/predicates/AuthenticationPredicate.scala
@@ -59,7 +59,7 @@ class AuthenticationPredicate @Inject()(val authorisedFunctions: FrontendAuthori
     }.recoverWith {
       case _: InsufficientEnrolments =>
         Logger.debug("[AuthenticationPredicate][async] No HMRC-MTD-IT Enrolment and/or No NINO.")
-        Future.successful(showInternalServerError)
+        Future.successful(Redirect(controllers.notEnrolled.routes.NotEnrolledController.show()))
       case _: BearerTokenExpired =>
         Logger.debug("[AuthenticationPredicate][async] Bearer Token Timed Out.")
         Future.successful(Redirect(controllers.timeout.routes.SessionTimeoutController.timeout()))

--- a/app/views/notEnrolled/notEnrolled.scala.html
+++ b/app/views/notEnrolled/notEnrolled.scala.html
@@ -19,9 +19,9 @@
 
 @()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
-@main_template(title = messages("timeout.title"), bodyClasses = None, showLogout = false, showBtaHeader = false) {
+@main_template(title = messages("not_enrolled.title"), bodyClasses = None, showLogout = true, showBtaHeader = false) {
 
-  <h1 class="h1-heading">@Messages("timeout.heading")</h1>
-  <p id="sign-in">@Html(Messages("timeout.signIn", controllers.routes.SignInController.signIn().url))</p>
+  <h1 class="h1-heading" id="page-heading">@Messages("not_enrolled.heading")</h1>
+  <p id="sign-up">@Html(Messages("not_enrolled.sign-up", appConfig.signUpUrl))</p>
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -21,3 +21,6 @@ GET         /sign-out                               controllers.SignOutControlle
 
 #Sign In Routes
 GET         /sign-in                                controllers.SignInController.signIn
+
+#Not Enrolled
+GET         /not-enrolled                           controllers.notEnrolled.NotEnrolledController.show

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -152,4 +152,6 @@ business-tax-account {
   url = "http://localhost:9020/business-account"
 }
 
-
+mtd-subscription-service {
+  url = "http://localhost:9561/report-quarterly/income-and-expesnes/sign-up"
+}

--- a/conf/messages
+++ b/conf/messages
@@ -48,7 +48,7 @@ status.open                                                     = Due by {0}
 ## Timeout page ##
 timeout.title                                                   = Your session has timed out
 timeout.heading                                                 = Your session has timed out
-timeout.signIn                                                  = To view your quarterly reporting details, you''ll have to <a id="sign-in-link" href="{0}" rel="external">sign in</a> using your Government Gateway ID.
+timeout.signIn                                                  = To view your quarterly reporting details, you''ll have to <a id="sign-in-link" href="{0}">sign in</a> using your Government Gateway ID.
 
 
 ## Sidebar ##
@@ -61,3 +61,8 @@ sidebar.self_assessment.h3                                      = Previous tax y
 sidebar.self_assessment.link                                    = View annual returns
 sidebar.future_tax_years.h3                                     = Future tax years
 sidebar.view_estimate_for_year.link                             = View {0} to {1} details
+
+## Not Enrolled
+not_enrolled.heading                                            = You can''t view this page
+not_enrolled.title                                              = You can''t view this page
+not_enrolled.sign-up                                            = You need to <a id="sign-up-link" href="{0}">sign up for quarterly reporting</a> before you can view this page.

--- a/test/assets/Messages.scala
+++ b/test/assets/Messages.scala
@@ -87,4 +87,10 @@ object Messages {
     val btaMessages = "Messages"
     val btaManageAccount = "Manage account"
   }
+
+  object NotEnrolled {
+    val title = "You can't view this page"
+    val heading = title
+    val signUp = "You need to sign up for quarterly reporting before you can view this page."
+  }
 }

--- a/test/controllers/NotEnrolledControllerSpec.scala
+++ b/test/controllers/NotEnrolledControllerSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.FrontendAppConfig
+import controllers.notEnrolled.NotEnrolledController
+import org.jsoup.Jsoup
+import play.api.http.Status
+import play.api.i18n.MessagesApi
+import utils.TestSupport
+import assets.Messages.{NotEnrolled => messages}
+
+class NotEnrolledControllerSpec extends TestSupport {
+
+  object TestNotEnrolledController extends NotEnrolledController()(
+    fakeApplication.injector.instanceOf[FrontendAppConfig],
+    fakeApplication.injector.instanceOf[MessagesApi]
+  )
+
+  "the NotEnrolledController.show() action" should {
+
+    lazy val result = TestNotEnrolledController.show(fakeRequestNoSession)
+    lazy val document = Jsoup.parse(bodyOf(result))
+
+    "return OK (200)" in {
+      status(result) shouldBe Status.OK
+    }
+
+    "show the not_enrolled page" in {
+      document.getElementById("page-heading").text() shouldBe messages.heading
+    }
+
+  }
+
+}

--- a/test/controllers/predicates/AsyncActionPredicateSpec.scala
+++ b/test/controllers/predicates/AsyncActionPredicateSpec.scala
@@ -63,9 +63,15 @@ class AsyncActionPredicateSpec extends TestSupport with MockitoSugar with MockAu
 
       "a HMRC-MTD-IT enrolment does NOT exist" should {
 
-        "return Internal Server Error (500)" in {
+        "have a redirect (303 - SEE_OTHER) status" in {
           setupMockAuthorisationException(new InsufficientEnrolments)
-          status(result) shouldBe Status.INTERNAL_SERVER_ERROR
+          status(result) shouldBe Status.SEE_OTHER
+
+        }
+
+        "redirect to the Not Enrolled page" in {
+          setupMockAuthorisationException(new InsufficientEnrolments)
+          redirectLocation(result) shouldBe Some(controllers.notEnrolled.routes.NotEnrolledController.show().url)
         }
       }
     }

--- a/test/routes/RoutesSpec.scala
+++ b/test/routes/RoutesSpec.scala
@@ -48,4 +48,11 @@ class RoutesSpec extends TestSupport {
       controllers.routes.FinancialDataController.getFinancialData(2018).url shouldBe s"$contextRoute/estimated-tax-liability/2018"
     }
   }
+
+  //Not-Enrolled route
+  "The URL for the NotEnrolledController.show action" should {
+    s"be equal to $contextRoute/not-enrolled" in {
+      controllers.notEnrolled.routes.NotEnrolledController.show().url shouldBe s"$contextRoute/not-enrolled"
+    }
+  }
 }

--- a/test/views/notEnrolled/NotEnrolledViewSpec.scala
+++ b/test/views/notEnrolled/NotEnrolledViewSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.notEnrolled
+
+import assets.Messages.{NotEnrolled => messages}
+import config.FrontendAppConfig
+import org.jsoup.Jsoup
+import play.api.Play.current
+import play.api.i18n.Messages.Implicits._
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import utils.TestSupport
+
+class NotEnrolledViewSpec extends TestSupport {
+
+  lazy val mockAppConfig = fakeApplication.injector.instanceOf[FrontendAppConfig]
+
+  lazy val page = views.html.notEnrolled.notEnrolled()(FakeRequest(), applicationMessages, mockAppConfig)
+  lazy val document = Jsoup.parse(contentAsString(page))
+
+  "The Not Enrolled view" should {
+
+    s"have the title '${messages.title}'" in {
+      document.title() shouldBe messages.title
+    }
+
+    s"have the H1 '${messages.heading}'" in {
+      document.getElementsByTag("H1").text() shouldBe messages.heading
+    }
+
+    s"have a paragraph" which {
+
+      "has the text" in {
+        document.getElementById("sign-up").text() shouldBe messages.signUp
+      }
+
+      "has a link to sign-in page" in {
+        document.getElementById("sign-up-link").attr("href") shouldBe mockAppConfig.signUpUrl
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
**Note**
- Please merge app-config-base PR before merging this.
https://github.tools.tax.service.gov.uk/HMRC/app-config-base/pull/724

There is also a styling fix for the session-timeout page.
