### PR TITLE
[BTAT-2253] Create generic ReportDeadlinesConnector

### DIFF
--- a/app/connectors/ReportDeadlinesConnector.scala
+++ b/app/connectors/ReportDeadlinesConnector.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import javax.inject.{Inject, Singleton}
+
+import config.FrontendAppConfig
+import models.reportDeadlines.{ReportDeadlinesErrorModel, ReportDeadlinesModel, ReportDeadlinesResponseModel}
+import play.api.Logger
+import play.api.http.Status
+import play.api.http.Status.OK
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
+
+import scala.concurrent.Future
+
+@Singleton
+class ReportDeadlinesConnector @Inject()(val http: HttpClient,
+                                         val config: FrontendAppConfig) extends RawResponseReads {
+
+  private[connectors] lazy val getReportDeadlinesUrl: String => String = incomeSourceID =>
+    s"${config.itvcProtectedService}/income-tax-view-change/income-source/$incomeSourceID/report-deadlines"
+
+  def getReportDeadlines(incomeSourceID: String)(implicit headerCarrier: HeaderCarrier): Future[ReportDeadlinesResponseModel] = {
+
+    val url = getReportDeadlinesUrl(incomeSourceID)
+    Logger.debug(s"[ReportDeadlinesConnector][getReportDeadlines] - GET $url")
+
+    http.GET[HttpResponse](url)(httpReads, headerCarrier.withExtraHeaders("Accept" -> "application/vnd.hmrc.1.0+json"), implicitly) map {
+      response =>
+        response.status match {
+          case OK =>
+            Logger.debug(s"[ReportDeadlinesConnector][getReportDeadlines] - RESPONSE status: ${response.status}, json: ${response.json}")
+            response.json.validate[ReportDeadlinesModel].fold(
+              invalid => {
+                Logger.warn("[ReportDeadlinesConnector][getReportDeadlines] - Json Validation Error. Parsing Report Deadlines Data Response")
+                Logger.debug(s"[ReportDeadlinesConnector][getReportDeadlines] - Json Validation Error: $invalid")
+                ReportDeadlinesErrorModel(Status.INTERNAL_SERVER_ERROR, "Json Validation Error. Parsing Report Deadlines Data Response")
+              },
+              valid => valid
+            )
+          case _ =>
+            Logger.debug(s"[ReportDeadlinesConnector][getReportDeadlines] - RESPONSE status: ${response.status}, body: ${response.body}")
+            Logger.warn(s"[ReportDeadlinesConnector][getReportDeadlines] - Status: [${response.status}] Returned from business report deadlines call")
+            ReportDeadlinesErrorModel(response.status, response.body)
+        }
+    } recover {
+      case _ =>
+        Logger.warn("[ReportDeadlinesConnector][getReportDeadlines] - Unexpected future failed error")
+        ReportDeadlinesErrorModel(Status.INTERNAL_SERVER_ERROR, "Unexpected future failed error")
+    }
+  }
+}

--- a/test/connectors/ReportDeadlinesConnectorSpec.scala
+++ b/test/connectors/ReportDeadlinesConnectorSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import assets.BaseTestConstants._
+import assets.ReportDeadlinesTestConstants._
+import mocks.MockHttp
+import models.reportDeadlines.{ReportDeadlinesErrorModel, ReportDeadlinesResponseModel}
+import play.api.libs.json.Json
+import play.mvc.Http.Status
+import uk.gov.hmrc.http.HttpResponse
+import utils.TestSupport
+
+import scala.concurrent.Future
+
+
+class ReportDeadlinesConnectorSpec extends TestSupport with MockHttp {
+
+  val successResponse = HttpResponse(Status.OK, Some(Json.toJson(obligationsDataSuccessModel)))
+  val successResponseBadJson = HttpResponse(Status.OK, responseJson = Some(Json.parse("{}")))
+  val badResponse = HttpResponse(Status.BAD_REQUEST, responseString = Some("Error Message"))
+
+  object TestReportDeadlinesDataConnector extends ReportDeadlinesConnector(mockHttpGet, frontendAppConfig)
+
+  "ReportDeadlinesDataConnector.getReportDeadlines()" should {
+
+    lazy val testUrl = TestReportDeadlinesDataConnector.getReportDeadlinesUrl(testSelfEmploymentId)
+    def result: Future[ReportDeadlinesResponseModel] = TestReportDeadlinesDataConnector.getReportDeadlines(testSelfEmploymentId)
+
+    "have the correct URL to ITVC backend" in {
+      testUrl shouldBe s"${frontendAppConfig.itvcProtectedService}/income-tax-view-change/income-source/$testSelfEmploymentId/report-deadlines"
+    }
+
+    "return a SuccessResponse with JSON in case of success" in {
+      setupMockHttpGet(testUrl)(successResponse)
+      await(result) shouldBe obligationsDataSuccessModel
+    }
+
+    "return ErrorResponse model in case of failure" in {
+      setupMockHttpGet(testUrl)(badResponse)
+      await(result) shouldBe ReportDeadlinesErrorModel(Status.BAD_REQUEST, "Error Message")
+    }
+
+    "return BusinessListError model when bad JSON is received" in {
+      setupMockHttpGet(testUrl)(successResponseBadJson)
+      await(result) shouldBe ReportDeadlinesErrorModel(Status.INTERNAL_SERVER_ERROR, "Json Validation Error. Parsing Report Deadlines Data Response")
+    }
+
+    "return ReportDeadlinesErrorModel model in case of future failed scenario" in {
+      setupMockFailedHttpGet(testUrl)(badResponse)
+      await(result) shouldBe ReportDeadlinesErrorModel(Status.INTERNAL_SERVER_ERROR, s"Unexpected future failed error")
+    }
+  }
+}


### PR DESCRIPTION
This connector calls the new endpoint on our protected service to retrieve Report Deadlines (Obligations) from DES API#1330 direct.