### PR TITLE
[BTAT-1966] Added Auditing to the calls to API#5 (Get Business Details)

### DIFF
--- a/app/audit/AuditingService.scala
+++ b/app/audit/AuditingService.scala
@@ -18,47 +18,66 @@ package audit
 
 import javax.inject.{Inject, Singleton}
 
-import audit.models.AuditModel
+import audit.models.{AuditModel, ExtendedAuditModel}
 import config.{FrontendAppConfig, FrontendAuditConnector}
 import play.api.Logger
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{JsObject, JsValue, Json, Writes}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.AuditExtensions
-import uk.gov.hmrc.play.audit.http.connector.AuditResult.{Failure, Success}
-import uk.gov.hmrc.play.audit.model.DataEvent
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
+import uk.gov.hmrc.play.audit.http.connector.AuditResult.{Disabled, Failure, Success}
+import uk.gov.hmrc.play.audit.model.{DataEvent, ExtendedDataEvent}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class AuditingService @Inject()(appConfig: FrontendAppConfig, auditConnector: FrontendAuditConnector) {
 
   implicit val dataEventWrites: Writes[DataEvent] = Json.writes[DataEvent]
+  implicit val extendedDataEventWrites: Writes[ExtendedDataEvent] = Json.writes[ExtendedDataEvent]
 
-  def audit(auditModel: AuditModel, path: String = "N/A")(implicit hc: HeaderCarrier, ec: ExecutionContext): Unit = {
+  def audit(auditModel: AuditModel, path: String = "-")(implicit hc: HeaderCarrier, ec: ExecutionContext): Unit = {
     val dataEvent = toDataEvent(appConfig.appName, auditModel, path)
     Logger.debug(s"Splunk Audit Event:\n\n${Json.toJson(dataEvent)}")
-    auditConnector.sendEvent(dataEvent).map {
-      //$COVERAGE-OFF$ Disabling scoverage as returns Unit, only used for Debug messages
-      case Success =>
-        Logger.debug("Splunk Audit Successful")
-      case Failure(err,_) =>
-        Logger.debug(s"Splunk Audit Error, message: $err")
-      case _ =>
-        Logger.debug(s"Unknown Splunk Error")
-      //$COVERAGE-ON$
-    }
+    handleAuditResult(auditConnector.sendEvent(dataEvent))
   }
 
-  def toDataEvent(appName: String, auditModel: AuditModel, path: String)(implicit hc: HeaderCarrier): DataEvent = {
-    val auditType: String = auditModel.auditType
-    val transactionName: String = auditModel.transactionName
-    val detail: Seq[(String, String)] = auditModel.detail
-
+  def toDataEvent(appName: String, auditModel: AuditModel, path: String)(implicit hc: HeaderCarrier): DataEvent =
     DataEvent(
       auditSource = appName,
-      auditType = auditType,
-      tags = AuditExtensions.auditHeaderCarrier(hc).toAuditTags(transactionName, path),
-      detail = AuditExtensions.auditHeaderCarrier(hc).toAuditDetails(detail: _*)
+      auditType = auditModel.auditType,
+      tags = AuditExtensions.auditHeaderCarrier(hc).toAuditTags(auditModel.transactionName, path),
+      detail = AuditExtensions.auditHeaderCarrier(hc).toAuditDetails(auditModel.detail: _*)
     )
+
+
+  def extendedAudit(auditModel: ExtendedAuditModel, path: String = "-")(implicit hc: HeaderCarrier, ec: ExecutionContext): Unit = {
+    val extendedDataEvent = toExtendedDataEvent(appConfig.appName, auditModel, path)
+    Logger.debug(s"Splunk Audit Event:\n\n${Json.toJson(extendedDataEvent)}")
+    handleAuditResult(auditConnector.sendExtendedEvent(extendedDataEvent))
+  }
+
+  def toExtendedDataEvent(appName: String, auditModel: ExtendedAuditModel, path: String)(implicit hc: HeaderCarrier): ExtendedDataEvent = {
+
+    val details: JsValue =
+      Json.toJson(AuditExtensions.auditHeaderCarrier(hc).toAuditDetails()).as[JsObject].deepMerge(auditModel.detail.as[JsObject])
+
+    ExtendedDataEvent(
+      auditSource = appName,
+      auditType = auditModel.auditType,
+      tags = AuditExtensions.auditHeaderCarrier(hc).toAuditTags(auditModel.transactionName, path),
+      detail = details
+    )
+  }
+
+  private def handleAuditResult(auditResult: Future[AuditResult])(implicit ec: ExecutionContext): Unit = auditResult.map {
+    //$COVERAGE-OFF$ Disabling scoverage as returns Unit, only used for Debug messages
+    case Success =>
+      Logger.debug("Splunk Audit Successful")
+    case Failure(err, _) =>
+      Logger.debug(s"Splunk Audit Error, message: $err")
+    case Disabled =>
+      Logger.debug(s"Auditing Disabled")
+    //$COVERAGE-ON$
   }
 }

--- a/app/audit/models/AuditModel.scala
+++ b/app/audit/models/AuditModel.scala
@@ -18,6 +18,6 @@ package audit.models
 
 trait AuditModel {
   val transactionName: String
-  val detail: Map[String, String]
+  val detail: Seq[(String, String)]
   val auditType: String
 }

--- a/app/audit/models/EstimatesAuditing.scala
+++ b/app/audit/models/EstimatesAuditing.scala
@@ -27,7 +27,7 @@ object EstimatesAuditing {
     override val transactionName: String = estimatesTransactionName
     //TODO: Auditing needs to be revisited for multiple businesses scenario - speak to Kris McLackland
     val business = user.incomeSources.businessIncomeSources.headOption
-    override val detail: Map[String, String] = Map(
+    override val detail: Seq[(String, String)] = Seq(
       "mtdid" -> user.mtditid,
       "nino" -> user.nino,
       "hasBusiness" -> user.incomeSources.hasBusinessIncome.toString,

--- a/app/audit/models/ExitSurveyAuditing.scala
+++ b/app/audit/models/ExitSurveyAuditing.scala
@@ -25,7 +25,7 @@ object ExitSurveyAuditing {
 
   case class ExitSurveyAuditModel(exitSurveyModel: ExitSurveyModel) extends AuditModel {
     override val transactionName: String = exitSurveyTransactionName
-    override val detail: Map[String, String] = Map(
+    override val detail: Seq[(String, String)] = Seq(
       "satisfaction" -> exitSurveyModel.satisfaction.fold("-")(x => x),
       "improvements" -> exitSurveyModel.improvements.fold("-")(x => x)
     )

--- a/app/audit/models/ExtendedAuditModel.scala
+++ b/app/audit/models/ExtendedAuditModel.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit.models
+
+import play.api.libs.json.JsValue
+
+trait ExtendedAuditModel {
+  val transactionName: String
+  val detail: JsValue
+  val auditType: String
+}

--- a/app/audit/models/IncomeSourceDetailsRequestAuditModel.scala
+++ b/app/audit/models/IncomeSourceDetailsRequestAuditModel.scala
@@ -16,14 +16,12 @@
 
 package audit.models
 
-import auth.MtdItUser
-
-case class IncomeSourceDetailsRequestAuditModel[A](user: MtdItUser[A]) extends AuditModel {
+case class IncomeSourceDetailsRequestAuditModel(mtditid: String, nino: String) extends AuditModel {
 
   override val transactionName: String = "income-source-details-request"
   override val auditType: String = "incomeSourceDetailsRequest"
   override val detail: Seq[(String, String)] = Seq(
-    "mtditid" -> user.mtditid,
-    "nino" -> user.nino
+    "mtditid" -> mtditid,
+    "nino" -> nino
   )
 }

--- a/app/audit/models/IncomeSourceDetailsRequestAuditModel.scala
+++ b/app/audit/models/IncomeSourceDetailsRequestAuditModel.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit.models
+
+import auth.MtdItUser
+
+case class IncomeSourceDetailsRequestAuditModel[A](user: MtdItUser[A], path: String) extends AuditModel {
+
+  override val transactionName: String = "income-source-details-request"
+  override val auditType: String = "incomeSourceDetailsRequest"
+  override val detail: Map[String, String] = Map(
+    "mtdid" -> user.mtditid,
+    "nino" -> user.nino
+  )
+}

--- a/app/audit/models/IncomeSourceDetailsRequestAuditModel.scala
+++ b/app/audit/models/IncomeSourceDetailsRequestAuditModel.scala
@@ -18,12 +18,12 @@ package audit.models
 
 import auth.MtdItUser
 
-case class IncomeSourceDetailsRequestAuditModel[A](user: MtdItUser[A], path: String) extends AuditModel {
+case class IncomeSourceDetailsRequestAuditModel[A](user: MtdItUser[A]) extends AuditModel {
 
   override val transactionName: String = "income-source-details-request"
   override val auditType: String = "incomeSourceDetailsRequest"
   override val detail: Seq[(String, String)] = Seq(
-    "mtdid" -> user.mtditid,
+    "mtditid" -> user.mtditid,
     "nino" -> user.nino
   )
 }

--- a/app/audit/models/IncomeSourceDetailsRequestAuditModel.scala
+++ b/app/audit/models/IncomeSourceDetailsRequestAuditModel.scala
@@ -22,7 +22,7 @@ case class IncomeSourceDetailsRequestAuditModel[A](user: MtdItUser[A], path: Str
 
   override val transactionName: String = "income-source-details-request"
   override val auditType: String = "incomeSourceDetailsRequest"
-  override val detail: Map[String, String] = Map(
+  override val detail: Seq[(String, String)] = Seq(
     "mtdid" -> user.mtditid,
     "nino" -> user.nino
   )

--- a/app/audit/models/IncomeSourceDetailsResponseAuditModel.scala
+++ b/app/audit/models/IncomeSourceDetailsResponseAuditModel.scala
@@ -29,7 +29,7 @@ case class IncomeSourceDetailsResponseAuditModel[A](selfEmploymentIds: List[Stri
     if (selfEmploymentIds.isEmpty) None else Some("selfEmploymentIncomeSourceIds" -> Json.toJson(selfEmploymentIds).toString)
 
   override val detail: Seq[(String, String)] = Seq(
-    Some("mtdid" -> user.mtditid),
+    Some("mtditid" -> user.mtditid),
     Some("nino" -> user.nino),
     seIds,
     propertyIncomeId.map("propertyIncomeSourceId" -> _)

--- a/app/audit/models/IncomeSourceDetailsResponseAuditModel.scala
+++ b/app/audit/models/IncomeSourceDetailsResponseAuditModel.scala
@@ -20,8 +20,7 @@ import auth.MtdItUser
 import play.api.libs.json.Json
 
 case class IncomeSourceDetailsResponseAuditModel[A](selfEmploymentIds: List[String],
-                                                    propertyIncomeId: Option[String],
-                                                    path: String)(implicit user: MtdItUser[A]) extends AuditModel {
+                                                    propertyIncomeId: Option[String])(implicit user: MtdItUser[A]) extends AuditModel {
 
   override val transactionName: String = "income-source-details-response"
   override val auditType: String = "incomeSourceDetailsResponse"

--- a/app/audit/models/IncomeSourceDetailsResponseAuditModel.scala
+++ b/app/audit/models/IncomeSourceDetailsResponseAuditModel.scala
@@ -16,16 +16,18 @@
 
 package audit.models
 
-import auth.MtdItUser
 import play.api.libs.json.{JsValue, Json, Writes}
 
-case class IncomeSourceDetailsResponseAuditModel[A](selfEmploymentIds: List[String],
-                                                    propertyIncomeId: Option[String])(implicit user: MtdItUser[A]) extends ExtendedAuditModel {
+case class IncomeSourceDetailsResponseAuditModel(mtditid: String,
+                                                 nino: String,
+                                                 selfEmploymentIds: List[String],
+                                                 propertyIncomeId: Option[String]) extends ExtendedAuditModel {
 
   override val transactionName: String = "income-source-details-response"
   override val auditType: String = "incomeSourceDetailsResponse"
 
-  private case class AuditDetail(mtditid: String, nino: String,
+  private case class AuditDetail(mtditid: String,
+                                 nino: String,
                                  selfEmploymentIncomeSourceIds: Option[List[String]],
                                  propertyIncomeSourceId: Option[String])
   private implicit val auditDetailWrites: Writes[AuditDetail] = Json.writes[AuditDetail]
@@ -34,8 +36,8 @@ case class IncomeSourceDetailsResponseAuditModel[A](selfEmploymentIds: List[Stri
 
   override val detail: JsValue = Json.toJson(
     AuditDetail(
-      user.mtditid,
-      user.nino,
+      mtditid,
+      nino,
       seIds,
       propertyIncomeId
     )

--- a/app/audit/models/IncomeSourceDetailsResponseAuditModel.scala
+++ b/app/audit/models/IncomeSourceDetailsResponseAuditModel.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit.models
+
+import auth.MtdItUser
+import play.api.libs.json.Json
+
+case class IncomeSourceDetailsResponseAuditModel[A](selfEmploymentIds: List[String],
+                                                    propertyIncomeId: Option[String],
+                                                    path: String)(implicit user: MtdItUser[A]) extends AuditModel {
+
+  override val transactionName: String = "income-source-details-response"
+  override val auditType: String = "incomeSourceDetailsResponse"
+
+  val seIds: Option[(String, String)] =
+    if (selfEmploymentIds.isEmpty) None else Some("selfEmploymentIncomeSourceIds" -> Json.toJson(selfEmploymentIds).toString)
+
+  override val detail: Seq[(String, String)] = Seq(
+    Some("mtdid" -> user.mtditid),
+    Some("nino" -> user.nino),
+    seIds,
+    propertyIncomeId.map("propertyIncomeSourceId" -> _)
+  ).flatten
+}

--- a/app/audit/models/NinoLookupAuditing.scala
+++ b/app/audit/models/NinoLookupAuditing.scala
@@ -25,7 +25,7 @@ object NinoLookupAuditing {
 
   case class NinoLookupAuditModel(nino: Nino, mtdRef: String) extends AuditModel {
     override val transactionName: String = ninoLookupTransactionName
-    override val detail: Map[String, String] = Map(
+    override val detail: Seq[(String, String)] = Seq(
       "mtdid" -> mtdRef,
       "nino" -> nino.nino
     )
@@ -34,7 +34,7 @@ object NinoLookupAuditing {
 
   case class NinoLookupErrorAuditModel( ninoError: NinoResponseError, mtdRef: String) extends AuditModel{
     override val transactionName: String = "ITVCNinoLookupError"
-    override val detail: Map[String, String] = Map(
+    override val detail: Seq[(String, String)] = Seq(
       "mtdid" -> mtdRef,
       "status" -> ninoError.status.toString,
       "reason" -> ninoError.reason

--- a/app/audit/models/ReportDeadlinesAuditing.scala
+++ b/app/audit/models/ReportDeadlinesAuditing.scala
@@ -27,7 +27,7 @@ object ReportDeadlinesAuditing {
     override val transactionName: String = reportDeadlineTransactionName
     //TODO: Auditing needs to be revisited for multiple businesses scenario - speak to Kris McLackland
     val business = user.incomeSources.businessIncomeSources.headOption
-    override val detail: Map[String, String] = Map(
+    override val detail: Seq[(String, String)] = Seq(
       "mtdid" -> user.mtditid,
       "nino" -> user.nino,
       "hasBusiness" -> user.incomeSources.hasBusinessIncome.toString,

--- a/app/controllers/BaseController.scala
+++ b/app/controllers/BaseController.scala
@@ -16,13 +16,23 @@
 
 package controllers
 
+import play.api.http.HeaderNames
 import play.api.i18n.I18nSupport
-import play.api.mvc.Result
+import play.api.mvc.{RequestHeader, Result}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.HeaderCarrierConverter
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
 import scala.concurrent.Future
 
 trait BaseController extends FrontendController with I18nSupport {
+  override implicit def hc(implicit rh: RequestHeader): HeaderCarrier = {
+    val hc = HeaderCarrierConverter.fromHeadersAndSession(rh.headers, Some(rh.session))
+    rh.headers.headers.find(_._1 == HeaderNames.REFERER) match {
+      case Some(referrer) => hc.withExtraHeaders(referrer)
+      case _ => hc
+    }
+  }
   def redirectToHome: Result = Redirect(controllers.routes.HomeController.home())
   def fRedirectToHome: Future[Result] = Future.successful(redirectToHome)
 }

--- a/app/controllers/BaseController.scala
+++ b/app/controllers/BaseController.scala
@@ -27,10 +27,9 @@ import scala.concurrent.Future
 
 trait BaseController extends FrontendController with I18nSupport {
   override implicit def hc(implicit rh: RequestHeader): HeaderCarrier = {
-    val hc = HeaderCarrierConverter.fromHeadersAndSession(rh.headers, Some(rh.session))
     rh.headers.headers.find(_._1 == HeaderNames.REFERER) match {
-      case Some(referrer) => hc.withExtraHeaders(referrer)
-      case _ => hc
+      case Some(referrer) => super.hc.withExtraHeaders(referrer)
+      case _ => super.hc
     }
   }
   def redirectToHome: Result = Redirect(controllers.routes.HomeController.home())

--- a/app/controllers/BusinessDetailsController.scala
+++ b/app/controllers/BusinessDetailsController.scala
@@ -46,7 +46,7 @@ class BusinessDetailsController @Inject()(implicit val config: FrontendAppConfig
     }
 
   private def renderView[A](id: Int)(implicit user: MtdItUser[A]): Future[Result] = {
-    incomeSourceDetailsService.getBusinessDetails(user.mtditid, id).map {
+    incomeSourceDetailsService.getBusinessDetails(user.mtditid, user.nino, id).map {
       case Right(Some((bizDeets, _))) => Ok(views.html.businessDetailsView(bizDeets))
       case Right(None) =>
         Logger.debug(s"[BusinessDetailsController][getBusinessDetails] No Business Details found with ID: $id")

--- a/app/controllers/predicates/IncomeSourceDetailsPredicate.scala
+++ b/app/controllers/predicates/IncomeSourceDetailsPredicate.scala
@@ -18,6 +18,8 @@ package controllers.predicates
 
 import javax.inject.{Inject, Singleton}
 
+import audit.AuditingService
+import audit.models.{IncomeSourceDetailsRequestAuditModel, IncomeSourceDetailsResponseAuditModel}
 import auth.{MtdItUser, MtdItUserWithNino}
 import config.ItvcErrorHandler
 import controllers.BaseController

--- a/test/assets/TestConstants.scala
+++ b/test/assets/TestConstants.scala
@@ -56,6 +56,7 @@ object TestConstants extends ImplicitDateFormatter {
     Enrolment("HMRC-MTD-IT", Seq(EnrolmentIdentifier("MTDITID", testMtditid)), "activated"),
     Enrolment("HMRC-NI", Seq(EnrolmentIdentifier("NINO", testNino)), "activated")
   )),Option(testUserDetailsUrl))
+  val testReferrerUrl: String = "/test/url"
 
   object ServiceInfoPartial {
     val serviceInfoPartialSuccess =

--- a/test/audit/mocks/MockAuditingService.scala
+++ b/test/audit/mocks/MockAuditingService.scala
@@ -17,7 +17,7 @@
 package audit.mocks
 
 import audit.AuditingService
-import audit.models.AuditModel
+import audit.models.{AuditModel, ExtendedAuditModel}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
@@ -35,8 +35,17 @@ trait MockAuditingService extends TestSupport with BeforeAndAfterEach {
 
   val mockAuditingService: AuditingService = mock[AuditingService]
 
-  def verifyAudit(model: AuditModel, path: String): Unit =
+  def verifyAudit(model: AuditModel, path: String = "-"): Unit =
     verify(mockAuditingService).audit(
+      ArgumentMatchers.eq(model),
+      ArgumentMatchers.eq(path)
+    )(
+      ArgumentMatchers.any[HeaderCarrier],
+      ArgumentMatchers.any[ExecutionContext]
+    )
+
+  def verifyExtendedAudit(model: ExtendedAuditModel, path: String = "-"): Unit =
+    verify(mockAuditingService).extendedAudit(
       ArgumentMatchers.eq(model),
       ArgumentMatchers.eq(path)
     )(

--- a/test/audit/models/IncomeSourceDetailsRequestAuditModelSpec.scala
+++ b/test/audit/models/IncomeSourceDetailsRequestAuditModelSpec.scala
@@ -16,7 +16,7 @@
 
 package audit.models
 
-import assets.TestConstants.testMtdItUser
+import assets.TestConstants.{testMtditid, testNino}
 import utils.TestSupport
 
 class IncomeSourceDetailsRequestAuditModelSpec extends TestSupport {
@@ -26,7 +26,7 @@ class IncomeSourceDetailsRequestAuditModelSpec extends TestSupport {
 
   "The IncomeSourceDetailsRequestAuditModel" should {
 
-    lazy val testIncomeSourceDetailsRequestAuditModel = IncomeSourceDetailsRequestAuditModel(testMtdItUser)
+    lazy val testIncomeSourceDetailsRequestAuditModel = IncomeSourceDetailsRequestAuditModel(testMtditid, testNino)
 
     s"Have the correct transaction name of '$transactionName'" in {
       testIncomeSourceDetailsRequestAuditModel.transactionName shouldBe transactionName
@@ -38,8 +38,8 @@ class IncomeSourceDetailsRequestAuditModelSpec extends TestSupport {
 
     "Have the correct details for the audit event" in {
       testIncomeSourceDetailsRequestAuditModel.detail shouldBe Seq(
-        "mtditid" -> testMtdItUser.mtditid,
-        "nino" -> testMtdItUser.nino
+        "mtditid" -> testMtditid,
+        "nino" -> testNino
       )
     }
   }

--- a/test/audit/models/IncomeSourceDetailsRequestAuditModelSpec.scala
+++ b/test/audit/models/IncomeSourceDetailsRequestAuditModelSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit.models
+
+import assets.TestConstants.testMtdItUser
+import utils.TestSupport
+
+class IncomeSourceDetailsRequestAuditModelSpec extends TestSupport {
+
+  val transactionName = "income-source-details-request"
+  val auditEvent = "incomeSourceDetailsRequest"
+
+  "The IncomeSourceDetailsRequestAuditModel" should {
+
+    lazy val testIncomeSourceDetailsRequestAuditModel = IncomeSourceDetailsRequestAuditModel(testMtdItUser)
+
+    s"Have the correct transaction name of '$transactionName'" in {
+      testIncomeSourceDetailsRequestAuditModel.transactionName shouldBe transactionName
+    }
+
+    s"Have the correct audit event type of '$auditEvent'" in {
+      testIncomeSourceDetailsRequestAuditModel.auditType shouldBe auditEvent
+    }
+
+    "Have the correct details for the audit event" in {
+      testIncomeSourceDetailsRequestAuditModel.detail shouldBe Seq(
+        "mtditid" -> testMtdItUser.mtditid,
+        "nino" -> testMtdItUser.nino
+      )
+    }
+  }
+}

--- a/test/audit/models/IncomeSourceDetailsResponseAuditModelSpec.scala
+++ b/test/audit/models/IncomeSourceDetailsResponseAuditModelSpec.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit.models
+
+import assets.TestConstants._
+import utils.TestSupport
+
+class IncomeSourceDetailsResponseAuditModelSpec extends TestSupport {
+
+  val transactionName = "income-source-details-response"
+  val auditEvent = "incomeSourceDetailsResponse"
+  val seIdsKey = "selfEmploymentIncomeSourceIds"
+  val propertyIdKey = "propertyIncomeSourceId"
+
+  "The IncomeSourceDetailsResponseAuditModel" when {
+
+    "Supplied with Multiple Business IDs and a Property ID" should {
+
+      val testIncomeSourceDetailsResponseAuditModel = IncomeSourceDetailsResponseAuditModel(
+        List(testSelfEmploymentId, testSelfEmploymentId2),
+        Some(testPropertyIncomeId)
+      )(testMtdItUser)
+
+      s"Have the correct transaction name of '$transactionName'" in {
+        testIncomeSourceDetailsResponseAuditModel.transactionName shouldBe transactionName
+      }
+
+      s"Have the correct audit event type of '$auditEvent'" in {
+        testIncomeSourceDetailsResponseAuditModel.auditType shouldBe auditEvent
+      }
+
+      "Have the correct details for the audit event" in {
+        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Seq(
+          "mtditid" -> testMtdItUser.mtditid,
+          "nino" -> testMtdItUser.nino,
+          seIdsKey -> s"""["$testSelfEmploymentId","$testSelfEmploymentId2"]""",
+          propertyIdKey -> testPropertyIncomeId
+        )
+      }
+    }
+
+    "Supplied with Single Business IDs and a Property ID" should {
+
+      val testIncomeSourceDetailsResponseAuditModel = IncomeSourceDetailsResponseAuditModel(
+        List(testSelfEmploymentId),
+        Some(testPropertyIncomeId)
+      )(testMtdItUser)
+
+      s"Have the correct transaction name of '$transactionName'" in {
+        testIncomeSourceDetailsResponseAuditModel.transactionName shouldBe transactionName
+      }
+
+      s"Have the correct audit event type of '$auditEvent'" in {
+        testIncomeSourceDetailsResponseAuditModel.auditType shouldBe auditEvent
+      }
+
+      "Have the correct details for the audit event" in {
+        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Seq(
+          "mtditid" -> testMtdItUser.mtditid,
+          "nino" -> testMtdItUser.nino,
+          seIdsKey -> s"""["$testSelfEmploymentId"]""",
+          propertyIdKey -> testPropertyIncomeId
+        )
+      }
+    }
+
+    "Supplied with No Business IDs and a Property ID" should {
+
+      val testIncomeSourceDetailsResponseAuditModel = IncomeSourceDetailsResponseAuditModel(
+        List(),
+        Some(testPropertyIncomeId)
+      )(testMtdItUser)
+
+      s"Have the correct transaction name of '$transactionName'" in {
+        testIncomeSourceDetailsResponseAuditModel.transactionName shouldBe transactionName
+      }
+
+      s"Have the correct audit event type of '$auditEvent'" in {
+        testIncomeSourceDetailsResponseAuditModel.auditType shouldBe auditEvent
+      }
+
+      "Have the correct details for the audit event" in {
+        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Seq(
+          "mtditid" -> testMtdItUser.mtditid,
+          "nino" -> testMtdItUser.nino,
+          propertyIdKey -> testPropertyIncomeId
+        )
+      }
+    }
+
+    "Supplied with Single Business IDs and No Property ID" should {
+
+      val testIncomeSourceDetailsResponseAuditModel = IncomeSourceDetailsResponseAuditModel(
+        List(testSelfEmploymentId),
+        None
+      )(testMtdItUser)
+
+      s"Have the correct transaction name of '$transactionName'" in {
+        testIncomeSourceDetailsResponseAuditModel.transactionName shouldBe transactionName
+      }
+
+      s"Have the correct audit event type of '$auditEvent'" in {
+        testIncomeSourceDetailsResponseAuditModel.auditType shouldBe auditEvent
+      }
+
+      "Have the correct details for the audit event" in {
+        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Seq(
+          "mtditid" -> testMtdItUser.mtditid,
+          "nino" -> testMtdItUser.nino,
+          seIdsKey -> s"""["$testSelfEmploymentId"]"""
+        )
+      }
+    }
+
+    "Supplied with Multiple Business IDs and No Property ID" should {
+
+      val testIncomeSourceDetailsResponseAuditModel = IncomeSourceDetailsResponseAuditModel(
+        List(testSelfEmploymentId, testSelfEmploymentId2),
+        None
+      )(testMtdItUser)
+
+      s"Have the correct transaction name of '$transactionName'" in {
+        testIncomeSourceDetailsResponseAuditModel.transactionName shouldBe transactionName
+      }
+
+      s"Have the correct audit event type of '$auditEvent'" in {
+        testIncomeSourceDetailsResponseAuditModel.auditType shouldBe auditEvent
+      }
+
+      "Have the correct details for the audit event" in {
+        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Seq(
+          "mtditid" -> testMtdItUser.mtditid,
+          "nino" -> testMtdItUser.nino,
+          seIdsKey -> s"""["$testSelfEmploymentId","$testSelfEmploymentId2"]"""
+        )
+      }
+    }
+
+    "Supplied with No Business IDs and No Property ID" should {
+
+      val testIncomeSourceDetailsResponseAuditModel = IncomeSourceDetailsResponseAuditModel(
+        List(),
+        None
+      )(testMtdItUser)
+
+      s"Have the correct transaction name of '$transactionName'" in {
+        testIncomeSourceDetailsResponseAuditModel.transactionName shouldBe transactionName
+      }
+
+      s"Have the correct audit event type of '$auditEvent'" in {
+        testIncomeSourceDetailsResponseAuditModel.auditType shouldBe auditEvent
+      }
+
+      "Have the correct details for the audit event" in {
+        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Seq(
+          "mtditid" -> testMtdItUser.mtditid,
+          "nino" -> testMtdItUser.nino
+        )
+      }
+    }
+  }
+}

--- a/test/audit/models/IncomeSourceDetailsResponseAuditModelSpec.scala
+++ b/test/audit/models/IncomeSourceDetailsResponseAuditModelSpec.scala
@@ -17,6 +17,7 @@
 package audit.models
 
 import assets.TestConstants._
+import play.api.libs.json.Json
 import utils.TestSupport
 
 class IncomeSourceDetailsResponseAuditModelSpec extends TestSupport {
@@ -44,10 +45,10 @@ class IncomeSourceDetailsResponseAuditModelSpec extends TestSupport {
       }
 
       "Have the correct details for the audit event" in {
-        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Seq(
+        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Json.obj(
           "mtditid" -> testMtdItUser.mtditid,
           "nino" -> testMtdItUser.nino,
-          seIdsKey -> s"""["$testSelfEmploymentId","$testSelfEmploymentId2"]""",
+          seIdsKey -> Json.toJson(List(testSelfEmploymentId, testSelfEmploymentId2)),
           propertyIdKey -> testPropertyIncomeId
         )
       }
@@ -69,10 +70,10 @@ class IncomeSourceDetailsResponseAuditModelSpec extends TestSupport {
       }
 
       "Have the correct details for the audit event" in {
-        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Seq(
+        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Json.obj(
           "mtditid" -> testMtdItUser.mtditid,
           "nino" -> testMtdItUser.nino,
-          seIdsKey -> s"""["$testSelfEmploymentId"]""",
+          seIdsKey -> Json.toJson(List(testSelfEmploymentId)),
           propertyIdKey -> testPropertyIncomeId
         )
       }
@@ -94,7 +95,7 @@ class IncomeSourceDetailsResponseAuditModelSpec extends TestSupport {
       }
 
       "Have the correct details for the audit event" in {
-        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Seq(
+        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Json.obj(
           "mtditid" -> testMtdItUser.mtditid,
           "nino" -> testMtdItUser.nino,
           propertyIdKey -> testPropertyIncomeId
@@ -118,10 +119,10 @@ class IncomeSourceDetailsResponseAuditModelSpec extends TestSupport {
       }
 
       "Have the correct details for the audit event" in {
-        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Seq(
+        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Json.obj(
           "mtditid" -> testMtdItUser.mtditid,
           "nino" -> testMtdItUser.nino,
-          seIdsKey -> s"""["$testSelfEmploymentId"]"""
+          seIdsKey -> Json.toJson(List(testSelfEmploymentId))
         )
       }
     }
@@ -142,10 +143,10 @@ class IncomeSourceDetailsResponseAuditModelSpec extends TestSupport {
       }
 
       "Have the correct details for the audit event" in {
-        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Seq(
+        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Json.obj(
           "mtditid" -> testMtdItUser.mtditid,
           "nino" -> testMtdItUser.nino,
-          seIdsKey -> s"""["$testSelfEmploymentId","$testSelfEmploymentId2"]"""
+          seIdsKey -> Json.toJson(List(testSelfEmploymentId, testSelfEmploymentId2))
         )
       }
     }
@@ -166,7 +167,7 @@ class IncomeSourceDetailsResponseAuditModelSpec extends TestSupport {
       }
 
       "Have the correct details for the audit event" in {
-        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Seq(
+        testIncomeSourceDetailsResponseAuditModel.detail shouldBe Json.obj(
           "mtditid" -> testMtdItUser.mtditid,
           "nino" -> testMtdItUser.nino
         )

--- a/test/audit/models/IncomeSourceDetailsResponseAuditModelSpec.scala
+++ b/test/audit/models/IncomeSourceDetailsResponseAuditModelSpec.scala
@@ -32,9 +32,11 @@ class IncomeSourceDetailsResponseAuditModelSpec extends TestSupport {
     "Supplied with Multiple Business IDs and a Property ID" should {
 
       val testIncomeSourceDetailsResponseAuditModel = IncomeSourceDetailsResponseAuditModel(
+        testMtditid,
+        testNino,
         List(testSelfEmploymentId, testSelfEmploymentId2),
         Some(testPropertyIncomeId)
-      )(testMtdItUser)
+      )
 
       s"Have the correct transaction name of '$transactionName'" in {
         testIncomeSourceDetailsResponseAuditModel.transactionName shouldBe transactionName
@@ -57,9 +59,11 @@ class IncomeSourceDetailsResponseAuditModelSpec extends TestSupport {
     "Supplied with Single Business IDs and a Property ID" should {
 
       val testIncomeSourceDetailsResponseAuditModel = IncomeSourceDetailsResponseAuditModel(
+        testMtditid,
+        testNino,
         List(testSelfEmploymentId),
         Some(testPropertyIncomeId)
-      )(testMtdItUser)
+      )
 
       s"Have the correct transaction name of '$transactionName'" in {
         testIncomeSourceDetailsResponseAuditModel.transactionName shouldBe transactionName
@@ -82,9 +86,11 @@ class IncomeSourceDetailsResponseAuditModelSpec extends TestSupport {
     "Supplied with No Business IDs and a Property ID" should {
 
       val testIncomeSourceDetailsResponseAuditModel = IncomeSourceDetailsResponseAuditModel(
+        testMtditid,
+        testNino,
         List(),
         Some(testPropertyIncomeId)
-      )(testMtdItUser)
+      )
 
       s"Have the correct transaction name of '$transactionName'" in {
         testIncomeSourceDetailsResponseAuditModel.transactionName shouldBe transactionName
@@ -106,9 +112,11 @@ class IncomeSourceDetailsResponseAuditModelSpec extends TestSupport {
     "Supplied with Single Business IDs and No Property ID" should {
 
       val testIncomeSourceDetailsResponseAuditModel = IncomeSourceDetailsResponseAuditModel(
+        testMtditid,
+        testNino,
         List(testSelfEmploymentId),
         None
-      )(testMtdItUser)
+      )
 
       s"Have the correct transaction name of '$transactionName'" in {
         testIncomeSourceDetailsResponseAuditModel.transactionName shouldBe transactionName
@@ -130,9 +138,11 @@ class IncomeSourceDetailsResponseAuditModelSpec extends TestSupport {
     "Supplied with Multiple Business IDs and No Property ID" should {
 
       val testIncomeSourceDetailsResponseAuditModel = IncomeSourceDetailsResponseAuditModel(
+        testMtditid,
+        testNino,
         List(testSelfEmploymentId, testSelfEmploymentId2),
         None
-      )(testMtdItUser)
+      )
 
       s"Have the correct transaction name of '$transactionName'" in {
         testIncomeSourceDetailsResponseAuditModel.transactionName shouldBe transactionName
@@ -154,9 +164,11 @@ class IncomeSourceDetailsResponseAuditModelSpec extends TestSupport {
     "Supplied with No Business IDs and No Property ID" should {
 
       val testIncomeSourceDetailsResponseAuditModel = IncomeSourceDetailsResponseAuditModel(
+        testMtditid,
+        testNino,
         List(),
         None
-      )(testMtdItUser)
+      )
 
       s"Have the correct transaction name of '$transactionName'" in {
         testIncomeSourceDetailsResponseAuditModel.transactionName shouldBe transactionName

--- a/test/connectors/IncomeSourceDetailsConnectorSpec.scala
+++ b/test/connectors/IncomeSourceDetailsConnectorSpec.scala
@@ -17,7 +17,9 @@
 package connectors
 
 import assets.TestConstants.NewIncomeSourceDetails._
-import assets.TestConstants.testMtditid
+import assets.TestConstants.{testMtditid, testNino, testSelfEmploymentId, testReferrerUrl}
+import audit.mocks.MockAuditingService
+import audit.models.{IncomeSourceDetailsRequestAuditModel, IncomeSourceDetailsResponseAuditModel}
 import mocks.MockHttp
 import models.incomeSourceDetails.{IncomeSourceDetailsError, IncomeSourceDetailsResponse}
 import play.api.libs.json.Json
@@ -27,37 +29,42 @@ import utils.TestSupport
 
 import scala.concurrent.Future
 
-class IncomeSourceDetailsConnectorSpec extends TestSupport with MockHttp {
+class IncomeSourceDetailsConnectorSpec extends TestSupport with MockHttp with MockAuditingService {
 
   val successResponse = HttpResponse(Status.OK, Some(Json.toJson(incomeSourceDetails)))
   val successResponseBadJson = HttpResponse(Status.OK, Some(Json.parse("{}")))
   val badResponse = HttpResponse(Status.BAD_REQUEST, responseString = Some("Error Message"))
 
-  object TestIncomeSourceDetailsConnector extends IncomeSourceDetailsConnector(mockHttpGet, frontendAppConfig)
+  object TestIncomeSourceDetailsConnector extends IncomeSourceDetailsConnector(mockHttpGet, frontendAppConfig, mockAuditingService)
 
   "IncomeSourceDetailsConnector.getIncomeSources" should {
 
     lazy val testUrl = TestIncomeSourceDetailsConnector.getIncomeSourcesUrl(testMtditid)
-    def result: Future[IncomeSourceDetailsResponse] = TestIncomeSourceDetailsConnector.getIncomeSources(testMtditid)
+    def result: Future[IncomeSourceDetailsResponse] = TestIncomeSourceDetailsConnector.getIncomeSources(testMtditid, testNino)
 
     "return an IncomeSourceDetailsModel when successful JSON is received" in {
       setupMockHttpGet(testUrl)(successResponse)
       await(result) shouldBe incomeSourceDetails
+      verifyAudit(IncomeSourceDetailsRequestAuditModel(testMtditid, testNino), testReferrerUrl)
+      verifyExtendedAudit(IncomeSourceDetailsResponseAuditModel(testMtditid, testNino, List(testSelfEmploymentId), None), testReferrerUrl)
     }
 
     "return IncomeSourceDetailsError in case of bad/malformed JSON response" in {
       setupMockHttpGet(testUrl)(successResponseBadJson)
       await(result) shouldBe IncomeSourceDetailsError(Status.INTERNAL_SERVER_ERROR, "Json Validation Error Parsing Income Source Details response")
+      verifyAudit(IncomeSourceDetailsRequestAuditModel(testMtditid, testNino), testReferrerUrl)
     }
 
     "return IncomeSourceDetailsError model in case of failure" in {
       setupMockHttpGet(testUrl)(badResponse)
       await(result) shouldBe IncomeSourceDetailsError(Status.BAD_REQUEST, "Error Message")
+      verifyAudit(IncomeSourceDetailsRequestAuditModel(testMtditid, testNino), testReferrerUrl)
     }
 
     "return IncomeSourceDetailsError model in case of future failed scenario" in {
       setupMockFailedHttpGet(testUrl)(badResponse)
       await(result) shouldBe IncomeSourceDetailsError(Status.INTERNAL_SERVER_ERROR, "Unexpected future failed error")
+      verifyAudit(IncomeSourceDetailsRequestAuditModel(testMtditid, testNino), testReferrerUrl)
     }
   }
 

--- a/test/controllers/BaseControllerSpec.scala
+++ b/test/controllers/BaseControllerSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import javax.inject.Inject
+
+import mocks.controllers.predicates.MockAuthenticationPredicate
+import play.api.http.HeaderNames
+import play.api.i18n.MessagesApi
+
+class BaseControllerSpec extends MockAuthenticationPredicate {
+
+  class TestBaseController @Inject()(implicit val messagesApi: MessagesApi) extends BaseController
+
+  object TestBaseController extends TestBaseController()(fakeApplication.injector.instanceOf[MessagesApi])
+
+  "The BaseController.hc() method" when {
+
+    "A referrer is provided on the request header" should {
+
+      "include the Referrer as part of the HeaderCarrier" in {
+        val hc = TestBaseController.hc(fakeRequestWithActiveSession)
+        hc.headers.find(_._1 == HeaderNames.REFERER).map(_._2) shouldBe Some("/test/url")
+      }
+    }
+
+    "No referrer is provided on the request header" should {
+
+      "NOT include the Referrer as part of the HeaderCarrier" in {
+        val hc = TestBaseController.hc(fakeRequestNoSession)
+        hc.headers.find(_._1 == HeaderNames.REFERER).map(_._2) shouldBe None
+      }
+    }
+  }
+
+}

--- a/test/controllers/BusinessDetailsControllerSpec.scala
+++ b/test/controllers/BusinessDetailsControllerSpec.scala
@@ -53,7 +53,7 @@ class BusinessDetailsControllerSpec extends TestSupport with MockIncomeSourceDet
         "return Status OK (200)" in {
           TestBusinessDetailsController.config.features.accountDetailsEnabled(true)
           mockSingleBusinessIncomeSource()
-          setupMockGetBusinessDetails(testMtditid, 0)(Right(Some(NewBizDeets.business1 -> 0)))
+          setupMockGetBusinessDetails(testMtditid, testNino, 0)(Right(Some(NewBizDeets.business1 -> 0)))
           status(result) shouldBe Status.OK
         }
 
@@ -75,7 +75,7 @@ class BusinessDetailsControllerSpec extends TestSupport with MockIncomeSourceDet
         "return Status (500)" in {
           TestBusinessDetailsController.config.features.accountDetailsEnabled(true)
           mockSingleBusinessIncomeSource()
-          setupMockGetBusinessDetails(testMtditid, 0)(Right(None))
+          setupMockGetBusinessDetails(testMtditid, testNino, 0)(Right(None))
           status(result) shouldBe Status.INTERNAL_SERVER_ERROR
         }
 
@@ -87,7 +87,7 @@ class BusinessDetailsControllerSpec extends TestSupport with MockIncomeSourceDet
 
         "return Status (500)" in {
           mockSingleBusinessIncomeSource()
-          setupMockGetBusinessDetails(testMtditid, 0)(Left(ErrorModel(INTERNAL_SERVER_ERROR, "error")))
+          setupMockGetBusinessDetails(testMtditid, testNino, 0)(Left(ErrorModel(INTERNAL_SERVER_ERROR, "error")))
           status(result) shouldBe Status.INTERNAL_SERVER_ERROR
         }
 

--- a/test/mocks/connectors/MockIncomeSourceDetailsConnector.scala
+++ b/test/mocks/connectors/MockIncomeSourceDetailsConnector.scala
@@ -36,8 +36,11 @@ trait MockIncomeSourceDetailsConnector extends UnitSpec with MockitoSugar with B
     reset(mockIncomeSourceDetailsConnector)
   }
 
-  def setupMockIncomeSourceDetailsResponse(mtditid: String)(response: IncomeSourceDetailsResponse): Unit ={
-    when(mockIncomeSourceDetailsConnector.getIncomeSources(ArgumentMatchers.eq(mtditid))(ArgumentMatchers.any()))
+  def setupMockIncomeSourceDetailsResponse(mtditid: String, nino: String)(response: IncomeSourceDetailsResponse): Unit ={
+    when(mockIncomeSourceDetailsConnector.getIncomeSources(
+      ArgumentMatchers.eq(mtditid),
+      ArgumentMatchers.eq(nino)
+    )(ArgumentMatchers.any()))
       .thenReturn(Future.successful(response))
   }
 

--- a/test/mocks/services/MockIncomeSourceDetailsService.scala
+++ b/test/mocks/services/MockIncomeSourceDetailsService.scala
@@ -45,8 +45,12 @@ trait MockIncomeSourceDetailsService extends BeforeAndAfterEach with MockitoSuga
       .thenReturn(Future.successful(sources))
   }
 
-  def setupMockGetBusinessDetails(mtditid: String, id: Int)(sources: Either[ErrorModel, Option[(BusinessDetailsModel, Int)]]): Unit = {
-    when(mockIncomeSourceDetailsService.getBusinessDetails(ArgumentMatchers.eq(mtditid), ArgumentMatchers.eq(id))(ArgumentMatchers.any()))
+  def setupMockGetBusinessDetails(mtditid: String, nino: String, id: Int)(sources: Either[ErrorModel, Option[(BusinessDetailsModel, Int)]]): Unit = {
+    when(mockIncomeSourceDetailsService.getBusinessDetails(
+      ArgumentMatchers.eq(mtditid),
+      ArgumentMatchers.eq(nino),
+      ArgumentMatchers.eq(id)
+    )(ArgumentMatchers.any()))
       .thenReturn(Future.successful(sources))
   }
 

--- a/test/services/IncomeSourceDetailsServiceSpec.scala
+++ b/test/services/IncomeSourceDetailsServiceSpec.scala
@@ -19,17 +19,19 @@ package services
 import assets.TestConstants.IncomeSources._
 import assets.TestConstants.ReportDeadlines.obligationsDataSuccessModel
 import assets.TestConstants._
+import audit.mocks.MockAuditingService
 import mocks.connectors.MockIncomeSourceDetailsConnector
 import mocks.services.MockReportDeadlinesService
 import models.incomeSourcesWithDeadlines.IncomeSourcesError
 import utils.TestSupport
 
 
-class IncomeSourceDetailsServiceSpec extends TestSupport with MockIncomeSourceDetailsConnector with MockReportDeadlinesService {
+class IncomeSourceDetailsServiceSpec extends TestSupport with MockIncomeSourceDetailsConnector with MockReportDeadlinesService with MockAuditingService {
 
   object TestIncomeSourceDetailsService extends IncomeSourceDetailsService(
     mockIncomeSourceDetailsConnector,
-    mockReportDeadlinesService
+    mockReportDeadlinesService,
+    mockAuditingService
   )
 
   "The IncomeSourceDetailsService.getIncomeSourceDetails method" when {
@@ -37,7 +39,7 @@ class IncomeSourceDetailsServiceSpec extends TestSupport with MockIncomeSourceDe
     "a result with both business and property details is returned" should {
 
       "return an IncomeSourceDetailsModel with business and property options" in {
-        setupMockIncomeSourceDetailsResponse(testMtditid)(NewIncomeSourceDetails.businessesAndPropertyIncome)
+        setupMockIncomeSourceDetailsResponse(testMtditid, testNino)(NewIncomeSourceDetails.businessesAndPropertyIncome)
         setupMockBusinessReportDeadlinesResult(testNino, testSelfEmploymentId)(obligationsDataSuccessModel)
         setupMockBusinessReportDeadlinesResult(testNino, testSelfEmploymentId2)(obligationsDataSuccessModel)
         setupMockPropertyReportDeadlinesResult(testNino)(obligationsDataSuccessModel)
@@ -48,7 +50,7 @@ class IncomeSourceDetailsServiceSpec extends TestSupport with MockIncomeSourceDe
 
     "a result with just business details is returned" should {
       "return an IncomeSourceDetailsModel with just a business option" in {
-        setupMockIncomeSourceDetailsResponse(testMtditid)(NewIncomeSourceDetails.singleBusinessIncome)
+        setupMockIncomeSourceDetailsResponse(testMtditid, testNino)(NewIncomeSourceDetails.singleBusinessIncome)
         setupMockBusinessReportDeadlinesResult(testNino, testSelfEmploymentId)(obligationsDataSuccessModel)
 
         await(TestIncomeSourceDetailsService.getIncomeSourceDetails(testMtditid, testNino)) shouldBe businessIncomeSourceSuccess
@@ -57,7 +59,7 @@ class IncomeSourceDetailsServiceSpec extends TestSupport with MockIncomeSourceDe
 
     "a result with just property details is returned" should {
       "return an IncomeSourceDetailsModel with just a property option" in {
-        setupMockIncomeSourceDetailsResponse(testMtditid)(NewIncomeSourceDetails.propertyIncomeOnly)
+        setupMockIncomeSourceDetailsResponse(testMtditid, testNino)(NewIncomeSourceDetails.propertyIncomeOnly)
         setupMockPropertyReportDeadlinesResult(testNino)(obligationsDataSuccessModel)
 
         await(TestIncomeSourceDetailsService.getIncomeSourceDetails(testMtditid, testNino)) shouldBe propertyIncomeSourceSuccess
@@ -66,7 +68,7 @@ class IncomeSourceDetailsServiceSpec extends TestSupport with MockIncomeSourceDe
 
     "a result with no income source details is returned" should {
       "return an IncomeSourceDetailsModel with no options" in {
-        setupMockIncomeSourceDetailsResponse(testMtditid)(NewIncomeSourceDetails.noIncomeDetails)
+        setupMockIncomeSourceDetailsResponse(testMtditid, testNino)(NewIncomeSourceDetails.noIncomeDetails)
 
         await(TestIncomeSourceDetailsService.getIncomeSourceDetails(testMtditid, testNino)) shouldBe noIncomeSourceSuccess
       }
@@ -74,7 +76,7 @@ class IncomeSourceDetailsServiceSpec extends TestSupport with MockIncomeSourceDe
 
     "a result where the Income Source Details are error" should {
       "return an IncomeSourceError" in {
-        setupMockIncomeSourceDetailsResponse(testMtditid)(NewIncomeSourceDetails.errorResponse)
+        setupMockIncomeSourceDetailsResponse(testMtditid, testNino)(NewIncomeSourceDetails.errorResponse)
 
         await(TestIncomeSourceDetailsService.getIncomeSourceDetails(testMtditid, testNino)) shouldBe IncomeSourcesError
       }
@@ -84,17 +86,17 @@ class IncomeSourceDetailsServiceSpec extends TestSupport with MockIncomeSourceDe
   "The IncomeSourceDetailsService .getBusinessDetails method" when {
     "a self-employment-ID is passed through" should {
       "return the corresponding BusinessModel" in {
-        setupMockIncomeSourceDetailsResponse(testMtditid)(NewIncomeSourceDetails.singleBusinessIncome)
+        setupMockIncomeSourceDetailsResponse(testMtditid, testNino)(NewIncomeSourceDetails.singleBusinessIncome)
 
-        await(TestIncomeSourceDetailsService.getBusinessDetails(testMtditid, 0)) shouldBe Right(Some((NewBizDeets.business1, 0)))
+        await(TestIncomeSourceDetailsService.getBusinessDetails(testMtditid, testNino, 0)) shouldBe Right(Some((NewBizDeets.business1, 0)))
       }
     }
 
     "an error is returned from the Income Source Details connector" should {
       "return a ErrorModel" in {
-        setupMockIncomeSourceDetailsResponse(testMtditid)(NewIncomeSourceDetails.errorResponse)
+        setupMockIncomeSourceDetailsResponse(testMtditid, testNino)(NewIncomeSourceDetails.errorResponse)
 
-        await(TestIncomeSourceDetailsService.getBusinessDetails(testMtditid, 0)) shouldBe Left(NewBizDeets.businessErrorModel)
+        await(TestIncomeSourceDetailsService.getBusinessDetails(testMtditid, testNino, 0)) shouldBe Left(NewBizDeets.businessErrorModel)
       }
     }
   }

--- a/test/utils/TestSupport.scala
+++ b/test/utils/TestSupport.scala
@@ -27,6 +27,7 @@ import org.jsoup.nodes.Document
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, Suite}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.http.HeaderNames
 import play.api.i18n.MessagesApi
 import play.api.mvc.Result
 import play.api.test.FakeRequest
@@ -47,7 +48,7 @@ trait TestSupport extends UnitSpec with GuiceOneServerPerSuite with MockitoSugar
 
   implicit val mockItvcHeaderCarrierForPartialsConverter: ItvcHeaderCarrierForPartialsConverter = mock[ItvcHeaderCarrierForPartialsConverter]
 
-  implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
+  implicit val headerCarrier: HeaderCarrier = HeaderCarrier().withExtraHeaders(HeaderNames.REFERER -> TestConstants.testReferrerUrl)
   implicit val hcwc: HeaderCarrierForPartials = HeaderCarrierForPartials(headerCarrier, "")
 
   implicit val conf: Configuration = app.configuration

--- a/test/utils/TestSupport.scala
+++ b/test/utils/TestSupport.scala
@@ -80,7 +80,10 @@ trait TestSupport extends UnitSpec with GuiceOneServerPerSuite with MockitoSugar
   lazy val fakeRequestWithActiveSession = FakeRequest().withSession(
     SessionKeys.lastRequestTimestamp -> "1498236506662",
     SessionKeys.authToken -> "Bearer Token"
+  ).withHeaders(
+    HeaderNames.REFERER -> "/test/url"
   )
+
   lazy val fakeRequestWithTimeoutSession = FakeRequest().withSession(
     SessionKeys.lastRequestTimestamp -> "1498236506662"
   )


### PR DESCRIPTION
Based on Draft TxM Assessment here:
https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=101666902

- Includes minor refactor of existing auditing events
- Path is extracted from the Referrer on the Request Header
- Uses ExtendedAuditModel based (despite deprecation warning) based on conversation with the TxM team