### PR TITLE
[Inject-Frontend-App-Config] Inject the frontend app config into connectors

### DIFF
--- a/app/config/frontendAppConfig.scala
+++ b/app/config/frontendAppConfig.scala
@@ -47,6 +47,9 @@ trait AppConfig {
   val signUpUrl: String
   val itvcFrontendEnvironment: String
   val exitSurveyUrl: String
+  val saApiService: String
+  val itvcProtectedService: String
+  val btaService: String
 }
 
 @Singleton
@@ -72,6 +75,12 @@ class FrontendAppConfig @Inject()(val environment: Environment,
   override lazy val betaFeedbackUrl = s"$baseUrl/feedback"
   override lazy val betaFeedbackUnauthenticatedUrl: String = betaFeedbackUrl
 
+  //SA-API Config
+  override lazy val saApiService: String = baseUrl("self-assessment-api")
+
+  //ITVC Protected Service
+  override lazy val itvcProtectedService: String = baseUrl("income-tax-view-change")
+
   //GA
   override lazy val analyticsToken: String = loadConfig(s"google-analytics.token")
   override lazy val analyticsHost: String = loadConfig(s"google-analytics.host")
@@ -93,6 +102,7 @@ class FrontendAppConfig @Inject()(val environment: Environment,
   override lazy val ninoIdentifierKey: String = loadConfig("enrolments.nino.identifier")
 
   //Business Tax Account
+  override lazy val btaService: String = baseUrl("business-account")
   override lazy val businessTaxAccount: String = loadConfig("business-tax-account.url")
   override lazy val btaManageAccountUrl: String = s"$businessTaxAccount/manage-account"
   override lazy val btaMessagesUrl: String = s"$businessTaxAccount/messages"

--- a/app/connectors/BusinessDetailsConnector.scala
+++ b/app/connectors/BusinessDetailsConnector.scala
@@ -18,26 +18,21 @@ package connectors
 
 import javax.inject.{Inject, Singleton}
 
+import config.FrontendAppConfig
 import models._
-import play.api.Mode.Mode
-import play.api.{Configuration, Environment, Logger}
+import play.api.Logger
 import play.api.http.Status
 import play.api.http.Status.OK
-import uk.gov.hmrc.play.config.ServicesConfig
+import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
+import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 
 import scala.concurrent.Future
-import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
-import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
 
 @Singleton
 class BusinessDetailsConnector @Inject()(val http: HttpGet,
-                                         val environment: Environment,
-                                         val conf: Configuration) extends ServicesConfig with RawResponseReads {
+                                         val config: FrontendAppConfig) extends RawResponseReads {
 
-  override protected def mode: Mode = environment.mode
-  override protected def runModeConfiguration: Configuration = conf
-  lazy val businessListUrl: String = baseUrl("self-assessment-api")
-  lazy val getBusinessListUrl: String => String = nino => s"$businessListUrl/ni/$nino/self-employments"
+  lazy val getBusinessListUrl: String => String = nino => s"${config.saApiService}/ni/$nino/self-employments"
 
   def getBusinessList(nino: String)(implicit headerCarrier: HeaderCarrier): Future[BusinessListResponseModel] = {
 

--- a/app/connectors/BusinessReportDeadlinesConnector.scala
+++ b/app/connectors/BusinessReportDeadlinesConnector.scala
@@ -18,27 +18,22 @@ package connectors
 
 import javax.inject.{Inject, Singleton}
 
+import config.FrontendAppConfig
 import models._
-import play.api.Mode.Mode
-import play.api.{Configuration, Environment, Logger}
+import play.api.Logger
 import play.api.http.Status
 import play.api.http.Status.OK
 import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
-import uk.gov.hmrc.play.config.ServicesConfig
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 @Singleton
 class BusinessReportDeadlinesConnector @Inject()(val http: HttpGet,
-                                                 val environment: Environment,
-                                                 val conf: Configuration) extends ServicesConfig with RawResponseReads {
+                                                 val config: FrontendAppConfig) extends RawResponseReads {
 
-  override protected def mode: Mode = environment.mode
-  override protected def runModeConfiguration: Configuration = conf
-  lazy val reportDeadlineDataUrl: String = baseUrl("self-assessment-api")
   lazy val getReportDeadlineDataUrl: (String, String) => String = (nino, selfEmploymentId) =>
-    s"$reportDeadlineDataUrl/ni/$nino/self-employments/$selfEmploymentId/obligations"
+    s"${config.saApiService}/ni/$nino/self-employments/$selfEmploymentId/obligations"
 
   def getBusinessReportDeadlineData(nino: String, selfEmploymentId: String)(implicit headerCarrier: HeaderCarrier): Future[ReportDeadlinesResponseModel] = {
 

--- a/app/connectors/CalculationDataConnector.scala
+++ b/app/connectors/CalculationDataConnector.scala
@@ -18,6 +18,7 @@ package connectors
 
 import javax.inject.{Inject, Singleton}
 
+import config.FrontendAppConfig
 import models._
 import play.api.Mode.Mode
 import uk.gov.hmrc.play.config.ServicesConfig
@@ -31,14 +32,9 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
 
 @Singleton
 class CalculationDataConnector @Inject()(val http: HttpGet,
-                                         val environment: Environment,
-                                         val conf: Configuration) extends ServicesConfig with RawResponseReads {
+                                         val config: FrontendAppConfig) extends RawResponseReads {
 
-  override protected def mode: Mode = environment.mode
-  override protected def runModeConfiguration: Configuration = conf
-
-  lazy val calculationDataUrl: String = baseUrl("self-assessment-api")
-  lazy val getCalculationDataUrl: (String, String) => String = (nino, taxCalculationId) => s"$calculationDataUrl/ni/$nino/calculations/$taxCalculationId"
+  lazy val getCalculationDataUrl: (String, String) => String = (nino, taxCalculationId) => s"${config.saApiService}/ni/$nino/calculations/$taxCalculationId"
 
   def getCalculationData(nino: String, taxCalculationId: String)(implicit headerCarrier: HeaderCarrier): Future[CalculationDataResponseModel] = {
 

--- a/app/connectors/LastTaxCalculationConnector.scala
+++ b/app/connectors/LastTaxCalculationConnector.scala
@@ -18,29 +18,22 @@ package connectors
 
 import javax.inject.{Inject, Singleton}
 
+import config.FrontendAppConfig
 import models._
-import play.api.Mode.Mode
-import play.api.{Configuration, Environment, Logger}
+import play.api.Logger
 import play.api.http.Status
 import play.api.http.Status._
-import uk.gov.hmrc.play.config.ServicesConfig
-import uk.gov.hmrc.play.http._
+import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
 
 @Singleton
 class LastTaxCalculationConnector @Inject()(val http: HttpGet,
-                                            val environment: Environment,
-                                            val conf: Configuration) extends ServicesConfig with RawResponseReads {
+                                            val config: FrontendAppConfig) extends RawResponseReads {
 
-  override protected def mode: Mode = environment.mode
-  override protected def runModeConfiguration: Configuration = conf
-
-  lazy val protectedMicroserviceUrl: String = baseUrl("income-tax-view-change")
   lazy val getEstimatedTaxLiabilityUrl: (String, String) => String = (nino, year) =>
-    s"$protectedMicroserviceUrl/income-tax-view-change/estimated-tax-liability/$nino/$year/it"
+    s"${config.itvcProtectedService}/income-tax-view-change/estimated-tax-liability/$nino/$year/it"
 
   def getLastEstimatedTax(nino: String, year: Int)(implicit headerCarrier: HeaderCarrier): Future[LastTaxCalculationResponseModel] = {
 

--- a/app/connectors/PropertyDetailsConnector.scala
+++ b/app/connectors/PropertyDetailsConnector.scala
@@ -18,28 +18,22 @@ package connectors
 
 import javax.inject.{Inject, Singleton}
 
+import config.FrontendAppConfig
 import models._
-import play.api.Mode.Mode
-import play.api.{Configuration, Environment, Logger}
+import play.api.Logger
 import play.api.http.Status
 import play.api.http.Status.{NOT_FOUND, OK}
-import uk.gov.hmrc.play.config.ServicesConfig
-import utils.ImplicitDateFormatter
+import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
+import utils.ImplicitDateFormatter
 
 import scala.concurrent.Future
-import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
 
 @Singleton
 class PropertyDetailsConnector @Inject()(val http: HttpGet,
-                                         val environment: Environment,
-                                         val conf: Configuration) extends ServicesConfig with RawResponseReads with ImplicitDateFormatter {
+                                         val config: FrontendAppConfig) extends RawResponseReads with ImplicitDateFormatter {
 
-  override protected def mode: Mode = environment.mode
-  override protected def runModeConfiguration: Configuration = conf
-
-  lazy val apiContextRoute: String = baseUrl("self-assessment-api")
-  lazy val getPropertyDetailsUrl: String => String = nino => s"$apiContextRoute/ni/$nino/uk-properties"
+  lazy val getPropertyDetailsUrl: String => String = nino => s"${config.saApiService}/ni/$nino/uk-properties"
 
   // TODO: For MVP the only accounting period for Property is 2017/18. This needs to be enhanced post-MVP
   val defaultSuccessResponse = PropertyDetailsModel(AccountingPeriodModel("2017-04-06", "2018-04-05"))

--- a/app/connectors/PropertyReportDeadlineDataConnector.scala
+++ b/app/connectors/PropertyReportDeadlineDataConnector.scala
@@ -18,27 +18,21 @@ package connectors
 
 import javax.inject.{Inject, Singleton}
 
+import config.FrontendAppConfig
 import models._
-import play.api.Mode.Mode
-import play.api.{Configuration, Environment, Logger}
+import play.api.Logger
 import play.api.http.Status
 import play.api.http.Status.OK
 import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
-import uk.gov.hmrc.play.config.ServicesConfig
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 @Singleton
 class PropertyReportDeadlineDataConnector @Inject()(val http: HttpGet,
-                                                    val environment: Environment,
-                                                    val conf: Configuration) extends ServicesConfig with RawResponseReads {
+                                                    val config: FrontendAppConfig) extends RawResponseReads {
 
-  override protected def mode: Mode = environment.mode
-  override protected def runModeConfiguration: Configuration = conf
-
-  lazy val propertyReportDeadlineDataUrl: String = baseUrl("self-assessment-api")
-  lazy val getPropertyReportDeadlineDataUrl: String => String = nino => s"$propertyReportDeadlineDataUrl/ni/$nino/uk-properties/obligations"
+  lazy val getPropertyReportDeadlineDataUrl: String => String = nino => s"${config.saApiService}/ni/$nino/uk-properties/obligations"
 
   def getPropertyReportDeadlineData(nino: String)(implicit headerCarrier: HeaderCarrier): Future[ReportDeadlinesResponseModel] = {
 

--- a/app/connectors/UserDetailsConnector.scala
+++ b/app/connectors/UserDetailsConnector.scala
@@ -19,22 +19,15 @@ package connectors
 import javax.inject.{Inject, Singleton}
 
 import models._
-import play.api.Mode.Mode
-import play.api.{Configuration, Environment, Logger}
+import play.api.Logger
 import play.api.http.Status.OK
-import uk.gov.hmrc.play.config.ServicesConfig
+import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
 
 @Singleton
-class UserDetailsConnector @Inject()(val http: HttpGet,
-                                     val environment: Environment,
-                                     val conf: Configuration) extends ServicesConfig with RawResponseReads {
-
-  override protected def mode: Mode = environment.mode
-  override protected def runModeConfiguration: Configuration = conf
+class UserDetailsConnector @Inject()(val http: HttpGet) extends RawResponseReads {
 
   def getUserDetails(userDetailsUrl: String)(implicit headerCarrier: HeaderCarrier): Future[UserDetailsResponseModel] = {
     Logger.debug(s"[UserDetailsConnector][getUserDetails] - GET $userDetailsUrl")

--- a/test/connectors/BusinessDetailsConnectorSpec.scala
+++ b/test/connectors/BusinessDetailsConnectorSpec.scala
@@ -35,7 +35,7 @@ class BusinessDetailsConnectorSpec extends TestSupport with MockHttp {
   val badResponse = HttpResponse(Status.BAD_REQUEST, responseString = Some("Error Message"))
   val successNoBusiness = HttpResponse(Status.OK, responseJson = Some(Json.parse(businessSuccessEmptyResponse)))
 
-  object TestBusinessDetailsConnector extends BusinessDetailsConnector(mockHttpGet, environment, conf)
+  object TestBusinessDetailsConnector extends BusinessDetailsConnector(mockHttpGet, frontendAppConfig)
 
   "BusinessDetailsConnector.getBusinessList" should {
 

--- a/test/connectors/BusinessReportDeadlinesConnectorSpec.scala
+++ b/test/connectors/BusinessReportDeadlinesConnectorSpec.scala
@@ -34,7 +34,7 @@ class BusinessReportDeadlinesConnectorSpec extends TestSupport with MockHttp {
   val successResponseBadJson = HttpResponse(Status.OK, responseJson = Some(Json.parse("{}")))
   val badResponse = HttpResponse(Status.BAD_REQUEST, responseString = Some("Error Message"))
 
-  object TestBusinessReportDeadlinesDataConnector extends BusinessReportDeadlinesConnector(mockHttpGet, environment, conf)
+  object TestBusinessReportDeadlinesDataConnector extends BusinessReportDeadlinesConnector(mockHttpGet, frontendAppConfig)
 
   "BusinessReportDealinesDataConnector.getObligationData" should {
 

--- a/test/connectors/CalculationDataConnectorSpec.scala
+++ b/test/connectors/CalculationDataConnectorSpec.scala
@@ -33,7 +33,7 @@ class CalculationDataConnectorSpec extends TestSupport with MockHttp {
   val successResponseBadJson = HttpResponse(Status.OK, responseJson = Some(Json.parse("{\"incomeTaxYTD\":\"somethingBad\"}")))
   val badResponse = HttpResponse(Status.BAD_REQUEST, responseString = Some("Error Message"))
 
-  object TestCalculationDataConnector extends CalculationDataConnector(mockHttpGet, environment, conf)
+  object TestCalculationDataConnector extends CalculationDataConnector(mockHttpGet, frontendAppConfig)
 
   "CalculationDataConnectorSpec.getCalculationData" should {
 

--- a/test/connectors/LastTaxCalculationConnectorSpec.scala
+++ b/test/connectors/LastTaxCalculationConnectorSpec.scala
@@ -35,7 +35,7 @@ class LastTaxCalculationConnectorSpec extends TestSupport with MockHttp {
   val noDataFound = HttpResponse(Status.NOT_FOUND)
   val badResponse = HttpResponse(Status.BAD_REQUEST, responseString = Some("Error Message"))
 
-  object TestLastTaxCalculationConnector extends LastTaxCalculationConnector(mockHttpGet, environment, conf)
+  object TestLastTaxCalculationConnector extends LastTaxCalculationConnector(mockHttpGet, frontendAppConfig)
 
   "EstimatedTaxLiabilityConnector.redirectToEarliestEstimatedTaxLiability" should {
 

--- a/test/connectors/PropertyDetailsConnectorSpec.scala
+++ b/test/connectors/PropertyDetailsConnectorSpec.scala
@@ -34,7 +34,7 @@ class PropertyDetailsConnectorSpec extends TestSupport with MockHttp {
   val badResponse = HttpResponse(Status.BAD_REQUEST, responseString = Some("Error Message"))
   val notFound = HttpResponse(Status.NOT_FOUND)
 
-  object TestPropertyDetailsConnector extends PropertyDetailsConnector(mockHttpGet, environment, conf)
+  object TestPropertyDetailsConnector extends PropertyDetailsConnector(mockHttpGet, frontendAppConfig)
 
   "The PropertyDetailsConnector.getPropertyDetails method" should {
 

--- a/test/connectors/PropertyReportDeadlinesConnectorSpec.scala
+++ b/test/connectors/PropertyReportDeadlinesConnectorSpec.scala
@@ -34,7 +34,7 @@ class PropertyReportDeadlinesConnectorSpec extends TestSupport with MockHttp {
   val successResponseBadJson = HttpResponse(Status.OK, responseJson = Some(Json.parse("{}")))
   val badResponse = HttpResponse(Status.BAD_REQUEST, responseString = Some("Error Message"))
 
-  object TestPropertyObligationDataConnector extends PropertyReportDeadlineDataConnector(mockHttpGet, environment, conf)
+  object TestPropertyObligationDataConnector extends PropertyReportDeadlineDataConnector(mockHttpGet, frontendAppConfig)
 
   "PropertyObligationDataConnector.getPropertyData" should {
 

--- a/test/connectors/ServiceInfoPartialConnectorSpec.scala
+++ b/test/connectors/ServiceInfoPartialConnectorSpec.scala
@@ -34,7 +34,7 @@ class ServiceInfoPartialConnectorSpec extends TestSupport with MockHttp {
   val gatewayTimeoutResponse = Failure(Some(Status.GATEWAY_TIMEOUT))
   val badResponse = HttpResponse(Status.BAD_REQUEST, responseString = Some("Error Message"))
 
-  object TestServiceInfoPartialConnector extends ServiceInfoPartialConnector(mockHttpGet, mockItvcHeaderCarrierForPartialsConverter, environment, conf)
+  object TestServiceInfoPartialConnector extends ServiceInfoPartialConnector(mockHttpGet, mockItvcHeaderCarrierForPartialsConverter, frontendAppConfig)
 
   "The ServiceInfoPartialConnector.getServiceInfoPartial() method" when {
     lazy val testUrl: String = TestServiceInfoPartialConnector.btaUrl

--- a/test/connectors/UserDetailsConnectorSpec.scala
+++ b/test/connectors/UserDetailsConnectorSpec.scala
@@ -33,7 +33,7 @@ class UserDetailsConnectorSpec extends TestSupport with MockHttp {
   val badJsonResponse = HttpResponse(Status.OK, responseJson = Some(Json.toJson("{}")))
   val badResponse = HttpResponse(Status.INTERNAL_SERVER_ERROR, responseString = Some("Error Message"))
 
-  object TestUserDetailsConnector extends UserDetailsConnector(mockHttpGet, environment, conf)
+  object TestUserDetailsConnector extends UserDetailsConnector(mockHttpGet)
 
   "The UserDetailsConnector.getUserDetails() method" should {
 

--- a/test/utils/TestSupport.scala
+++ b/test/utils/TestSupport.scala
@@ -18,7 +18,7 @@ package utils
 
 import auth.MtdItUser
 import com.typesafe.config.Config
-import config.ItvcHeaderCarrierForPartialsConverter
+import config.{FrontendAppConfig, ItvcHeaderCarrierForPartialsConverter}
 import models.UserDetailsModel
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -51,6 +51,7 @@ trait TestSupport extends UnitSpec with GuiceOneServerPerSuite with MockitoSugar
 
   implicit val conf: Configuration = app.configuration
   implicit val environment: Environment = app.injector.instanceOf[Environment]
+  implicit val frontendAppConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
   implicit val config: Config = app.configuration.underlying
 
   implicit val user: MtdItUser = MtdItUser(


### PR DESCRIPTION
- Changed the connectors to have the frontend app config injected into them - removing the need to override `mode` and `runmode` configuration continually as this is already catered for in the FrontendAppConf 