### PR TITLE
[BTAT-2411] Introduce and use common verification methods.

### DIFF
--- a/app/config/features/Feature.scala
+++ b/app/config/features/Feature.scala
@@ -21,6 +21,6 @@ import play.api.Configuration
 import scala.sys.SystemProperties
 
 class Feature(val key: String, config: Configuration) {
-  def apply(value: Boolean): SystemProperties = sys.props += key -> value.toString
+  def apply(value: Boolean): Unit = sys.props.update(key, value.toString)
   def apply(): Boolean = sys.props.get(key).fold(config.getBoolean(key).getOrElse(false))(_.toBoolean)
 }

--- a/it/controllers/BillsControllerISpec.scala
+++ b/it/controllers/BillsControllerISpec.scala
@@ -30,42 +30,13 @@ class BillsControllerISpec extends ComponentSpecBase with GenericStubMethods {
 
   lazy val appConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
 
-  "Calling the CalculationController.viewCrystallisedCalculations" when {
-
-    "the Bills Feature is disabled" should {
-
-      "redirect to home page" in {
-
-        appConfig.features.billsEnabled(false)
-
-        And("I wiremock stub a successful Income Source Details response with 1 Business and Property income")
-        IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
-
-        And("I wiremock stub multiple open and received obligations response")
-        IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
-        IncomeTaxViewChangeStub.stubGetReportDeadlines(testPropertyIncomeId, multipleReportDeadlinesDataSuccessModel)
-
-        And("I wiremock stub a successful Get CalculationData response")
-        SelfAssessmentStub.stubGetCalcData(testNino, testCalcId, calculationDataSuccessWithEoyJson.toString())
-
-        When(s"I call GET /report-quarterly/income-and-expenses/view/bills")
-        val res = IncomeTaxViewChangeFrontend.getBills
-
-        Then("The view should have the correct headings and a single tax bill link")
-        res should have(
-          httpStatus(SEE_OTHER),
-          redirectURI(controllers.routes.HomeController.home().url)
-        )
-      }
-    }
+  "Calling the BillsController" when {
 
     "the Bill Feature is enabled" when {
 
       "isAuthorisedUser with an active enrolment, and a single, valid crystallised estimate" should {
 
         "return the correct page with bills links" in {
-
-          appConfig.features.billsEnabled(true)
 
           And("I wiremock stub a successful Income Source Details response with 1 Business and Property income")
           IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
@@ -83,18 +54,12 @@ class BillsControllerISpec extends ComponentSpecBase with GenericStubMethods {
             )
           IncomeTaxViewChangeStub.stubGetLastTaxCalc(testNino, testYear, lastTaxCalcResponse)
 
-          And("I wiremock stub a successful Get CalculationData response")
-          val calcBreakdownResponse = calculationDataSuccessWithEoYModel
-          SelfAssessmentStub.stubGetCalcData(testNino, testCalcId, calculationDataSuccessWithEoyJson.toString())
-
           When(s"I call GET /report-quarterly/income-and-expenses/view/bills")
           val res = IncomeTaxViewChangeFrontend.getBills
 
-          Then("I verify the Income Source Details has been successfully wiremocked")
-          IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
-          Then("I verify the Estimated Tax Liability response has been wiremocked")
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
+          verifyIncomeSourceDetailsCall(testMtditid)
+          verifyReportDeadlinesCall(testSelfEmploymentId, testPropertyIncomeId)
+          verifyLastTaxCalculationCall(testNino, testYear)
 
           Then("The view should have the correct headings and a single tax bill link")
           res should have(
@@ -112,12 +77,8 @@ class BillsControllerISpec extends ComponentSpecBase with GenericStubMethods {
 
         "return the correct page with tax links" in {
 
-          appConfig.features.billsEnabled(true)
-
           And("I wiremock stub a successful Income Source Details response with Multiple Business and Property income")
-          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-            OK, multipleBusinessesAndPropertyResponse
-          )
+          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, multipleBusinessesAndPropertyResponse)
 
           And("I wiremock stub multiple open and received obligations response")
           IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -140,21 +101,13 @@ class BillsControllerISpec extends ComponentSpecBase with GenericStubMethods {
           IncomeTaxViewChangeStub.stubGetLastTaxCalc(testNino, testYear, lastTaxCalcResponse)
           IncomeTaxViewChangeStub.stubGetLastTaxCalc(testNino, testYearPlusOne, lastTaxCalcResponse2)
 
-          And("I wiremock stub a successful Get CalculationData response")
-          val calcBreakdownResponse = calculationDataSuccessWithEoYModel
-          SelfAssessmentStub.stubGetCalcData(testNino, testCalcId, calculationDataSuccessWithEoyJson.toString())
-          SelfAssessmentStub.stubGetCalcData(testNino, testCalcId2, calculationDataSuccessWithEoyJson.toString())
-
-
           When(s"I call GET /report-quarterly/income-and-expenses/view/bills")
           val res = IncomeTaxViewChangeFrontend.getBills
 
-          Then("I verify the Income Source Details has been successfully wiremocked")
-          IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
-          Then("I verify the Estimated Tax Liability response has been wiremocked")
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYearPlusOne)
+          verifyIncomeSourceDetailsCall(testMtditid)
+          verifyReportDeadlinesCall(testSelfEmploymentId, otherTestSelfEmploymentId, testPropertyIncomeId)
+          verifyLastTaxCalculationCall(testNino, testYear)
+          verifyLastTaxCalculationCall(testNino, testYearPlusOne)
 
           Then("The view should have the correct headings and two tax bill links")
           res should have(
@@ -172,12 +125,8 @@ class BillsControllerISpec extends ComponentSpecBase with GenericStubMethods {
       "isAuthorisedUser with an active enrolment, with a crystallised calculation and a tax estimate" should {
         "return the correct page with just the tax bill link" in {
 
-          appConfig.features.billsEnabled(true)
-
           And("I wiremock stub a successful Income Source Details response with Multiple Business and Property income")
-          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-            OK, multipleBusinessesAndPropertyResponse
-          )
+          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, multipleBusinessesAndPropertyResponse)
 
           And("I wiremock stub multiple open and received obligations response")
           IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -202,21 +151,13 @@ class BillsControllerISpec extends ComponentSpecBase with GenericStubMethods {
           IncomeTaxViewChangeStub.stubGetLastTaxCalc(testNino, testYear, lastTaxCalcResponse)
           IncomeTaxViewChangeStub.stubGetLastTaxCalc(testNino, testYearPlusOne, crystallisedLastTaxCalcResponse)
 
-          And("I wiremock stub a successful Get CalculationData response")
-          val calcBreakdownResponse = calculationDataSuccessWithEoYModel
-          SelfAssessmentStub.stubGetCalcData(testNino, testCalcId, calculationDataSuccessWithEoyJson.toString())
-          SelfAssessmentStub.stubGetCalcData(testNino, testCalcId2, calculationDataSuccessWithEoyJson.toString())
-
-
           When(s"I call GET /report-quarterly/income-and-expenses/view/bills")
           val res = IncomeTaxViewChangeFrontend.getBills
 
-          Then("I verify the Income Source Details has been successfully wiremocked")
-          IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
-          Then("I verify the Estimated Tax Liability response has been wiremocked")
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYearPlusOne)
+          verifyIncomeSourceDetailsCall(testMtditid)
+          verifyReportDeadlinesCall(testSelfEmploymentId, otherTestSelfEmploymentId, testPropertyIncomeId)
+          verifyLastTaxCalculationCall(testNino, testYear)
+          verifyLastTaxCalculationCall(testNino, testYearPlusOne)
 
           Then("The view should have the correct headings and a single tax bill link")
           res should have(
@@ -233,12 +174,8 @@ class BillsControllerISpec extends ComponentSpecBase with GenericStubMethods {
       "isAuthorisedUser with an active enrolment, and no tax bills" should {
         "return the correct page with no bills found message" in {
 
-          appConfig.features.billsEnabled(true)
-
           And("I wiremock stub a successful Income Source Details response with single Business and Property income")
-          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-            OK, businessAndPropertyResponse
-          )
+          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
 
           And("I wiremock stub multiple open and received obligations response")
           IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -254,19 +191,12 @@ class BillsControllerISpec extends ComponentSpecBase with GenericStubMethods {
             )
           IncomeTaxViewChangeStub.stubGetLastTaxCalc(testNino, testYear, lastTaxCalcResponse)
 
-          And("I wiremock stub a successful Get CalculationData response")
-          val calcBreakdownResponse = calculationDataSuccessWithEoYModel
-          SelfAssessmentStub.stubGetCalcData(testNino, testCalcId, calculationDataSuccessWithEoyJson.toString())
-
-
           When(s"I call GET /report-quarterly/income-and-expenses/view/bills")
           val res = IncomeTaxViewChangeFrontend.getBills
 
-          Then("I verify the Income Source Details has been successfully wiremocked")
-          IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
-          Then("I verify the Estimated Tax Liability response has been wiremocked")
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
+          verifyIncomeSourceDetailsCall(testMtditid)
+          verifyReportDeadlinesCall(testSelfEmploymentId, testPropertyIncomeId)
+          verifyLastTaxCalculationCall(testNino, testYear)
 
           Then("The view should have the correct headings and a single tax estimate link")
           res should have(
@@ -276,6 +206,25 @@ class BillsControllerISpec extends ComponentSpecBase with GenericStubMethods {
             nElementsWithClass("bills-link")(0)
           )
         }
+      }
+
+      unauthorisedTest("/bills")
+    }
+
+    "the Bills Feature is disabled" should {
+
+      "redirect to home page" in {
+
+        appConfig.features.billsEnabled(false)
+
+        When(s"I call GET /report-quarterly/income-and-expenses/view/bills")
+        val res = IncomeTaxViewChangeFrontend.getBills
+
+        Then("I should be redirected to the Home Page")
+        res should have(
+          httpStatus(SEE_OTHER),
+          redirectURI(controllers.routes.HomeController.home().url)
+        )
       }
 
       unauthorisedTest("/bills")

--- a/it/controllers/BusinessDetailsControllerISpec.scala
+++ b/it/controllers/BusinessDetailsControllerISpec.scala
@@ -40,9 +40,7 @@ class BusinessDetailsControllerISpec extends ComponentSpecBase with GenericStubM
         When("I call GET /report-quarterly/income-and-expenses/view/business-details")
         val res = IncomeTaxViewChangeFrontend.getBusinessDetails(0)
 
-        Then("I verify the Income Source Details has been successfully wiremocked")
-        IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
+        verifyIncomeSourceDetailsCall(testMtditid)
         verifyReportDeadlinesCall(testSelfEmploymentId)
 
         Then("the view displays the correct title, username and links")
@@ -79,9 +77,7 @@ class BusinessDetailsControllerISpec extends ComponentSpecBase with GenericStubM
         When("I call GET /report-quarterly/income-and-expenses/view/business-details")
         val res = IncomeTaxViewChangeFrontend.getBusinessDetails(0)
 
-        Then("I verify the Income Source Details has been successfully wiremocked")
-        IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
+        verifyIncomeSourceDetailsCall(testMtditid)
         verifyReportDeadlinesCall(testSelfEmploymentId)
 
         Then("an ISE is displayed")
@@ -101,8 +97,7 @@ class BusinessDetailsControllerISpec extends ComponentSpecBase with GenericStubM
         When("I call GET /report-quarterly/income-and-expenses/view/business-details")
         val res = IncomeTaxViewChangeFrontend.getBusinessDetails(0)
 
-        Then("I verify the Income Source Details has been successfully wiremocked")
-        IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
+        verifyIncomeSourceDetailsCall(testMtditid)
 
         Then("an ISE is displayed")
         res should have(

--- a/it/controllers/CalculationControllerISpec.scala
+++ b/it/controllers/CalculationControllerISpec.scala
@@ -49,9 +49,7 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
       "return the correct page with a valid total" in {
 
         And("I wiremock stub a successful Income Source Details response with single Business and Property income")
-        IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-          OK, businessAndPropertyResponse
-        )
+        IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
 
         And("I wiremock stub multiple open and received obligations response")
         IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -67,13 +65,12 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
         SelfAssessmentStub.stubGetCalcData(testNino, testCalcId, calculationDataSuccessWithEoyJson.toString())
 
         When(s"I call GET /report-quarterly/income-and-expenses/view/calculation/$testYear")
-        val res = IncomeTaxViewChangeFrontend.getFinancialData(testYear)
+        val res = IncomeTaxViewChangeFrontend.getCalculation(testYear)
 
-        Then("I verify the Income Source Details has been successfully wiremocked")
-        IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
-        Then("I verify the Estimated Tax Liability response has been wiremocked")
-        IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
+        verifyIncomeSourceDetailsCall(testMtditid)
+        verifyReportDeadlinesCall(testSelfEmploymentId, testPropertyIncomeId)
+        verifyLastTaxCalculationCall(testNino, testYear)
+        verifyCalculationDataCall(testNino, testCalcId)
 
         res should have (
           httpStatus(OK),
@@ -121,9 +118,7 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
         "return the correct page with a valid total" in {
 
           And("I wiremock stub a successful Income Source Details response with single Business and Property income")
-          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-            OK, businessAndPropertyResponse
-          )
+          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
 
           And("I wiremock stub multiple open and received obligations response")
           IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -143,15 +138,13 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
           FinancialTransactionsStub.stubGetFinancialTransactions(testMtditid)(Status.OK, financialTransactionsJson(1000.0))
 
           When(s"I call GET /report-quarterly/income-and-expenses/view/calculation/$testYear")
-          val res = IncomeTaxViewChangeFrontend.getFinancialData(testYear)
+          val res = IncomeTaxViewChangeFrontend.getCalculation(testYear)
 
-          Then("I verify the Income Source Details has been successfully wiremocked")
-          IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
+          verifyIncomeSourceDetailsCall(testMtditid)
+          verifyReportDeadlinesCall(testSelfEmploymentId, testPropertyIncomeId)
+          verifyLastTaxCalculationCall(testNino, testYear)
+          verifyCalculationDataCall(testNino, testCalcId)
           verifyFinancialTransactionsCall(testMtditid)
-
-          Then("I verify the Estimated Tax Liability response has been wiremocked")
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
 
           res should have(
             httpStatus(OK),
@@ -201,9 +194,7 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
         "return the correct page with a valid total" in {
 
           And("I wiremock stub a successful Income Source Details response with single Business and Property income")
-          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-            OK, businessAndPropertyResponse
-          )
+          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
 
           And("I wiremock stub multiple open and received obligations response")
           IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -223,15 +214,13 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
           FinancialTransactionsStub.stubGetFinancialTransactions(testMtditid)(Status.OK, financialTransactionsJson(0.0))
 
           When(s"I call GET /report-quarterly/income-and-expenses/view/calculation/$testYear")
-          val res = IncomeTaxViewChangeFrontend.getFinancialData(testYear)
+          val res = IncomeTaxViewChangeFrontend.getCalculation(testYear)
 
-          Then("I verify the Income Source Details has been successfully wiremocked")
-          IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
+          verifyIncomeSourceDetailsCall(testMtditid)
+          verifyReportDeadlinesCall(testSelfEmploymentId, testPropertyIncomeId)
+          verifyLastTaxCalculationCall(testNino, testYear)
+          verifyCalculationDataCall(testNino, testCalcId)
           verifyFinancialTransactionsCall(testMtditid)
-
-          Then("I verify the Estimated Tax Liability response has been wiremocked")
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
 
           res should have(
             httpStatus(OK),
@@ -279,9 +268,7 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
         "return an Internal Server Error page" in {
 
           And("I wiremock stub a successful Income Source Details response with single Business and Property income")
-          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-            OK, businessAndPropertyResponse
-          )
+          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
 
           And("I wiremock stub multiple open and received obligations response")
           IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -300,15 +287,13 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
           FinancialTransactionsStub.stubGetFinancialTransactions(testMtditid)(Status.OK, financialTransactionsSingleErrorJson)
 
           When(s"I call GET /report-quarterly/income-and-expenses/view/calculation/$testYear")
-          val res = IncomeTaxViewChangeFrontend.getFinancialData(testYear)
+          val res = IncomeTaxViewChangeFrontend.getCalculation(testYear)
 
-          Then("I verify the Income Source Details has been successfully wiremocked")
-          IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
+          verifyIncomeSourceDetailsCall(testMtditid)
+          verifyReportDeadlinesCall(testSelfEmploymentId, testPropertyIncomeId)
+          verifyLastTaxCalculationCall(testNino, testYear)
+          verifyCalculationDataCall(testNino, testCalcId)
           verifyFinancialTransactionsCall(testMtditid)
-
-          Then("I verify the Estimated Tax Liability response has been wiremocked")
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
 
           res should have(httpStatus(INTERNAL_SERVER_ERROR))
 
@@ -321,9 +306,7 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
       "return the correct page with a valid total" in {
 
         And("I wiremock stub a successful Income Source Details response with single Business and Property income")
-        IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-          OK, businessAndPropertyResponse
-        )
+        IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
 
         And("I wiremock stub multiple open and received obligations response")
         IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -339,14 +322,12 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
         SelfAssessmentStub.stubGetCalcData(testNino, testCalcId, calculationDataSuccessJson.toString())
 
         When(s"I call GET /report-quarterly/income-and-expenses/view/calculation/$testYear")
-        val res = IncomeTaxViewChangeFrontend.getFinancialData(testYear)
+        val res = IncomeTaxViewChangeFrontend.getCalculation(testYear)
 
-        Then("I verify the Income Source Details has been successfully wiremocked")
-        IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
-        Then("I verify the Estimated Tax Liability response has been wiremocked")
-        IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
-        //IncomeTaxViewChangeStub.stubGetCalcData(testNino,testYear,calculationResponse)
+        verifyIncomeSourceDetailsCall(testMtditid)
+        verifyReportDeadlinesCall(testSelfEmploymentId, testPropertyIncomeId)
+        verifyLastTaxCalculationCall(testNino, testYear)
+        verifyCalculationDataCall(testNino, testCalcId)
 
         res should have (
           httpStatus(OK),
@@ -394,9 +375,7 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
         stubUserDetailsError()
 
         And("I wiremock stub a successful Income Source Details response with single Business and Property income")
-        IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-          OK, businessAndPropertyResponse
-        )
+        IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
 
         And("I wiremock stub multiple open and received obligations response")
         IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -408,19 +387,15 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
         IncomeTaxViewChangeStub.stubGetLastTaxCalc(testNino, testYear, lastTaxCalcResponse)
 
         And("I wiremock stub an erroneous response")
-        val calc = calculationDataErrorModel
-        val calculationResponse = CalculationDataErrorModel(calc.code, calc.message)
-
-        SelfAssessmentStub.stubGetCalcError(testNino, testCalcId, calculationResponse)
+        SelfAssessmentStub.stubGetCalcDataError(testNino, testCalcId, calculationDataErrorModel)
 
         When(s"I make a call to GET /report-quarterly/income-and-expenses/view/calculation/$testYear")
-        val res = IncomeTaxViewChangeFrontend.getFinancialData(testYear)
+        val res = IncomeTaxViewChangeFrontend.getCalculation(testYear)
 
-        Then("I verify the Income Source Details has been successfully wiremocked")
-        IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
-        Then("verification that the Estimated Tax Liability response has been wiremocked ")
-        IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
+        verifyIncomeSourceDetailsCall(testMtditid)
+        verifyReportDeadlinesCall(testSelfEmploymentId, testPropertyIncomeId)
+        verifyLastTaxCalculationCall(testNino, testYear)
+        verifyCalculationDataCall(testNino, testCalcId)
 
         Then("a successful response is returned with the correct estimate")
         res should have(
@@ -438,9 +413,7 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
       "Return no data found response and render view explaining that this will be available once they've submitted income" in {
 
         And("I wiremock stub a successful Income Source Details response with single Business and Property income")
-        IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-          OK, businessAndPropertyResponse
-        )
+        IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
 
         And("I wiremock stub multiple open and received obligations response")
         IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -450,13 +423,11 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
         IncomeTaxViewChangeStub.stubGetLastCalcNoData(testNino, testYear)
 
         When(s"I make a call to GET /report-quarterly/income-and-expenses/view/calculation/$testYear ")
-        val res = IncomeTaxViewChangeFrontend.getFinancialData(testYear)
+        val res = IncomeTaxViewChangeFrontend.getCalculation(testYear)
 
-        Then("I verify the Income Source Details has been successfully wiremocked")
-        IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
-        Then("verification that the Estimated Tax Liability response has been wiremocked ")
-        IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
+        verifyIncomeSourceDetailsCall(testMtditid)
+        verifyReportDeadlinesCall(testSelfEmploymentId, testPropertyIncomeId)
+        verifyLastTaxCalculationCall(testNino, testYear)
 
         Then("a Not Found response is returned and correct view rendered")
         res should have(
@@ -471,9 +442,7 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
       "Render the Estimated Tax Liability Error Page" in {
 
         And("I wiremock stub a successful Income Source Details response with single Business and Property income")
-        IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-          OK, businessAndPropertyResponse
-        )
+        IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
 
         And("I wiremock stub multiple open and received obligations response")
         IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -483,13 +452,11 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
         IncomeTaxViewChangeStub.stubGetLastCalcError(testNino, testYear)
 
         When(s"I make a call to GET /report-quarterly/income-and-expenses/view/calculation/$testYear ")
-        val res = IncomeTaxViewChangeFrontend.getFinancialData(testYear)
+        val res = IncomeTaxViewChangeFrontend.getCalculation(testYear)
 
-        Then("I verify the Income Source Details has been successfully wiremocked")
-        IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
-        Then("verification that the Estimated Tax Liability response has been wiremocked ")
-        IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
+        verifyIncomeSourceDetailsCall(testMtditid)
+        verifyReportDeadlinesCall(testSelfEmploymentId, testPropertyIncomeId)
+        verifyLastTaxCalculationCall(testNino, testYear)
 
         Then("an Internal Server Error response is returned and correct view rendered")
         res should have(

--- a/it/controllers/CalculationControllerISpec.scala
+++ b/it/controllers/CalculationControllerISpec.scala
@@ -148,7 +148,7 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
           Then("I verify the Income Source Details has been successfully wiremocked")
           IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
 
-          verifyFinancialTransactionsCall()
+          verifyFinancialTransactionsCall(testMtditid)
 
           Then("I verify the Estimated Tax Liability response has been wiremocked")
           IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
@@ -228,7 +228,7 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
           Then("I verify the Income Source Details has been successfully wiremocked")
           IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
 
-          verifyFinancialTransactionsCall()
+          verifyFinancialTransactionsCall(testMtditid)
 
           Then("I verify the Estimated Tax Liability response has been wiremocked")
           IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
@@ -305,7 +305,7 @@ class CalculationControllerISpec extends ComponentSpecBase with GenericStubMetho
           Then("I verify the Income Source Details has been successfully wiremocked")
           IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
 
-          verifyFinancialTransactionsCall()
+          verifyFinancialTransactionsCall(testMtditid)
 
           Then("I verify the Estimated Tax Liability response has been wiremocked")
           IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)

--- a/it/controllers/EstimatesControllerISpec.scala
+++ b/it/controllers/EstimatesControllerISpec.scala
@@ -32,37 +32,14 @@ class EstimatesControllerISpec extends ComponentSpecBase with GenericStubMethods
 
   "Calling the EstimatesController.viewEstimatedCalculations" when {
 
-    "Estimates Feature is disabled" should {
-
-      "redirect to home page" in {
-
-        appConfig.features.estimatesEnabled(false)
-
-        And("I wiremock stub a successful Income Source Details response with 1 Business and Property income")
-        IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
-
-        When(s"I call GET /report-quarterly/income-and-expenses/view/estimates")
-        val res = IncomeTaxViewChangeFrontend.getEstimates
-
-        Then("The view should have the correct headings and a single tax estimate link")
-        res should have(
-          httpStatus(SEE_OTHER),
-          redirectURI(controllers.routes.HomeController.home().url)
-        )
-      }
-    }
-
-
     "Estimates Feature switch is enabled" when {
+
       "isAuthorisedUser with an active enrolment, and a single, valid tax estimate" should {
+
         "return the correct page with tax links" in {
 
-          appConfig.features.estimatesEnabled(true)
-
           And("I wiremock stub a successful Income Source Details response with single Business and Property income")
-          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-            OK, businessAndPropertyResponse
-          )
+          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
 
           And("I wiremock stub multiple open and received obligations response")
           IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -73,18 +50,12 @@ class EstimatesControllerISpec extends ComponentSpecBase with GenericStubMethods
             LastTaxCalculation(testCalcId, "2017-07-06T12:34:56.789Z", calculationDataSuccessWithEoYModel.totalIncomeTaxNicYtd, Estimate)
           IncomeTaxViewChangeStub.stubGetLastTaxCalc(testNino, testYear, lastTaxCalcResponse)
 
-          And("I wiremock stub a successful Get CalculationData response")
-          val calcBreakdownResponse = calculationDataSuccessWithEoYModel
-          SelfAssessmentStub.stubGetCalcData(testNino, testCalcId, calculationDataSuccessWithEoyJson.toString())
-
           When(s"I call GET /report-quarterly/income-and-expenses/view/estimates")
           val res = IncomeTaxViewChangeFrontend.getEstimates
 
-          Then("I verify the Income Source Details has been successfully wiremocked")
-          IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
-          Then("I verify the Estimated Tax Liability response has been wiremocked")
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
+          verifyIncomeSourceDetailsCall(testMtditid)
+          verifyReportDeadlinesCall(testSelfEmploymentId, testPropertyIncomeId)
+          verifyLastTaxCalculationCall(testNino, testYear)
 
           Then("The view should have the correct headings and a single tax estimate link")
           res should have(
@@ -97,12 +68,8 @@ class EstimatesControllerISpec extends ComponentSpecBase with GenericStubMethods
       "isAuthorisedUser with an active enrolment, and multiple valid tax estimates" should {
         "return the correct page with tax links" in {
 
-          appConfig.features.estimatesEnabled(true)
-
           And("I wiremock stub a successful Income Source Details response with single Business and Property income")
-          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-            OK, multipleBusinessesAndPropertyResponse
-          )
+          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, multipleBusinessesAndPropertyResponse)
 
           And("I wiremock stub multiple open and received obligations response")
           IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -117,20 +84,14 @@ class EstimatesControllerISpec extends ComponentSpecBase with GenericStubMethods
           IncomeTaxViewChangeStub.stubGetLastTaxCalc(testNino, testYear, lastTaxCalcResponse)
           IncomeTaxViewChangeStub.stubGetLastTaxCalc(testNino, testYearPlusOne, lastTaxCalcResponse2)
 
-          And("I wiremock stub a successful Get CalculationData response")
-          val calcBreakdownResponse = calculationDataSuccessWithEoYModel
-          SelfAssessmentStub.stubGetCalcData(testNino, testCalcId, calculationDataSuccessWithEoyJson.toString())
-          SelfAssessmentStub.stubGetCalcData(testNino, testCalcId2, calculationDataSuccessWithEoyJson.toString())
 
           When(s"I call GET /report-quarterly/income-and-expenses/view/estimates")
           val res = IncomeTaxViewChangeFrontend.getEstimates
 
-          Then("I verify the Income Source Details has been successfully wiremocked")
-          IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
-          Then("I verify the Estimated Tax Liability response has been wiremocked")
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYearPlusOne)
+          verifyIncomeSourceDetailsCall(testMtditid)
+          verifyReportDeadlinesCall(testSelfEmploymentId, otherTestSelfEmploymentId, testPropertyIncomeId)
+          verifyLastTaxCalculationCall(testNino, testYear)
+          verifyLastTaxCalculationCall(testNino, testYearPlusOne)
 
           Then("The view should have the correct headings and two tax estimate links")
           res should have(
@@ -147,12 +108,8 @@ class EstimatesControllerISpec extends ComponentSpecBase with GenericStubMethods
       "isAuthorisedUser with an active enrolment, with a crystallised calculation and a tax estimate" should {
         "return the correct estimate page" in {
 
-          appConfig.features.estimatesEnabled(true)
-
           And("I wiremock stub a successful Income Source Details response with single Business and Property income")
-          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-            OK, multipleBusinessesAndPropertyResponse
-          )
+          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, multipleBusinessesAndPropertyResponse)
 
           And("I wiremock stub multiple open and received obligations response")
           IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -177,21 +134,14 @@ class EstimatesControllerISpec extends ComponentSpecBase with GenericStubMethods
           IncomeTaxViewChangeStub.stubGetLastTaxCalc(testNino, testYear, crystallisedLastTaxCalcResponse)
           IncomeTaxViewChangeStub.stubGetLastTaxCalc(testNino, testYearPlusOne, lastTaxCalcResponse)
 
-          And("I wiremock stub a successful Get CalculationData response")
-          val calcBreakdownResponse = calculationDataSuccessWithEoYModel
-          SelfAssessmentStub.stubGetCalcData(testNino, testCalcId, calculationDataSuccessWithEoyJson.toString())
-          SelfAssessmentStub.stubGetCalcData(testNino, testCalcId2, calculationDataSuccessWithEoyJson.toString())
-
 
           When(s"I call GET /report-quarterly/income-and-expenses/view/estimates")
           val res = IncomeTaxViewChangeFrontend.getEstimates
 
-          Then("I verify the Income Source Details has been successfully wiremocked")
-          IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
-          Then("I verify the Estimated Tax Liability response has been wiremocked")
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYearPlusOne)
+          verifyIncomeSourceDetailsCall(testMtditid)
+          verifyReportDeadlinesCall(testSelfEmploymentId, otherTestSelfEmploymentId, testPropertyIncomeId)
+          verifyLastTaxCalculationCall(testNino, testYear)
+          verifyLastTaxCalculationCall(testNino, testYearPlusOne)
 
           Then("The view should have the correct headings and a single tax estimate link")
           res should have(
@@ -204,12 +154,8 @@ class EstimatesControllerISpec extends ComponentSpecBase with GenericStubMethods
       "isAuthorisedUser with an active enrolment, and no tax estimates" should {
         "return the correct page with no estimates found message" in {
 
-          appConfig.features.estimatesEnabled(true)
-
           And("I wiremock stub a successful Income Source Details response with single Business and Property income")
-          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
-            OK, businessAndPropertyResponse
-          )
+          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
 
           And("I wiremock stub multiple open and received obligations response")
           IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
@@ -225,19 +171,13 @@ class EstimatesControllerISpec extends ComponentSpecBase with GenericStubMethods
             )
           IncomeTaxViewChangeStub.stubGetLastTaxCalc(testNino, testYear, lastTaxCalcResponse)
 
-          And("I wiremock stub a successful Get CalculationData response")
-          val calcBreakdownResponse = calculationDataSuccessWithEoYModel
-          SelfAssessmentStub.stubGetCalcData(testNino, testCalcId, calculationDataSuccessWithEoyJson.toString())
-
 
           When(s"I call GET /report-quarterly/income-and-expenses/view/estimates")
           val res = IncomeTaxViewChangeFrontend.getEstimates
 
-          Then("I verify the Income Source Details has been successfully wiremocked")
-          IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(testMtditid)
-
-          Then("I verify the Estimated Tax Liability response has been wiremocked")
-          IncomeTaxViewChangeStub.verifyGetLastTaxCalc(testNino, testYear)
+          verifyIncomeSourceDetailsCall(testMtditid)
+          verifyReportDeadlinesCall(testSelfEmploymentId, testPropertyIncomeId)
+          verifyLastTaxCalculationCall(testNino, testYear)
 
           Then("The view should have the correct headings and a single tax estimate link")
           res should have(
@@ -250,6 +190,33 @@ class EstimatesControllerISpec extends ComponentSpecBase with GenericStubMethods
       }
 
       unauthorisedTest("/estimates")
+    }
+
+    "Estimates Feature is disabled" should {
+
+      "redirect to home page" in {
+
+        appConfig.features.estimatesEnabled(false)
+
+        And("I wiremock stub a successful Income Source Details response with 1 Business and Property income")
+        IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
+
+        And("I wiremock stub multiple open and received obligations response")
+        IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, multipleReportDeadlinesDataSuccessModel)
+        IncomeTaxViewChangeStub.stubGetReportDeadlines(testPropertyIncomeId, multipleReportDeadlinesDataSuccessModel)
+
+        When(s"I call GET /report-quarterly/income-and-expenses/view/estimates")
+        val res = IncomeTaxViewChangeFrontend.getEstimates
+
+        verifyIncomeSourceDetailsCall(testMtditid)
+        verifyReportDeadlinesCall(testSelfEmploymentId, testPropertyIncomeId)
+
+        Then("The view should have the correct headings and a single tax estimate link")
+        res should have(
+          httpStatus(SEE_OTHER),
+          redirectURI(controllers.routes.HomeController.home().url)
+        )
+      }
     }
   }
 }

--- a/it/controllers/HomeControllerISpec.scala
+++ b/it/controllers/HomeControllerISpec.scala
@@ -15,20 +15,11 @@
  */
 package controllers
 
-import assets.BaseIntegrationTestConstants._
-import assets.BusinessDetailsIntegrationTestConstants._
-import assets.PropertyDetailsIntegrationTestConstants._
-import assets.ReportDeadlinesIntegrationTestConstants._
-import config.FrontendAppConfig
-import helpers.servicemocks.{AuthStub, IncomeTaxViewChangeStub, SelfAssessmentStub}
 import helpers.{ComponentSpecBase, GenericStubMethods}
-import models.core.{Nino, NinoResponseError}
 import play.api.http.Status._
 import utils.ImplicitDateFormatter
 
 class HomeControllerISpec extends ComponentSpecBase with GenericStubMethods with ImplicitDateFormatter {
-
-  lazy val appConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
 
   "Navigating to /report-quarterly/income-and-expenses/view" when {
 
@@ -41,68 +32,12 @@ class HomeControllerISpec extends ComponentSpecBase with GenericStubMethods with
 
         Then("the result should have a HTTP status of OK (200) and the Income Tax home page")
         res should have(
-
-          //Check Status OK (200) Result
           httpStatus(OK),
-
-          //Check Redirect Location
           pageTitle("Your Income Tax")
         )
       }
     }
 
     unauthorisedTest("")
-  }
-
-  "Navigating to /report-quarterly/income-and-expenses/view/obligations" when {
-    "a user is without a HMRC-NI enrolment" should {
-      "redirect to the report deadlines page" in {
-
-        Given("I wiremock stub an authorised with no Nino user response")
-        AuthStub.stubAuthorisedNoNino()
-
-        IncomeTaxViewChangeStub.stubGetNinoResponse(testMtditid, Nino(testNino))
-
-        stubUserDetails()
-
-        And("I wiremock stub a single business obligation response")
-        IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, singleObligationOverdueModel)
-
-        When("I call GET /report-quarterly/income-and-expenses/view/obligations")
-        val res = IncomeTaxViewChangeFrontend.getReportDeadlines
-
-        Then("Verify NINO lookup has been called")
-        IncomeTaxViewChangeStub.verifyGetNino(testMtditid)
-
-        res should have(
-          httpStatus(SEE_OTHER),
-          redirectURI("/report-quarterly/income-and-expenses/view/obligations")
-        )
-      }
-
-      "be displayed a technical error page if there is no NINO" in {
-
-        Given("I wiremock stub an authorised with no Nino user response")
-        AuthStub.stubAuthorisedNoNino()
-
-        IncomeTaxViewChangeStub.stubGetNinoError(testMtditid, NinoResponseError(INTERNAL_SERVER_ERROR, "Error Message"))
-
-        stubUserDetails()
-
-        And("I wiremock stub a single business obligation response")
-        IncomeTaxViewChangeStub.stubGetReportDeadlines(testSelfEmploymentId, singleObligationOverdueModel)
-
-        When("I call GET /report-quarterly/income-and-expenses/view/obligations")
-        val res = IncomeTaxViewChangeFrontend.getReportDeadlines
-
-        Then("Verify NINO lookup has been called")
-        IncomeTaxViewChangeStub.verifyGetNino(testMtditid)
-
-        res should have(
-          httpStatus(INTERNAL_SERVER_ERROR),
-          pageTitle("Sorry, we are experiencing technical difficulties - 500")
-        )
-      }
-    }
   }
 }

--- a/it/controllers/StatementsControllerISpec.scala
+++ b/it/controllers/StatementsControllerISpec.scala
@@ -36,34 +36,11 @@ class StatementsControllerISpec extends ComponentSpecBase with ImplicitDateForma
 
     "the statements page feature is disabled" should {
 
-      "redirect to the home page" in {
-
-        appConfig.features.statementsEnabled(false)
-
-        And("I wiremock stub a successful Get Financial Transactions response")
-        val statementResponse = Json.toJson(singleFinancialTransactionsModel)
-        FinancialTransactionsStub.stubGetFinancialTransactions(testMtditid)(Status.OK, statementResponse)
-
-        When(s"I call GET /report-quarterly/income-and-expenses/view/statements")
-        val res = IncomeTaxViewChangeFrontend.getStatements
-
-        Then("redirect to the home page")
-        res should have(
-          httpStatus(SEE_OTHER),
-          redirectURI(controllers.routes.HomeController.home().url)
-        )
-      }
-    }
-
-    "the statements page feature is disabled" should {
-
       "isAuthorisedUser with an active enrolment" which {
 
         "has a single statement with a single charge" should {
 
           "display the tax year for the statement and the associated charge" in {
-
-            appConfig.features.statementsEnabled(true)
 
             And("I wiremock stub a successful Get Financial Transactions response")
             val statementResponse = Json.toJson(singleFinancialTransactionsModel)
@@ -72,8 +49,7 @@ class StatementsControllerISpec extends ComponentSpecBase with ImplicitDateForma
             When(s"I call GET /report-quarterly/income-and-expenses/view/statements")
             val res = IncomeTaxViewChangeFrontend.getStatements
 
-            Then("I verify the Financial Transactions response has been wiremocked")
-            FinancialTransactionsStub.verifyGetFinancialTransactions(testMtditid)
+            verifyFinancialTransactionsCall(testMtditid)
 
             Then("The view should have the correct headings and single statement")
             val model = singleChargeTransactionModel
@@ -95,8 +71,6 @@ class StatementsControllerISpec extends ComponentSpecBase with ImplicitDateForma
 
           "display the tax year for the statements and the associated charge & payments" in {
 
-            appConfig.features.statementsEnabled(true)
-
             And("I wiremock stub a successful Get Financial Transactions response")
             val statementResponse = Json.toJson(singleFTModel1charge2payments)
             FinancialTransactionsStub.stubGetFinancialTransactions(testMtditid)(Status.OK, statementResponse)
@@ -104,8 +78,7 @@ class StatementsControllerISpec extends ComponentSpecBase with ImplicitDateForma
             When(s"I call GET /report-quarterly/income-and-expenses/view/statements")
             val res = IncomeTaxViewChangeFrontend.getStatements
 
-            Then("I verify the Financial Transactions response has been wiremocked")
-            FinancialTransactionsStub.verifyGetFinancialTransactions(testMtditid)
+            verifyFinancialTransactionsCall(testMtditid)
 
             Then("The view should have the correct headings and single statement")
             val statement1Model = singleChargeTransactionModel
@@ -135,8 +108,6 @@ class StatementsControllerISpec extends ComponentSpecBase with ImplicitDateForma
 
           "state that the user has no transactions since tey started reporting via software" in {
 
-            appConfig.features.statementsEnabled(true)
-
             And("I wiremock stub a successful Get Financial Transactions response")
             val statementResponse = Json.toJson(emptyFTModel)
             FinancialTransactionsStub.stubGetFinancialTransactions(testMtditid)(Status.OK, statementResponse)
@@ -144,8 +115,7 @@ class StatementsControllerISpec extends ComponentSpecBase with ImplicitDateForma
             When(s"I call GET /report-quarterly/income-and-expenses/view/statements")
             val res = IncomeTaxViewChangeFrontend.getStatements
 
-            Then("I verify the Financial Transactions response has been wiremocked")
-            FinancialTransactionsStub.verifyGetFinancialTransactions(testMtditid)
+            verifyFinancialTransactionsCall(testMtditid)
 
             Then("The view should have the correct headings and single statement")
             res should have(
@@ -164,16 +134,13 @@ class StatementsControllerISpec extends ComponentSpecBase with ImplicitDateForma
 
           "return an error page" in {
 
-            appConfig.features.statementsEnabled(true)
-
             And("I wiremock stub a successful Get Financial Transactions response")
             FinancialTransactionsStub.stubGetFinancialTransactions(testMtditid)(Status.INTERNAL_SERVER_ERROR, Json.obj())
 
             When(s"I call GET /report-quarterly/income-and-expenses/view/statements")
             val res = IncomeTaxViewChangeFrontend.getStatements
 
-            Then("I verify the Financial Transactions response has been wiremocked")
-            FinancialTransactionsStub.verifyGetFinancialTransactions(testMtditid)
+            verifyFinancialTransactionsCall(testMtditid)
 
             Then("The view should have the correct headings and single statement")
             res should have(
@@ -183,6 +150,32 @@ class StatementsControllerISpec extends ComponentSpecBase with ImplicitDateForma
             )
 
           }
+        }
+      }
+
+      unauthorisedTest("/statements")
+    }
+
+    "the statements page feature is disabled" when {
+
+      "Authorised" should {
+
+        "redirect to the home page" in {
+
+          appConfig.features.statementsEnabled(false)
+
+          And("I wiremock stub a successful Get Financial Transactions response")
+          val statementResponse = Json.toJson(singleFinancialTransactionsModel)
+          FinancialTransactionsStub.stubGetFinancialTransactions(testMtditid)(Status.OK, statementResponse)
+
+          When(s"I call GET /report-quarterly/income-and-expenses/view/statements")
+          val res = IncomeTaxViewChangeFrontend.getStatements
+
+          Then("redirect to the home page")
+          res should have(
+            httpStatus(SEE_OTHER),
+            redirectURI(controllers.routes.HomeController.home().url)
+          )
         }
       }
 

--- a/it/helpers/ComponentSpecBase.scala
+++ b/it/helpers/ComponentSpecBase.scala
@@ -75,7 +75,7 @@ trait ComponentSpecBase extends TestSuite with CustomMatchers
     def getEstimates: WSResponse = get("/estimates")
     def getStatements: WSResponse = get("/statements")
     def getBills: WSResponse = get("/bills")
-    def getFinancialData(year: String): WSResponse = get(s"/calculation/$year")
+    def getCalculation(year: String): WSResponse = get(s"/calculation/$year")
     def getReportDeadlines: WSResponse = get(s"/obligations")
     def getAccountDetails: WSResponse = get(s"/account-details")
     def getBusinessDetails(id: Int): WSResponse = get(s"/account-details/$id")

--- a/it/helpers/ComponentSpecBase.scala
+++ b/it/helpers/ComponentSpecBase.scala
@@ -56,6 +56,10 @@ trait ComponentSpecBase extends TestSuite with CustomMatchers
   override def beforeAll(): Unit = {
     super.beforeAll()
     startWiremock()
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
     isAuthorisedUser(true)
     stubUserDetails()
   }

--- a/it/helpers/GenericStubMethods.scala
+++ b/it/helpers/GenericStubMethods.scala
@@ -41,11 +41,6 @@ trait GenericStubMethods extends CustomMatchers {
     UserDetailsStub.stubGetUserDetailsError()
   }
 
-  def stubPartial(): Unit = {
-    And("I wiremock stub a ServiceInfo Partial response")
-    BtaPartialStub.stubGetServiceInfoPartial()
-  }
-
   def verifyReportDeadlinesCall(incomeSourceIds: String*): Unit = {
     for(incomeSourceId <- incomeSourceIds) {
       Then(s"Verify that Report Deadlines has been called for $incomeSourceId")

--- a/it/helpers/GenericStubMethods.scala
+++ b/it/helpers/GenericStubMethods.scala
@@ -41,16 +41,31 @@ trait GenericStubMethods extends CustomMatchers {
     UserDetailsStub.stubGetUserDetailsError()
   }
 
+  def verifyIncomeSourceDetailsCall(mtditid: String): Unit = {
+    Then(s"Verify that Income Source Details has been called for MTDITID = $mtditid")
+    IncomeTaxViewChangeStub.verifyGetIncomeSourceDetails(mtditid)
+  }
+
   def verifyReportDeadlinesCall(incomeSourceIds: String*): Unit = {
     for(incomeSourceId <- incomeSourceIds) {
-      Then(s"Verify that Report Deadlines has been called for $incomeSourceId")
+      Then(s"Verify that Report Deadlines has been called for incomeSourceID = $incomeSourceId")
       IncomeTaxViewChangeStub.verifyGetReportDeadlines(incomeSourceId)
     }
   }
 
-  def verifyFinancialTransactionsCall(): Unit = {
+  def verifyFinancialTransactionsCall(mtditid: String): Unit = {
     Then("Verify that Financial Transactions has been called")
-    FinancialTransactionsStub.verifyGetFinancialTransactions(testMtditid)
+    FinancialTransactionsStub.verifyGetFinancialTransactions(mtditid)
+  }
+
+  def verifyLastTaxCalculationCall(nino: String, taxYear: String): Unit = {
+    Then(s"Verify that Last Tax Calculation has been called for NINO = $nino and CalcID = $taxYear")
+    IncomeTaxViewChangeStub.verifyGetLastTaxCalc(nino, taxYear)
+  }
+
+  def verifyCalculationDataCall(nino: String, calcId: String): Unit = {
+    Then(s"Verify that Calculation Data has been called for NINO = $nino and CalcID = $calcId")
+    SelfAssessmentStub.verifyGetCalcData(nino, calcId)
   }
 
 }

--- a/it/helpers/servicemocks/SelfAssessmentStub.scala
+++ b/it/helpers/servicemocks/SelfAssessmentStub.scala
@@ -32,7 +32,7 @@ object SelfAssessmentStub {
     WiremockHelper.stubGet(calcUrl(nino, year), Status.OK, calc)
   }
 
-  def stubGetCalcError(nino: String, year: String, error: CalculationDataErrorModel): Unit = {
+  def stubGetCalcDataError(nino: String, year: String, error: CalculationDataErrorModel): Unit = {
     WiremockHelper.stubGet(calcUrl(nino, year), Status.INTERNAL_SERVER_ERROR, Json.toJson(error).toString())
   }
 


### PR DESCRIPTION
Includes minor tweaks:

- Authorised User is now on a `beforeEach()` rather than `beforeAll()` so that the authorised state is always guaranteed for each specific test. Unless overidden to unathorised. This was due to an unauthorised test bleeding into the following test.
- Made the last test the disabled test so that the assumed default can be enabled.