### PR TITLE
[BTAT-1708] Added Property EOPS Connector, note: assumed URL

### DIFF
--- a/app/connectors/PropertyEOPSDeadlinesConnector.scala
+++ b/app/connectors/PropertyEOPSDeadlinesConnector.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import javax.inject.{Inject, Singleton}
+
+import config.FrontendAppConfig
+import models._
+import play.api.Logger
+import play.api.http.Status
+import play.api.http.Status.OK
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
+
+import scala.concurrent.Future
+
+@Singleton
+class PropertyEOPSDeadlinesConnector @Inject()(val http: HttpClient, val config: FrontendAppConfig) extends RawResponseReads {
+
+  def getPropertyEOPSDeadlineUrl(nino: String): String =
+    //TODO: This URL has been assumed; this may need to be updated when the SA API makes the endpoint available
+    s"${config.saApiService}/ni/$nino/uk-properties/end-of-period-statements/obligations"
+
+  def getPropertyEOPSDeadline(nino: String)(implicit headerCarrier: HeaderCarrier): Future[ReportDeadlinesResponseModel] = {
+
+    val url = getPropertyEOPSDeadlineUrl(nino)
+    Logger.debug(s"[PropertyEOPSDeadlinesConnector][getPropertyEOPSDeadline] - GET $url")
+
+    http.GET[HttpResponse](url)(httpReads, headerCarrier.withExtraHeaders("Accept" -> "application/vnd.hmrc.1.0+json"), implicitly) map {
+      response =>
+        response.status match {
+          case OK =>
+            Logger.debug(s"[PropertyEOPSDeadlinesConnector][getPropertyEOPSDeadline] - RESPONSE status: ${response.status}, json: ${response.json}")
+            response.json.validate[ReportDeadlinesModel].fold(
+              invalid => {
+                Logger.warn(s"[PropertyEOPSDeadlinesConnector][getPropertyEOPSDeadline] - Json Validation Error. Parsing Property Obligation Data Response")
+                ReportDeadlinesErrorModel(Status.INTERNAL_SERVER_ERROR, "Json Validation Error. Parsing Property Obligation Data Response")
+              },
+              valid => valid
+            )
+          case _ =>
+            Logger.debug(s"[PropertyEOPSDeadlinesConnector][getPropertyEOPSDeadline] - RESPONSE status: ${response.status}, body: ${response.body}")
+            Logger.warn(
+              s"[PropertyEOPSDeadlinesConnector][getPropertyEOPSDeadline] - Response status: [${response.status}] returned from Property ReportDeadlines call")
+            ReportDeadlinesErrorModel(response.status, response.body)
+        }
+    } recover {
+      case _ =>
+        Logger.warn(s"[PropertyEOPSDeadlinesConnector][getPropertyEOPSDeadline] - Unexpected future failed error")
+        ReportDeadlinesErrorModel(Status.INTERNAL_SERVER_ERROR, s"Unexpected future failed error")
+    }
+  }
+}

--- a/app/connectors/PropertyEOPSDeadlinesConnector.scala
+++ b/app/connectors/PropertyEOPSDeadlinesConnector.scala
@@ -48,15 +48,15 @@ class PropertyEOPSDeadlinesConnector @Inject()(val http: HttpClient, val config:
             Logger.debug(s"[PropertyEOPSDeadlinesConnector][getPropertyEOPSDeadline] - RESPONSE status: ${response.status}, json: ${response.json}")
             response.json.validate[ReportDeadlinesModel].fold(
               invalid => {
-                Logger.warn(s"[PropertyEOPSDeadlinesConnector][getPropertyEOPSDeadline] - Json Validation Error. Parsing Property Obligation Data Response")
-                ReportDeadlinesErrorModel(Status.INTERNAL_SERVER_ERROR, "Json Validation Error. Parsing Property Obligation Data Response")
+                Logger.warn(s"[PropertyEOPSDeadlinesConnector][getPropertyEOPSDeadline] - Json Validation Error. Parsing Property EOPS Deadlines Response")
+                ReportDeadlinesErrorModel(Status.INTERNAL_SERVER_ERROR, "Json Validation Error. Parsing Property EOPS Deadlines Response")
               },
               valid => valid
             )
           case _ =>
             Logger.debug(s"[PropertyEOPSDeadlinesConnector][getPropertyEOPSDeadline] - RESPONSE status: ${response.status}, body: ${response.body}")
             Logger.warn(
-              s"[PropertyEOPSDeadlinesConnector][getPropertyEOPSDeadline] - Response status: [${response.status}] returned from Property ReportDeadlines call")
+              s"[PropertyEOPSDeadlinesConnector][getPropertyEOPSDeadline] - Response status: [${response.status}] returned from Property EOPS Deadlines call")
             ReportDeadlinesErrorModel(response.status, response.body)
         }
     } recover {

--- a/test/connectors/PropertyEOPSDeadlinesConnectorSpec.scala
+++ b/test/connectors/PropertyEOPSDeadlinesConnectorSpec.scala
@@ -58,7 +58,7 @@ class PropertyEOPSDeadlinesConnectorSpec extends TestSupport with MockHttp {
 
     "return ReportDeadlinesErrorModel when bad JSON is received" in {
       setupMockHttpGet(testUrl)(successResponseBadJson)
-      await(result) shouldBe ReportDeadlinesErrorModel(Status.INTERNAL_SERVER_ERROR, "Json Validation Error. Parsing Property Obligation Data Response")
+      await(result) shouldBe ReportDeadlinesErrorModel(Status.INTERNAL_SERVER_ERROR, "Json Validation Error. Parsing Property EOPS Deadlines Response")
     }
 
     "return ReportDeadlinesErrorModel model in case of future failed scenario" in {

--- a/test/connectors/PropertyEOPSDeadlinesConnectorSpec.scala
+++ b/test/connectors/PropertyEOPSDeadlinesConnectorSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import assets.TestConstants.ReportDeadlines._
+import assets.TestConstants._
+import mocks.MockHttp
+import models.{ReportDeadlinesErrorModel, ReportDeadlinesResponseModel}
+import play.api.libs.json.Json
+import play.mvc.Http.Status
+import uk.gov.hmrc.http.HttpResponse
+import utils.TestSupport
+
+import scala.concurrent.Future
+
+
+class PropertyEOPSDeadlinesConnectorSpec extends TestSupport with MockHttp {
+
+  val successResponse = HttpResponse(Status.OK, Some(Json.toJson(obligationsDataSuccessModel)))
+  val successResponseBadJson = HttpResponse(Status.OK, responseJson = Some(Json.parse("{}")))
+  val badResponse = HttpResponse(Status.BAD_REQUEST, responseString = Some("Error Message"))
+
+  object TestPropertyEOPSDeadlinesConnector extends PropertyEOPSDeadlinesConnector(mockHttpGet, frontendAppConfig)
+
+  "PropertyEOPSDeadlinesConnector.getPropertyEOPSDeadlineUrl" should {
+
+    lazy val testUrl = TestPropertyEOPSDeadlinesConnector.getPropertyEOPSDeadlineUrl(testNino)
+    def result: Future[ReportDeadlinesResponseModel] = TestPropertyEOPSDeadlinesConnector.getPropertyEOPSDeadline(testNino)
+
+    "have the correct url to Property" in {
+      //TODO: This URL has been assumed; this may need to be updated when the SA API makes the endpoint available
+      testUrl shouldBe s"${frontendAppConfig.saApiService}/ni/$testNino/uk-properties/end-of-period-statements/obligations"
+    }
+
+    "return a SuccessResponse with JSON in case of success" in {
+      setupMockHttpGet(testUrl)(successResponse)
+      await(result) shouldBe obligationsDataSuccessModel
+    }
+
+    "return ErrorResponse model in case of failure" in {
+      setupMockHttpGet(testUrl)(badResponse)
+      await(result) shouldBe ReportDeadlinesErrorModel(Status.BAD_REQUEST, "Error Message")
+    }
+
+    "return ReportDeadlinesErrorModel when bad JSON is received" in {
+      setupMockHttpGet(testUrl)(successResponseBadJson)
+      await(result) shouldBe ReportDeadlinesErrorModel(Status.INTERNAL_SERVER_ERROR, "Json Validation Error. Parsing Property Obligation Data Response")
+    }
+
+    "return ReportDeadlinesErrorModel model in case of future failed scenario" in {
+      setupMockFailedHttpGet(testUrl)(badResponse)
+      await(result) shouldBe ReportDeadlinesErrorModel(Status.INTERNAL_SERVER_ERROR, s"Unexpected future failed error")
+    }
+  }
+}


### PR DESCRIPTION
There is currently no endpoint defined for Property EOPS on the SA API service. Therefore the URL has been assumed based on similar endpoints. I have included a TODO comment to ensure that we revisit this once the endpoint is available.

The call to retrieve EOPS for property will be featureswitched until the enpoint is available in production.