### PR TITLE
MIT-27 - Use new income structure, display scottish tax bands

### DIFF
--- a/app/connectors/CalculationDataConnector.scala
+++ b/app/connectors/CalculationDataConnector.scala
@@ -17,6 +17,7 @@
 package connectors
 
 import javax.inject.{Inject, Singleton}
+
 import config.FrontendAppConfig
 import models.calculation._
 import play.api.Logger

--- a/app/models/calculation/CalcDisplayModel.scala
+++ b/app/models/calculation/CalcDisplayModel.scala
@@ -34,10 +34,6 @@ case class CalcDisplayModel(calcTimestamp: String,
   val breakdownNonEmpty: Boolean = calcDataModel.nonEmpty
   val hasEoyEstimate: Boolean = calcDataModel.fold(false)(_.eoyEstimate.nonEmpty)
 
-  val hasBRTSection: Boolean = calcDataModel.fold(false)(_.payPensionsProfit.basicBand.taxableIncome > 0)
-  val hasHRTSection: Boolean = calcDataModel.fold(false)(_.payPensionsProfit.higherBand.taxableIncome > 0)
-  val hasARTSection: Boolean = calcDataModel.fold(false)(_.payPensionsProfit.additionalBand.taxableIncome > 0)
-
   val hasNic2Amount: Boolean = calcDataModel.fold(false)(_.nic.class2 > 0)
   val hasNic4Amount: Boolean = calcDataModel.fold(false)(_.nic.class4 > 0)
   val hasNISection: Boolean = hasNic2Amount || hasNic4Amount

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -33,5 +33,5 @@ import play.api.libs.json.{JsPath, Reads}
  */
 
 package object models {
-  val defaultZero: JsPath => Reads[BigDecimal] = _.read[BigDecimal].orElse(Reads.pure[BigDecimal](BigDecimal(0)))
+  val defaultZero: JsPath => Reads[BigDecimal] = _.read[BigDecimal].orElse(Reads.pure[BigDecimal](0.00))
 }

--- a/app/views/helpers/calcBreakdownHelper.scala.html
+++ b/app/views/helpers/calcBreakdownHelper.scala.html
@@ -96,42 +96,17 @@
         }
 
         <!-- Income Tax Section -->
-        @if(calcModel.hasBRTSection) {
-            <tr id="brt-section" class="no-border-bottom">
-                <td id="brt-it-calc-heading">
-                    @messages("estimated_tax_liability.calc-breakdown.income-tax")
-                    (<span id="brt-it-calc">@{breakdown.brtITCalc.toCurrencyString}</span>
-                    @messages("estimated_tax_liability.calc-breakdown.at")
-                    <span id="brt-rate">@breakdown.payPensionsProfit.basicBand.taxRate</span>%)
+
+        @for(band <- breakdown.payAndPensionsProfitBands if band.income > 0) {
+            <tr id="@{band.name}-section" class="no-border-bottom">
+                <td id="@{band.name}-it-calc-heading">
+                    @messages("estimated_tax_liability.calc-breakdown.income-tax-band", band.income.toCurrencyString, band.rate.toString)
                 </td>
-                <td id="brt-amount" class="summary-data">@{(breakdown.brtITAmount).toCurrency}</td>
+                <td id="@{band.name}-amount" class="summary-data">
+                    @band.amount.toCurrency
+                </td>
             </tr>
-
-            @if(calcModel.hasHRTSection){
-                <tr id="hrt-section" class="no-border-bottom">
-                    <td id="hrt-it-calc-heading">
-                        @messages("estimated_tax_liability.calc-breakdown.income-tax")
-                        (<span id="hrt-it-calc"> @{breakdown.hrtITCalc.toCurrencyString}</span>
-                        @messages("estimated_tax_liability.calc-breakdown.at")
-                        <span id="hrt-rate">@breakdown.payPensionsProfit.higherBand.taxRate</span>%)
-                    </td>
-                    <td id="hrt-amount" class="summary-data">@{breakdown.hrtITAmount.toCurrency}</td>
-                </tr>
-
-                @if(calcModel.hasARTSection){
-                    <tr id="art-section" class="no-border-bottom">
-                        <td id="art-it-calc-heading">
-                            @messages("estimated_tax_liability.calc-breakdown.income-tax")
-                            (<span id="art-it-calc">@{breakdown.artITCalc.toCurrencyString}</span>
-                            @messages("estimated_tax_liability.calc-breakdown.at")
-                            <span id="art-rate">@breakdown.payPensionsProfit.additionalBand.taxRate</span>%)
-                        </td>
-                        <td id="art-amount" class="summary-data">@{breakdown.artITAmount.toCurrency}</td>
-                    </tr>
-                }
-            }
         }
-
 
         <!-- Dividends Section -->
         @if(breakdown.hasDividendsAtBRT) {

--- a/conf/messages
+++ b/conf/messages
@@ -62,6 +62,7 @@ estimated_tax_liability.calc-breakdown.dividend-income          = Income from di
 estimated_tax_liability.calc-breakdown.dividend-allowance       = Personal Allowance (dividends)
 estimated_tax_liability.calc-breakdown.taxable-dividend-income  = Your taxable income (dividends)
 estimated_tax_liability.calc-breakdown.income-tax               = Income Tax
+estimated_tax_liability.calc-breakdown.income-tax-band          = Income Tax ({0} at {1}%)
 estimated_tax_liability.calc-breakdown.dividend-tax             = Dividend tax
 estimated_tax_liability.calc-breakdown.at                       = at
 estimated_tax_liability.calc-breakdown.nic2                     = Class 2 National Insurance

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -62,6 +62,7 @@ estimated_tax_liability.calc-breakdown.dividend-income          = Incwm o ddifid
 estimated_tax_liability.calc-breakdown.dividend-allowance       = Lwfans Personol (difidendau)
 estimated_tax_liability.calc-breakdown.taxable-dividend-income  = Eich incwm trethadwy (difidendau)
 estimated_tax_liability.calc-breakdown.income-tax               = Treth Incwm
+estimated_tax_liability.calc-breakdown.income-tax-band          = Treth Incwn ({0} ar {1})
 estimated_tax_liability.calc-breakdown.dividend-tax             = Treth ar Ddifidendau
 estimated_tax_liability.calc-breakdown.at                       = ar
 estimated_tax_liability.calc-breakdown.nic2                     = Yswiriant Gwladol Dosbarth 2

--- a/it/assets/CalcDataIntegrationTestConstants.scala
+++ b/it/assets/CalcDataIntegrationTestConstants.scala
@@ -32,23 +32,6 @@ object CalcDataIntegrationTestConstants {
       bankBuildingSocietyInterest = 2000.00,
       ukDividends = 11000.00
     ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 20000.00,
-        taxRate = 20.0,
-        taxAmount = 4000.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 100000.00,
-        taxRate = 40.0,
-        taxAmount = 40000.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 50000.00,
-        taxRate = 45.0,
-        taxAmount = 22500.00
-      )
-    ),
     savingsAndGains = SavingsAndGainsModel(
       startBand = BandModel(
         taxableIncome = 1.00,
@@ -98,7 +81,12 @@ object CalcDataIntegrationTestConstants {
       class2 = 10000.00,
       class4 = 14000.00
     ),
-    eoyEstimate = Some(EoyEstimate(25000.00))
+    eoyEstimate = Some(EoyEstimate(25000.00)),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("BRT", 20.0, 20000.00, 4000.00),
+      TaxBandModel("HRT", 40.0, 100000.00, 40000.00),
+      TaxBandModel("ART", 45.0, 50000.00, 22500.00)
+    )
   )
 
   val calculationDataSuccessModel = CalculationDataModel(
@@ -113,23 +101,6 @@ object CalcDataIntegrationTestConstants {
       bankBuildingSocietyInterest = 2000.00,
       ukDividends = 11000.00
     ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 20000.00,
-        taxRate = 20.0,
-        taxAmount = 4000.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 100000.00,
-        taxRate = 40.0,
-        taxAmount = 40000.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 50000.00,
-        taxRate = 45.0,
-        taxAmount = 22500.00
-      )
-    ),
     savingsAndGains = SavingsAndGainsModel(
       startBand = BandModel(
         taxableIncome = 1.00,
@@ -178,6 +149,11 @@ object CalcDataIntegrationTestConstants {
     nic = NicModel(
       class2 = 10000.00,
       class4 = 14000.00
+    ),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("BRT", 20.0, 20000.00, 4000.00),
+      TaxBandModel("HRT", 40.0, 100000.00, 40000.00),
+      TaxBandModel("ART", 45.0, 50000.00, 22500.00)
     )
   )
 
@@ -414,6 +390,27 @@ object CalcDataIntegrationTestConstants {
         "nic4" -> 89999999.99,
         "totalNicAmount" -> 9999999.99,
         "incomeTaxNicAmount" -> 66000.00
+      ),
+      "incomeTax" -> Json.obj(
+        "payAndPensionsProfit" -> Json.obj(
+          "band" -> Json.arr(Json.obj(
+            "name" -> "BRT",
+            "rate" -> 20.0,
+            "income" -> 20000.00,
+            "amount" -> 4000.00
+          ), Json.obj(
+            "name" -> "HRT",
+            "rate" -> 40.0,
+            "income" -> 100000.00,
+            "amount" -> 40000.00
+          ), Json.obj(
+            "name" -> "ART",
+            "rate" -> 45.0,
+            "income" -> 50000.00,
+            "amount" -> 22500.00
+          )
+          )
+        )
       )
     )
 
@@ -618,7 +615,28 @@ object CalcDataIntegrationTestConstants {
     "proportionClass2NICsLimit" -> 0,
     "proportionClass4NICsLimitBR" -> 0,
     "proportionClass4NICsLimitHR" -> 0,
-    "proportionReducedAllowanceLimit" -> 0
+    "proportionReducedAllowanceLimit" -> 0,
+    "incomeTax" -> Json.obj(
+      "payAndPensionsProfit" -> Json.obj(
+        "band" -> Json.arr(Json.obj(
+          "name" -> "BRT",
+          "rate" -> 20.0,
+          "income" -> 20000.00,
+          "amount" -> 4000.00
+        ), Json.obj(
+          "name" -> "HRT",
+          "rate" -> 40.0,
+          "income" -> 100000.00,
+          "amount" -> 40000.00
+        ), Json.obj(
+          "name" -> "ART",
+          "rate" -> 45.0,
+          "income" -> 50000.00,
+          "amount" -> 22500.00
+        )
+        )
+      )
+    )
   )
 
   val latestCalcModel: CalculationModel =

--- a/it/controllers/CalculationControllerISpec.scala
+++ b/it/controllers/CalculationControllerISpec.scala
@@ -74,6 +74,10 @@ class CalculationControllerISpec extends ComponentSpecBase {
         verifyLastTaxCalculationCall(testNino, testYear)
         verifyCalculationDataCall(testNino, testCalcId)
 
+        val brtBand = calculationDataSuccessWithEoYModel.payAndPensionsProfitBands.find(_.name == "BRT").get
+        val hrtBand = calculationDataSuccessWithEoYModel.payAndPensionsProfitBands.find(_.name == "HRT").get
+        val artBand = calculationDataSuccessWithEoYModel.payAndPensionsProfitBands.find(_.name == "ART").get
+
         res should have (
           httpStatus(OK),
           pageTitle(messages.title(testYearInt)),
@@ -84,15 +88,12 @@ class CalculationControllerISpec extends ComponentSpecBase {
           elementTextByID("personal-allowance")(s"-${totalAllowance(calculationDataSuccessWithEoYModel)}"),
           elementTextByID("additional-allowances")("-" + calculationDataSuccessWithEoYModel.additionalAllowances.toCurrencyString),
           elementTextByID("taxable-income")(taxableIncome(calculationDataSuccessWithEoYModel)),
-          elementTextByID("brt-it-calc")((calculationDataSuccessWithEoYModel.payPensionsProfit.basicBand.taxableIncome + calculationDataSuccessWithEoYModel.savingsAndGains.basicBand.taxableIncome).toCurrencyString),
-          elementTextByID("brt-rate")(calculationDataSuccessWithEoYModel.payPensionsProfit.basicBand.taxRate.toStringNoDecimal),
-          elementTextByID("brt-amount")((calculationDataSuccessWithEoYModel.payPensionsProfit.basicBand.taxAmount + calculationDataSuccessWithEoYModel.savingsAndGains.basicBand.taxAmount).toCurrencyString),
-          elementTextByID("hrt-it-calc")((calculationDataSuccessWithEoYModel.payPensionsProfit.higherBand.taxableIncome + calculationDataSuccessWithEoYModel.savingsAndGains.higherBand.taxableIncome).toCurrencyString),
-          elementTextByID("hrt-rate")(calculationDataSuccessWithEoYModel.payPensionsProfit.higherBand.taxRate.toStringNoDecimal),
-          elementTextByID("hrt-amount")((calculationDataSuccessWithEoYModel.payPensionsProfit.higherBand.taxAmount + calculationDataSuccessWithEoYModel.savingsAndGains.higherBand.taxAmount).toCurrencyString),
-          elementTextByID("art-it-calc")((calculationDataSuccessWithEoYModel.payPensionsProfit.additionalBand.taxableIncome + calculationDataSuccessWithEoYModel.savingsAndGains.additionalBand.taxableIncome).toCurrencyString),
-          elementTextByID("art-rate")(calculationDataSuccessWithEoYModel.payPensionsProfit.additionalBand.taxRate.toStringNoDecimal),
-          elementTextByID("art-amount")((calculationDataSuccessWithEoYModel.payPensionsProfit.additionalBand.taxAmount + calculationDataSuccessWithEoYModel.savingsAndGains.additionalBand.taxAmount).toCurrencyString),
+          elementTextByID("BRT-it-calc-heading")(s"Income Tax (${brtBand.income.toCurrencyString} at ${brtBand.rate.toStringNoDecimal}%)"),
+          elementTextByID("BRT-amount")(brtBand.amount.toCurrencyString),
+          elementTextByID("HRT-it-calc-heading")(s"Income Tax (${hrtBand.income.toCurrencyString} at ${hrtBand.rate.toStringNoDecimal}%)"),
+          elementTextByID("HRT-amount")(hrtBand.amount.toCurrencyString),
+          elementTextByID("ART-it-calc-heading")(s"Income Tax (${artBand.income.toCurrencyString} at ${artBand.rate.toStringNoDecimal}%)"),
+          elementTextByID("ART-amount")(artBand.amount.toCurrencyString),
           elementTextByID("dividend-income")(calculationDataSuccessWithEoYModel.incomeReceived.ukDividends.toCurrencyString),
           elementTextByID("dividend-allowance")(s"-${calculationDataSuccessWithEoYModel.dividends.allowance.toCurrencyString}"),
           elementTextByID("taxable-dividend-income")(calculationDataSuccessWithEoYModel.taxableDividendIncome.toCurrencyString),
@@ -140,6 +141,10 @@ class CalculationControllerISpec extends ComponentSpecBase {
           verifyCalculationDataCall(testNino, testCalcId)
           verifyFinancialTransactionsCall(testMtditid)
 
+          val brtBand = calculationDataSuccessWithEoYModel.payAndPensionsProfitBands.find(_.name == "BRT").get
+          val hrtBand = calculationDataSuccessWithEoYModel.payAndPensionsProfitBands.find(_.name == "HRT").get
+          val artBand = calculationDataSuccessWithEoYModel.payAndPensionsProfitBands.find(_.name == "ART").get
+
           res should have(
             httpStatus(OK),
             pageTitle(messages.title(testYearInt)),
@@ -153,15 +158,12 @@ class CalculationControllerISpec extends ComponentSpecBase {
             elementTextByID("personal-allowance")(s"-${totalAllowance(calculationDataSuccessWithEoYModel)}"),
             elementTextByID("additional-allowances")("-" + calculationDataSuccessWithEoYModel.additionalAllowances.toCurrencyString),
             elementTextByID("taxable-income")(taxableIncome(calculationDataSuccessWithEoYModel)),
-            elementTextByID("brt-it-calc")((calculationDataSuccessWithEoYModel.payPensionsProfit.basicBand.taxableIncome + calculationDataSuccessWithEoYModel.savingsAndGains.basicBand.taxableIncome).toCurrencyString),
-            elementTextByID("brt-rate")(calculationDataSuccessWithEoYModel.payPensionsProfit.basicBand.taxRate.toStringNoDecimal),
-            elementTextByID("brt-amount")((calculationDataSuccessWithEoYModel.payPensionsProfit.basicBand.taxAmount + calculationDataSuccessWithEoYModel.savingsAndGains.basicBand.taxAmount).toCurrencyString),
-            elementTextByID("hrt-it-calc")((calculationDataSuccessWithEoYModel.payPensionsProfit.higherBand.taxableIncome + calculationDataSuccessWithEoYModel.savingsAndGains.higherBand.taxableIncome).toCurrencyString),
-            elementTextByID("hrt-rate")(calculationDataSuccessWithEoYModel.payPensionsProfit.higherBand.taxRate.toStringNoDecimal),
-            elementTextByID("hrt-amount")((calculationDataSuccessWithEoYModel.payPensionsProfit.higherBand.taxAmount + calculationDataSuccessWithEoYModel.savingsAndGains.higherBand.taxAmount).toCurrencyString),
-            elementTextByID("art-it-calc")((calculationDataSuccessWithEoYModel.payPensionsProfit.additionalBand.taxableIncome + calculationDataSuccessWithEoYModel.savingsAndGains.additionalBand.taxableIncome).toCurrencyString),
-            elementTextByID("art-rate")(calculationDataSuccessWithEoYModel.payPensionsProfit.additionalBand.taxRate.toStringNoDecimal),
-            elementTextByID("art-amount")((calculationDataSuccessWithEoYModel.payPensionsProfit.additionalBand.taxAmount + calculationDataSuccessWithEoYModel.savingsAndGains.additionalBand.taxAmount).toCurrencyString),
+            elementTextByID("BRT-it-calc-heading")(s"Income Tax (${brtBand.income.toCurrencyString} at ${brtBand.rate.toStringNoDecimal}%)"),
+            elementTextByID("BRT-amount")(brtBand.amount.toCurrencyString),
+            elementTextByID("HRT-it-calc-heading")(s"Income Tax (${hrtBand.income.toCurrencyString} at ${hrtBand.rate.toStringNoDecimal}%)"),
+            elementTextByID("HRT-amount")(hrtBand.amount.toCurrencyString),
+            elementTextByID("ART-it-calc-heading")(s"Income Tax (${artBand.income.toCurrencyString} at ${artBand.rate.toStringNoDecimal}%)"),
+            elementTextByID("ART-amount")(artBand.amount.toCurrencyString),
             elementTextByID("dividend-income")(calculationDataSuccessWithEoYModel.incomeReceived.ukDividends.toCurrencyString),
             elementTextByID("dividend-allowance")(s"-${calculationDataSuccessWithEoYModel.dividends.allowance.toCurrencyString}"),
             elementTextByID("taxable-dividend-income")(calculationDataSuccessWithEoYModel.taxableDividendIncome.toCurrencyString),
@@ -208,6 +210,10 @@ class CalculationControllerISpec extends ComponentSpecBase {
           verifyCalculationDataCall(testNino, testCalcId)
           verifyFinancialTransactionsCall(testMtditid)
 
+          val brtBand = calculationDataSuccessWithEoYModel.payAndPensionsProfitBands.find(_.name == "BRT").get
+          val hrtBand = calculationDataSuccessWithEoYModel.payAndPensionsProfitBands.find(_.name == "HRT").get
+          val artBand = calculationDataSuccessWithEoYModel.payAndPensionsProfitBands.find(_.name == "ART").get
+
           res should have(
             httpStatus(OK),
             pageTitle(messages.heading(testYearInt)),
@@ -219,15 +225,12 @@ class CalculationControllerISpec extends ComponentSpecBase {
             elementTextByID("personal-allowance")(s"-${totalAllowance(calculationDataSuccessWithEoYModel)}"),
             elementTextByID("additional-allowances")("-" + calculationDataSuccessWithEoYModel.additionalAllowances.toCurrencyString),
             elementTextByID("taxable-income")(taxableIncome(calculationDataSuccessWithEoYModel)),
-            elementTextByID("brt-it-calc")((calculationDataSuccessWithEoYModel.payPensionsProfit.basicBand.taxableIncome + calculationDataSuccessWithEoYModel.savingsAndGains.basicBand.taxableIncome).toCurrencyString),
-            elementTextByID("brt-rate")(calculationDataSuccessWithEoYModel.payPensionsProfit.basicBand.taxRate.toStringNoDecimal),
-            elementTextByID("brt-amount")((calculationDataSuccessWithEoYModel.payPensionsProfit.basicBand.taxAmount + calculationDataSuccessWithEoYModel.savingsAndGains.basicBand.taxAmount).toCurrencyString),
-            elementTextByID("hrt-it-calc")((calculationDataSuccessWithEoYModel.payPensionsProfit.higherBand.taxableIncome + calculationDataSuccessWithEoYModel.savingsAndGains.higherBand.taxableIncome).toCurrencyString),
-            elementTextByID("hrt-rate")(calculationDataSuccessWithEoYModel.payPensionsProfit.higherBand.taxRate.toStringNoDecimal),
-            elementTextByID("hrt-amount")((calculationDataSuccessWithEoYModel.payPensionsProfit.higherBand.taxAmount + calculationDataSuccessWithEoYModel.savingsAndGains.higherBand.taxAmount).toCurrencyString),
-            elementTextByID("art-it-calc")((calculationDataSuccessWithEoYModel.payPensionsProfit.additionalBand.taxableIncome + calculationDataSuccessWithEoYModel.savingsAndGains.additionalBand.taxableIncome).toCurrencyString),
-            elementTextByID("art-rate")(calculationDataSuccessWithEoYModel.payPensionsProfit.additionalBand.taxRate.toStringNoDecimal),
-            elementTextByID("art-amount")((calculationDataSuccessWithEoYModel.payPensionsProfit.additionalBand.taxAmount + calculationDataSuccessWithEoYModel.savingsAndGains.additionalBand.taxAmount).toCurrencyString),
+            elementTextByID("BRT-it-calc-heading")(s"Income Tax (${brtBand.income.toCurrencyString} at ${brtBand.rate.toStringNoDecimal}%)"),
+            elementTextByID("BRT-amount")(brtBand.amount.toCurrencyString),
+            elementTextByID("HRT-it-calc-heading")(s"Income Tax (${hrtBand.income.toCurrencyString} at ${hrtBand.rate.toStringNoDecimal}%)"),
+            elementTextByID("HRT-amount")(hrtBand.amount.toCurrencyString),
+            elementTextByID("ART-it-calc-heading")(s"Income Tax (${artBand.income.toCurrencyString} at ${artBand.rate.toStringNoDecimal}%)"),
+            elementTextByID("ART-amount")(artBand.amount.toCurrencyString),
             elementTextByID("dividend-income")(calculationDataSuccessWithEoYModel.incomeReceived.ukDividends.toCurrencyString),
             elementTextByID("dividend-allowance")(s"-${calculationDataSuccessWithEoYModel.dividends.allowance.toCurrencyString}"),
             elementTextByID("taxable-dividend-income")(calculationDataSuccessWithEoYModel.taxableDividendIncome.toCurrencyString),
@@ -299,6 +302,10 @@ class CalculationControllerISpec extends ComponentSpecBase {
         verifyLastTaxCalculationCall(testNino, testYear)
         verifyCalculationDataCall(testNino, testCalcId)
 
+        val brtBand = calculationDataSuccessModel.payAndPensionsProfitBands.find(_.name == "BRT").get
+        val hrtBand = calculationDataSuccessModel.payAndPensionsProfitBands.find(_.name == "HRT").get
+        val artBand = calculationDataSuccessModel.payAndPensionsProfitBands.find(_.name == "ART").get
+
         res should have (
           httpStatus(OK),
           pageTitle(messages.title(testYearInt)),
@@ -309,15 +316,12 @@ class CalculationControllerISpec extends ComponentSpecBase {
           elementTextByID("personal-allowance")(s"-${totalAllowance(calculationDataSuccessModel)}"),
           elementTextByID("additional-allowances")("-" + calculationDataSuccessModel.additionalAllowances.toCurrencyString),
           elementTextByID("taxable-income")(taxableIncome(calculationDataSuccessModel)),
-          elementTextByID("brt-it-calc")((calculationDataSuccessModel.payPensionsProfit.basicBand.taxableIncome + calculationDataSuccessModel.savingsAndGains.basicBand.taxableIncome).toCurrencyString),
-          elementTextByID("brt-rate")(calculationDataSuccessModel.payPensionsProfit.basicBand.taxRate.toStringNoDecimal),
-          elementTextByID("brt-amount")((calculationDataSuccessModel.payPensionsProfit.basicBand.taxAmount + calculationDataSuccessModel.savingsAndGains.basicBand.taxAmount).toCurrencyString),
-          elementTextByID("hrt-it-calc")((calculationDataSuccessModel.payPensionsProfit.higherBand.taxableIncome + calculationDataSuccessModel.savingsAndGains.higherBand.taxableIncome).toCurrencyString),
-          elementTextByID("hrt-rate")(calculationDataSuccessModel.payPensionsProfit.higherBand.taxRate.toStringNoDecimal),
-          elementTextByID("hrt-amount")((calculationDataSuccessModel.payPensionsProfit.higherBand.taxAmount + calculationDataSuccessModel.savingsAndGains.higherBand.taxAmount).toCurrencyString),
-          elementTextByID("art-it-calc")((calculationDataSuccessModel.payPensionsProfit.additionalBand.taxableIncome + calculationDataSuccessModel.savingsAndGains.additionalBand.taxableIncome).toCurrencyString),
-          elementTextByID("art-rate")(calculationDataSuccessModel.payPensionsProfit.additionalBand.taxRate.toStringNoDecimal),
-          elementTextByID("art-amount")((calculationDataSuccessModel.payPensionsProfit.additionalBand.taxAmount + calculationDataSuccessModel.savingsAndGains.additionalBand.taxAmount).toCurrencyString),
+          elementTextByID("BRT-it-calc-heading")(s"Income Tax (${brtBand.income.toCurrencyString} at ${brtBand.rate.toStringNoDecimal}%)"),
+          elementTextByID("BRT-amount")(brtBand.amount.toCurrencyString),
+          elementTextByID("HRT-it-calc-heading")(s"Income Tax (${hrtBand.income.toCurrencyString} at ${hrtBand.rate.toStringNoDecimal}%)"),
+          elementTextByID("HRT-amount")(hrtBand.amount.toCurrencyString),
+          elementTextByID("ART-it-calc-heading")(s"Income Tax (${artBand.income.toCurrencyString} at ${artBand.rate.toStringNoDecimal}%)"),
+          elementTextByID("ART-amount")(artBand.amount.toCurrencyString),
           elementTextByID("dividend-income")(calculationDataSuccessModel.incomeReceived.ukDividends.toCurrencyString),
           elementTextByID("dividend-allowance")(s"-${calculationDataSuccessModel.dividends.allowance.toCurrencyString}"),
           elementTextByID("taxable-dividend-income")(calculationDataSuccessModel.taxableDividendIncome.toCurrencyString),

--- a/test/assets/CalcBreakdownTestConstants.scala
+++ b/test/assets/CalcBreakdownTestConstants.scala
@@ -29,30 +29,13 @@ object CalcBreakdownTestConstants {
     totalIncomeTaxNicYtd = 90500.00,
     totalTaxableIncome = 198500.00,
     personalAllowance = 11500.00,
-    taxReliefs = 0,
+    taxReliefs = 0.00,
     totalIncomeAllowancesUsed = 12005.00,
     incomeReceived = IncomeReceivedModel(
       selfEmployment = 200000.00,
       ukProperty = 10000.00,
       bankBuildingSocietyInterest = 1999.00,
       ukDividends = 10000.00
-    ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 20000.00,
-        taxRate = 20.0,
-        taxAmount = 4000.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 100000.00,
-        taxRate = 40.0,
-        taxAmount = 40000.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 50000.00,
-        taxRate = 45.0,
-        taxAmount = 22500.00
-      )
     ),
     savingsAndGains = SavingsAndGainsModel(
       startBand = BandModel(
@@ -103,171 +86,15 @@ object CalcBreakdownTestConstants {
       class2 = 10000.00,
       class4 = 14000.00
     ),
-    eoyEstimate = Some(EoyEstimate(66000.00))
-  )
-
-  val noTaxOrNICalcDataModel = CalculationDataModel(
-    totalIncomeTaxNicYtd = 0.00,
-    totalTaxableIncome = 0.00,
-    personalAllowance = 2868.00,
-    taxReliefs = 0,
-    totalIncomeAllowancesUsed = 2868.00,
-    incomeReceived = IncomeReceivedModel(
-      selfEmployment = 500.00,
-      ukProperty = 500.00,
-      bankBuildingSocietyInterest = 0.00,
-      ukDividends = 0.0
-    ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 20.0,
-        taxAmount = 0.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 40.0,
-        taxAmount = 0.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 45.0,
-        taxAmount = 0.00
-      )
-    ),
-    savingsAndGains = SavingsAndGainsModel(
-      startBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 0.0,
-        taxAmount = 0.0
-      ),
-      zeroBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 0.0,
-        taxAmount = 0.0
-      ),
-      basicBand = BandModel(
-        taxableIncome = 0.0,
-        taxRate = 20.0,
-        taxAmount = 0.0
-      ),
-      higherBand = BandModel(
-        taxableIncome = 0.0,
-        taxRate = 40.0,
-        taxAmount = 0.0
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 0.0,
-        taxRate = 45.0,
-        taxAmount = 0.0
-      )
-    ),
-    dividends = DividendsModel(
-      allowance = 0.0,
-      basicBand = BandModel(
-        taxableIncome = 0.0,
-        taxRate = 0.0,
-        taxAmount = 0.0
-      ),
-      higherBand = BandModel(
-        taxableIncome = 0.0,
-        taxRate = 0.0,
-        taxAmount = 0.0
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 0.0,
-        taxRate = 0.0,
-        taxAmount = 0.0
-      )
-    ),
-    nic = NicModel(
-      class2 = 0.00,
-      class4 = 0.00
+    eoyEstimate = Some(EoyEstimate(66000.00)),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("BRT", 20.0, 20000.00, 4000.00),
+      TaxBandModel("HRT", 40.0, 100000.00, 40000.00),
+      TaxBandModel("ART", 45.0, 50000.00, 22500.00)
     )
   )
 
-  val noTaxJustNICalcDataModel = CalculationDataModel(
-    totalIncomeTaxNicYtd = 37.05,
-    totalTaxableIncome = 0.00,
-    personalAllowance = 2868.00,
-    taxReliefs = 10.05,
-    totalIncomeAllowancesUsed = 2868.00,
-    incomeReceived = IncomeReceivedModel(
-      selfEmployment = 1506.25,
-      ukProperty = 0.00,
-      bankBuildingSocietyInterest = 0.00,
-      ukDividends = 0.0
-    ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 20.0,
-        taxAmount = 0.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 40.0,
-        taxAmount = 0.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 45.0,
-        taxAmount = 0.00
-      )
-    ),
-    savingsAndGains = SavingsAndGainsModel(
-      startBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 0.0,
-        taxAmount = 0.0
-      ),
-      zeroBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 0.0,
-        taxAmount = 0.0
-      ),
-      basicBand = BandModel(
-        taxableIncome = 0.0,
-        taxRate = 20.0,
-        taxAmount = 0.0
-      ),
-      higherBand = BandModel(
-        taxableIncome = 0.0,
-        taxRate = 40.0,
-        taxAmount = 0.0
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 0.0,
-        taxRate = 45.0,
-        taxAmount = 0.0
-      )
-    ),
-    dividends = DividendsModel(
-      allowance = 0.0,
-      basicBand = BandModel(
-        taxableIncome = 0.0,
-        taxRate = 0.0,
-        taxAmount = 0.0
-      ),
-      higherBand = BandModel(
-        taxableIncome = 0.0,
-        taxRate = 0.0,
-        taxAmount = 0.0
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 0.0,
-        taxRate = 0.0,
-        taxAmount = 0.0
-      )
-    ),
-    nic = NicModel(
-      class2 = 20.05,
-      class4 = 17.05
-    )
-  )
-
-
-  val busPropBRTCalcDataModel = CalculationDataModel(
+  val scottishBandModelJustSRT = CalculationDataModel(
     totalIncomeTaxNicYtd = 149.86,
     totalTaxableIncome = 132.00,
     personalAllowance = 2868.00,
@@ -278,23 +105,6 @@ object CalcBreakdownTestConstants {
       ukProperty = 1500.00,
       bankBuildingSocietyInterest = 0.00,
       ukDividends = 0.0
-    ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 132.00,
-        taxRate = 20.0,
-        taxAmount = 26.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 40.0,
-        taxAmount = 0.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 45.0,
-        taxAmount = 0.00
-      )
     ),
     savingsAndGains = SavingsAndGainsModel(
       startBand = BandModel(
@@ -345,7 +155,359 @@ object CalcBreakdownTestConstants {
       class2 = 110,
       class4 = 13.86
     ),
-    eoyEstimate = Some(EoyEstimate(66000.00))
+    eoyEstimate = Some(EoyEstimate(66000.00)),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("SRT", 15.0, 5000.00, 750.00),
+      TaxBandModel("BRT", 20.0, 0.00, 0.00),
+      TaxBandModel("IRT", 30.0, 0.00, 0.00),
+      TaxBandModel("HRT", 40.0, 0.00, 0.00),
+      TaxBandModel("ART", 45.0, 0.00, 0.00)
+    )
+  )
+
+  val scottishBandModelIRT = CalculationDataModel(
+    totalIncomeTaxNicYtd = 149.86,
+    totalTaxableIncome = 132.00,
+    personalAllowance = 2868.00,
+    taxReliefs=24.90,
+    totalIncomeAllowancesUsed = 2868.00,
+    incomeReceived = IncomeReceivedModel(
+      selfEmployment = 1500.00,
+      ukProperty = 1500.00,
+      bankBuildingSocietyInterest = 0.00,
+      ukDividends = 0.0
+    ),
+    savingsAndGains = SavingsAndGainsModel(
+      startBand = BandModel(
+        taxableIncome = 0.00,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      zeroBand = BandModel(
+        taxableIncome = 0.00,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      basicBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 20.0,
+        taxAmount = 0.0
+      ),
+      higherBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 40.0,
+        taxAmount = 0.0
+      ),
+      additionalBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 45.0,
+        taxAmount = 0.0
+      )
+    ),
+    dividends = DividendsModel(
+      allowance = 0.0,
+      basicBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      higherBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      additionalBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      )
+    ),
+    nic = NicModel(
+      class2 = 110,
+      class4 = 13.86
+    ),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("SRT", 15.0, 5000.00, 750.00),
+      TaxBandModel("BRT", 20.0, 10000.00, 2000.00),
+      TaxBandModel("IRT", 30.0, 20000.00, 6000.00),
+      TaxBandModel("HRT", 40.0, 0.00, 0.00),
+      TaxBandModel("ART", 45.0, 0.00, 0.00)
+    )
+  )
+
+  val scottishBandModelAllIncomeBands = CalculationDataModel(
+    totalIncomeTaxNicYtd = 149.86,
+    totalTaxableIncome = 132.00,
+    personalAllowance = 2868.00,
+    taxReliefs=24.90,
+    totalIncomeAllowancesUsed = 2868.00,
+    incomeReceived = IncomeReceivedModel(
+      selfEmployment = 1500.00,
+      ukProperty = 1500.00,
+      bankBuildingSocietyInterest = 0.00,
+      ukDividends = 0.0
+    ),
+    savingsAndGains = SavingsAndGainsModel(
+      startBand = BandModel(
+        taxableIncome = 0.00,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      zeroBand = BandModel(
+        taxableIncome = 0.00,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      basicBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 20.0,
+        taxAmount = 0.0
+      ),
+      higherBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 40.0,
+        taxAmount = 0.0
+      ),
+      additionalBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 45.0,
+        taxAmount = 0.0
+      )
+    ),
+    dividends = DividendsModel(
+      allowance = 0.0,
+      basicBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      higherBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      additionalBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      )
+    ),
+    nic = NicModel(
+      class2 = 110,
+      class4 = 13.86
+    ),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("SRT", 15.0, 5000.00, 750.00),
+      TaxBandModel("BRT", 20.0, 10000.00, 2000.00),
+      TaxBandModel("IRT", 30.0, 20000.00, 6000.00),
+      TaxBandModel("HRT", 40.0, 50000.00, 20000.00),
+      TaxBandModel("ART", 45.0, 10000.00, 4500.00)
+    )
+  )
+
+  val noTaxOrNICalcDataModel = CalculationDataModel(
+    totalIncomeTaxNicYtd = 0.00,
+    totalTaxableIncome = 0.00,
+    personalAllowance = 2868.00,
+    taxReliefs = 0,
+    totalIncomeAllowancesUsed = 2868.00,
+    incomeReceived = IncomeReceivedModel(
+      selfEmployment = 500.00,
+      ukProperty = 500.00,
+      bankBuildingSocietyInterest = 0.00,
+      ukDividends = 0.0
+    ),
+    savingsAndGains = SavingsAndGainsModel(
+      startBand = BandModel(
+        taxableIncome = 0.00,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      zeroBand = BandModel(
+        taxableIncome = 0.00,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      basicBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 20.0,
+        taxAmount = 0.0
+      ),
+      higherBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 40.0,
+        taxAmount = 0.0
+      ),
+      additionalBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 45.0,
+        taxAmount = 0.0
+      )
+    ),
+    dividends = DividendsModel(
+      allowance = 0.0,
+      basicBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      higherBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      additionalBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      )
+    ),
+    nic = NicModel(
+      class2 = 0.00,
+      class4 = 0.00
+    ),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("BRT", 20.0, 0.00, 0.00),
+      TaxBandModel("HRT", 40.0, 0.00, 0.00),
+      TaxBandModel("ART", 45.0, 0.00, 0.00)
+    )
+  )
+
+  val noTaxJustNICalcDataModel = CalculationDataModel(
+    totalIncomeTaxNicYtd = 37.05,
+    totalTaxableIncome = 0.00,
+    personalAllowance = 2868.00,
+    taxReliefs = 10.05,
+    totalIncomeAllowancesUsed = 2868.00,
+    incomeReceived = IncomeReceivedModel(
+      selfEmployment = 1506.25,
+      ukProperty = 0.00,
+      bankBuildingSocietyInterest = 0.00,
+      ukDividends = 0.0
+    ),
+    savingsAndGains = SavingsAndGainsModel(
+      startBand = BandModel(
+        taxableIncome = 0.00,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      zeroBand = BandModel(
+        taxableIncome = 0.00,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      basicBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 20.0,
+        taxAmount = 0.0
+      ),
+      higherBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 40.0,
+        taxAmount = 0.0
+      ),
+      additionalBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 45.0,
+        taxAmount = 0.0
+      )
+    ),
+    dividends = DividendsModel(
+      allowance = 0.0,
+      basicBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      higherBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      additionalBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      )
+    ),
+    nic = NicModel(
+      class2 = 20.05,
+      class4 = 17.05
+    ),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("BRT", 20.0, 0.00, 0.00),
+      TaxBandModel("HRT", 40.0, 0.00, 0.00),
+      TaxBandModel("ART", 45.0, 0.00, 0.00)
+    )
+  )
+
+  val busPropBRTCalcDataModel = CalculationDataModel(
+    totalIncomeTaxNicYtd = 149.86,
+    totalTaxableIncome = 132.00,
+    personalAllowance = 2868.00,
+    taxReliefs=24.90,
+    totalIncomeAllowancesUsed = 2868.00,
+    incomeReceived = IncomeReceivedModel(
+      selfEmployment = 1500.00,
+      ukProperty = 1500.00,
+      bankBuildingSocietyInterest = 0.00,
+      ukDividends = 0.0
+    ),
+    savingsAndGains = SavingsAndGainsModel(
+      startBand = BandModel(
+        taxableIncome = 0.00,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      zeroBand = BandModel(
+        taxableIncome = 0.00,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      basicBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 20.0,
+        taxAmount = 0.0
+      ),
+      higherBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 40.0,
+        taxAmount = 0.0
+      ),
+      additionalBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 45.0,
+        taxAmount = 0.0
+      )
+    ),
+    dividends = DividendsModel(
+      allowance = 0.0,
+      basicBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      higherBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      ),
+      additionalBand = BandModel(
+        taxableIncome = 0.0,
+        taxRate = 0.0,
+        taxAmount = 0.0
+      )
+    ),
+    nic = NicModel(
+      class2 = 110,
+      class4 = 13.86
+    ),
+    eoyEstimate = Some(EoyEstimate(66000.00)),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("BRT", 20.0, 132.00, 26.00),
+      TaxBandModel("HRT", 40.0, 0.00, 0.00),
+      TaxBandModel("ART", 45.0, 0.00, 0.00)
+    )
   )
 
   val busBropHRTCalcDataModel = CalculationDataModel(
@@ -359,23 +521,6 @@ object CalcBreakdownTestConstants {
       ukProperty = 7875.00,
       bankBuildingSocietyInterest = 0.00,
       ukDividends = 0.0
-    ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 8352.00,
-        taxRate = 20.0,
-        taxAmount = 1670.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 26654.00,
-        taxRate = 40.0,
-        taxAmount = 10661.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 45.0,
-        taxAmount = 0.00
-      )
     ),
     savingsAndGains = SavingsAndGainsModel(
       startBand = BandModel(
@@ -425,6 +570,11 @@ object CalcBreakdownTestConstants {
     nic = NicModel(
       class2 = 500.71,
       class4 = 896.00
+    ),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("BRT", 20.0, 8352.00, 1670.00),
+      TaxBandModel("HRT", 40.0, 26654.00, 10661.00),
+      TaxBandModel("ART", 45.0, 0.00, 0.00)
     )
   )
 
@@ -439,23 +589,6 @@ object CalcBreakdownTestConstants {
       ukProperty = 40000.00,
       bankBuildingSocietyInterest = 0.00,
       ukDividends = 0.0
-    ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 8352.00,
-        taxRate = 20.0,
-        taxAmount = 1670.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 29044.00,
-        taxRate = 40.0,
-        taxAmount = 11617.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 609.00,
-        taxRate = 45.0,
-        taxAmount = 274.00
-      )
     ),
     savingsAndGains = SavingsAndGainsModel(
       startBand = BandModel(
@@ -505,6 +638,11 @@ object CalcBreakdownTestConstants {
     nic = NicModel(
       class2 = 1000,
       class4 = 456.71
+    ),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("BRT", 20.0, 8352.00, 1670.00),
+      TaxBandModel("HRT", 40.0, 29044.00, 11617.00),
+      TaxBandModel("ART", 45.0, 609.00, 274.00)
     )
   )
 
@@ -519,23 +657,6 @@ object CalcBreakdownTestConstants {
       ukProperty = 10000.00,
       bankBuildingSocietyInterest = 1999.00,
       ukDividends = 10000.00
-    ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 20000.00,
-        taxRate = 20.0,
-        taxAmount = 4000.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 100000.00,
-        taxRate = 40.0,
-        taxAmount = 40000.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 50000.00,
-        taxRate = 45.0,
-        taxAmount = 22500.00
-      )
     ),
     savingsAndGains = SavingsAndGainsModel(
       startBand = BandModel(
@@ -586,7 +707,12 @@ object CalcBreakdownTestConstants {
       class2 = 10000.00,
       class4 = 14000.00
     ),
-    eoyEstimate = Some(EoyEstimate(66000.00))
+    eoyEstimate = Some(EoyEstimate(66000.00)),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("BRT", 20.0, 20000.00, 4000.00),
+      TaxBandModel("HRT", 40.0, 100000.00, 40000.00),
+      TaxBandModel("ART", 45.0, 50000.00, 22500.00)
+    )
   )
 
   val dividendAtHRT = CalculationDataModel(
@@ -600,23 +726,6 @@ object CalcBreakdownTestConstants {
       ukProperty = 10000.00,
       bankBuildingSocietyInterest = 1999.00,
       ukDividends = 10000.00
-    ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 20000.00,
-        taxRate = 20.0,
-        taxAmount = 4000.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 100000.00,
-        taxRate = 40.0,
-        taxAmount = 40000.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 50000.00,
-        taxRate = 45.0,
-        taxAmount = 22500.00
-      )
     ),
     savingsAndGains = SavingsAndGainsModel(
       startBand = BandModel(
@@ -667,7 +776,12 @@ object CalcBreakdownTestConstants {
       class2 = 10000.00,
       class4 = 14000.00
     ),
-    eoyEstimate = Some(EoyEstimate(66000.00))
+    eoyEstimate = Some(EoyEstimate(66000.00)),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("BRT", 20.0, 20000.00, 4000.00),
+      TaxBandModel("HRT", 40.0, 100000.00, 40000.00),
+      TaxBandModel("ART", 45.0, 50000.00, 22500.00)
+    )
   )
 
   val dividendAtART = CalculationDataModel(
@@ -681,23 +795,6 @@ object CalcBreakdownTestConstants {
       ukProperty = 10000.00,
       bankBuildingSocietyInterest = 1999.00,
       ukDividends = 10000.00
-    ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 20000.00,
-        taxRate = 20.0,
-        taxAmount = 4000.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 100000.00,
-        taxRate = 40.0,
-        taxAmount = 40000.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 50000.00,
-        taxRate = 45.0,
-        taxAmount = 22500.00
-      )
     ),
     savingsAndGains = SavingsAndGainsModel(
       startBand = BandModel(
@@ -748,7 +845,12 @@ object CalcBreakdownTestConstants {
       class2 = 10000.00,
       class4 = 14000.00
     ),
-    eoyEstimate = Some(EoyEstimate(66000.00))
+    eoyEstimate = Some(EoyEstimate(66000.00)),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("BRT", 20.0, 20000.00, 4000.00),
+      TaxBandModel("HRT", 40.0, 100000.00, 40000.00),
+      TaxBandModel("ART", 45.0, 50000.00, 22500.00)
+    )
   )
 
   val justBusinessCalcDataModel = CalculationDataModel(
@@ -762,23 +864,6 @@ object CalcBreakdownTestConstants {
       ukProperty = 0.00,
       bankBuildingSocietyInterest = 0.00,
       ukDividends = 0.0
-    ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 132.00,
-        taxRate = 20.0,
-        taxAmount = 26.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 40.0,
-        taxAmount = 0.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 45.0,
-        taxAmount = 0.00
-      )
     ),
     savingsAndGains = SavingsAndGainsModel(
       startBand = BandModel(
@@ -828,6 +913,11 @@ object CalcBreakdownTestConstants {
     nic = NicModel(
       class2 = 100.0,
       class4 = 23.86
+    ),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("BRT", 20.0, 132.00, 26.00),
+      TaxBandModel("HRT", 40.0, 0.00, 0.00),
+      TaxBandModel("ART", 45.0, 0.00, 0.00)
     )
   )
 
@@ -843,23 +933,6 @@ object CalcBreakdownTestConstants {
       bankBuildingSocietyInterest = 0.00,
       ukDividends = 0.0
     ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 132.00,
-        taxRate = 20.0,
-        taxAmount = 26.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 40.0,
-        taxAmount = 0.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 45.0,
-        taxAmount = 0.00
-      )
-    ),
     savingsAndGains = SavingsAndGainsModel(
       startBand = BandModel(
         taxableIncome = 0.00,
@@ -908,6 +981,11 @@ object CalcBreakdownTestConstants {
     nic = NicModel(
       class2 = 100.0,
       class4 = 23.86
+    ),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("BRT", 20.0, 132.00, 26.00),
+      TaxBandModel("HRT", 40.0, 0.00, 0.00),
+      TaxBandModel("ART", 45.0, 0.00, 0.00)
     )
   )
 
@@ -922,23 +1000,6 @@ object CalcBreakdownTestConstants {
       ukProperty = 3000.00,
       bankBuildingSocietyInterest = 2500.00,
       ukDividends = 0.0
-    ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 132.00,
-        taxRate = 20.0,
-        taxAmount = 26.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 40.0,
-        taxAmount = 0.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 45.0,
-        taxAmount = 0.00
-      )
     ),
     savingsAndGains = SavingsAndGainsModel(
       startBand = BandModel(
@@ -988,6 +1049,11 @@ object CalcBreakdownTestConstants {
     nic = NicModel(
       class2 = 100.0,
       class4 = 23.86
+    ),
+    payAndPensionsProfitBands = List(
+      TaxBandModel("BRT", 20.0, 132.00, 26.00),
+      TaxBandModel("HRT", 40.0, 0.00, 0.00),
+      TaxBandModel("ART", 45.0, 0.00, 0.00)
     )
   )
 
@@ -1002,23 +1068,6 @@ object CalcBreakdownTestConstants {
       ukProperty = 0.00,
       bankBuildingSocietyInterest = 0.00,
       ukDividends = 0.0
-    ),
-    payPensionsProfit = PayPensionsProfitModel(
-      basicBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 0.0,
-        taxAmount = 0.00
-      ),
-      higherBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 0.0,
-        taxAmount = 0.00
-      ),
-      additionalBand = BandModel(
-        taxableIncome = 0.00,
-        taxRate = 0.0,
-        taxAmount = 0.00
-      )
     ),
     savingsAndGains = SavingsAndGainsModel(
       startBand = BandModel(
@@ -1068,10 +1117,9 @@ object CalcBreakdownTestConstants {
     nic = NicModel(
       class2 = 0.0,
       class4 = 0.0
-    )
+    ),
+    payAndPensionsProfitBands = Nil
   )
-
-
 
   val mandatoryCalculationDataSuccessJson: JsValue = Json.obj(
     "incomeTaxYTD" -> 90500,
@@ -1090,309 +1138,337 @@ object CalcBreakdownTestConstants {
       "bankBuildingSocietyInterest" -> 1999,
       "ukDividends" -> 10000
     ),
-     "payPensionsProfit" -> Json.obj(
-       "basicBand" -> Json.obj(
-         "taxableIncome" -> 20000,
-         "taxRate" -> 20,
-         "taxAmount" -> 4000
-       ),
-       "higherBand" -> Json.obj(
-         "taxableIncome" -> 100000,
-         "taxRate" -> 40,
-         "taxAmount" -> 40000
-       ),
-       "additionalBand" -> Json.obj(
-         "taxableIncome" -> 50000,
-         "taxRate" -> 45,
-         "taxAmount" -> 22500
-       )
-     ),
-     "savingsAndGains" -> Json.obj(
-       "startBand" -> Json.obj(
-         "taxableIncome" -> 1.00,
-         "taxRate" -> 0,
-         "taxAmount" -> 0
-       ),
-       "zeroBand" -> Json.obj(
-         "taxableIncome" -> 20.00,
-         "taxRate" -> 0,
-         "taxAmount" -> 0
-       ),
-       "basicBand" -> Json.obj(
-         "taxableIncome" -> 0,
-         "taxRate" -> 20,
-         "taxAmount" -> 0
-       ),
-       "higherBand" -> Json.obj(
-         "taxableIncome" -> 0,
-         "taxRate" -> 40,
-         "taxAmount" -> 0
-       ),
-       "additionalBand" -> Json.obj(
-         "taxableIncome" -> 0,
-         "taxRate" -> 45,
-         "taxAmount" -> 0
-       )
-     ),
-     "dividends" -> Json.obj(
-       "allowance" -> 5000,
-       "basicBand" -> Json.obj(
-         "taxableIncome" -> 1000,
-         "taxRate" -> 7.5,
-         "taxAmount" -> 75
-       ),
-       "higherBand" -> Json.obj(
-         "taxableIncome" -> 2000,
-         "taxRate" -> 37.5,
-         "taxAmount" -> 750
-       ),
-       "additionalBand" -> Json.obj(
-         "taxableIncome" -> 3000,
-         "taxRate" -> 38.1,
-         "taxAmount" -> 1143
-       )
-     ),
-     "nic" -> Json.obj(
-       "class2" -> 10000,
-       "class4" -> 14000
-     ),
-     "eoyEstimate" -> Json.obj(
-       "incomeTaxNicAmount" -> 66000
-     )
+    "savingsAndGains" -> Json.obj(
+      "startBand" -> Json.obj(
+        "taxableIncome" -> 1.00,
+        "taxRate" -> 0,
+        "taxAmount" -> 0
+      ),
+      "zeroBand" -> Json.obj(
+        "taxableIncome" -> 20.00,
+        "taxRate" -> 0,
+        "taxAmount" -> 0
+      ),
+      "basicBand" -> Json.obj(
+        "taxableIncome" -> 0,
+        "taxRate" -> 20,
+        "taxAmount" -> 0
+      ),
+      "higherBand" -> Json.obj(
+        "taxableIncome" -> 0,
+        "taxRate" -> 40,
+        "taxAmount" -> 0
+      ),
+      "additionalBand" -> Json.obj(
+        "taxableIncome" -> 0,
+        "taxRate" -> 45,
+        "taxAmount" -> 0
+      )
+    ),
+    "dividends" -> Json.obj(
+      "allowance" -> 5000,
+      "basicBand" -> Json.obj(
+        "taxableIncome" -> 1000,
+        "taxRate" -> 7.5,
+        "taxAmount" -> 75
+      ),
+      "higherBand" -> Json.obj(
+        "taxableIncome" -> 2000,
+        "taxRate" -> 37.5,
+        "taxAmount" -> 750
+      ),
+      "additionalBand" -> Json.obj(
+        "taxableIncome" -> 3000,
+        "taxRate" -> 38.1,
+        "taxAmount" -> 1143
+      )
+    ),
+    "nic" -> Json.obj(
+      "class2" -> 10000,
+      "class4" -> 14000
+    ),
+    "eoyEstimate" -> Json.obj(
+      "incomeTaxNicAmount" -> 66000
+    ),
+    "incomeTax" -> Json.obj(
+      "payAndPensionsProfit" -> Json.obj(
+        "band" -> Json.arr(
+          Json.obj(
+            "name" -> "BRT",
+            "rate" -> 20.0,
+            "income" -> 20000.00,
+            "amount" -> 4000.00
+          ),
+          Json.obj(
+            "name" -> "HRT",
+            "rate" -> 40.0,
+            "income" -> 100000.00,
+            "amount" -> 40000.00
+          ),
+          Json.obj(
+            "name" -> "ART",
+            "rate" -> 45.0,
+            "income" -> 50000.00,
+            "amount" -> 22500.00
+          )
+        )
+      )
+    )
   )
 
 
   val calculationDataFullJson: JsValue = Json.obj(
-   "incomeTaxYTD" -> 90500,
-   "incomeTaxThisPeriod" -> 20,
-   "payFromAllEmployments" -> 0,
-   "totalIncomeAllowancesUsed" -> 12005,
-   "benefitsAndExpensesReceived" -> 0,
-   "allowableExpenses" -> 0,
-   "payFromAllEmploymentsAfterExpenses" -> 0,
-   "shareSchemes" -> 0,
-   "profitFromSelfEmployment" -> 200000,
-   "profitFromPartnerships" -> 0,
-   "profitFromUkLandAndProperty" -> 10000,
-   "dividendsFromForeignCompanies" -> 0,
-   "foreignIncome" -> 0,
-   "trustsAndEstates" -> 0,
-   "interestReceivedFromUkBanksAndBuildingSocieties" -> 1999,
-   "dividendsFromUkCompanies" -> 10000,
-   "ukPensionsAndStateBenefits" -> 0,
-   "gainsOnLifeInsurance" -> 0,
-   "otherIncome" -> 0,
-   "totalIncomeReceived" -> 230000,
-   "paymentsIntoARetirementAnnuity" -> 0,
-   "foreignTaxOnEstates" -> 0,
-   "incomeTaxRelief" -> 0,
-   "incomeTaxReliefReducedToMaximumAllowable" -> 0,
-   "annuities" -> 0,
-   "giftOfInvestmentsAndPropertyToCharity" -> 0,
-   "personalAllowance" -> 11500,
-   "marriageAllowanceTransfer" -> 0,
-   "blindPersonAllowance" -> 0,
-   "blindPersonSurplusAllowanceFromSpouse" -> 0,
-   "incomeExcluded" -> 0,
-   "totalIncomeOnWhichTaxIsDue" -> 198500,
-   "payPensionsExtender" -> 0,
-   "giftExtender" -> 0,
-   "extendedBR" -> 0,
-   "payPensionsProfitAtBRT" -> 20000,
-   "incomeTaxOnPayPensionsProfitAtBRT" -> 4000,
-   "payPensionsProfitAtHRT" -> 100000,
-   "incomeTaxOnPayPensionsProfitAtHRT" -> 40000,
-   "payPensionsProfitAtART" -> 50000,
-   "incomeTaxOnPayPensionsProfitAtART" -> 22500,
-   "netPropertyFinanceCosts" -> 0,
-   "interestReceivedAtStartingRate" -> 1,
-   "incomeTaxOnInterestReceivedAtStartingRate" -> 0,
-   "interestReceivedAtZeroRate" -> 20,
-   "incomeTaxOnInterestReceivedAtZeroRate" -> 0,
-   "interestReceivedAtBRT" -> 0,
-   "incomeTaxOnInterestReceivedAtBRT" -> 0,
-   "interestReceivedAtHRT" -> 0,
-   "incomeTaxOnInterestReceivedAtHRT" -> 0,
-   "interestReceivedAtART" -> 0,
-   "incomeTaxOnInterestReceivedAtART" -> 0,
-   "dividendsAtZeroRate" -> 0,
-   "incomeTaxOnDividendsAtZeroRate" -> 0,
-   "dividendsAtBRT" -> 1000,
-   "incomeTaxOnDividendsAtBRT" -> 75,
-   "dividendsAtHRT" -> 2000,
-   "incomeTaxOnDividendsAtHRT" -> 750,
-   "dividendsAtART" -> 3000,
-   "incomeTaxOnDividendsAtART" -> 1143,
-   "totalIncomeOnWhichTaxHasBeenCharged" -> 0,
-   "taxOnOtherIncome" -> 0,
-   "incomeTaxDue" -> 66500,
-   "incomeTaxCharged" -> 0,
-   "deficiencyRelief" -> 0,
-   "topSlicingRelief" -> 0,
-   "ventureCapitalTrustRelief" -> 0,
-   "enterpriseInvestmentSchemeRelief" -> 0,
-   "seedEnterpriseInvestmentSchemeRelief" -> 0,
-   "communityInvestmentTaxRelief" -> 0,
-   "socialInvestmentTaxRelief" -> 0,
-   "maintenanceAndAlimonyPaid" -> 0,
-   "marriedCouplesAllowance" -> 0,
-   "marriedCouplesAllowanceRelief" -> 0,
-   "surplusMarriedCouplesAllowance" -> 0,
-   "surplusMarriedCouplesAllowanceRelief" -> 0,
-   "notionalTaxFromLifePolicies" -> 0,
-   "notionalTaxFromDividendsAndOtherIncome" -> 0,
-   "foreignTaxCreditRelief" -> 0,
-   "incomeTaxDueAfterAllowancesAndReliefs" -> 0,
-   "giftAidPaymentsAmount" -> 0,
-   "giftAidTaxDue" -> 0,
-   "capitalGainsTaxDue" -> 0,
-   "remittanceForNonDomiciles" -> 0,
-   "highIncomeChildBenefitCharge" -> 0,
-   "totalGiftAidTaxReduced" -> 0,
-   "incomeTaxDueAfterGiftAidReduction" -> 0,
-   "annuityAmount" -> 0,
-   "taxDueOnAnnuity" -> 0,
-   "taxCreditsOnDividendsFromUkCompanies" -> 0,
-   "incomeTaxDueAfterDividendTaxCredits" -> 0,
-   "nationalInsuranceContributionAmount" -> 0,
-   "nationalInsuranceContributionCharge" -> 0,
-   "nationalInsuranceContributionSupAmount" -> 0,
-   "nationalInsuranceContributionSupCharge" -> 0,
-   "totalClass4Charge" -> 14000,
-   "nationalInsuranceClass1Amount" -> 0,
-   "nationalInsuranceClass2Amount" -> 10000,
-   "nicTotal" -> 24000,
-   "underpaidTaxForPreviousYears" -> 0,
-   "studentLoanRepayments" -> 0,
-   "pensionChargesGross" -> 0,
-   "pensionChargesTaxPaid" -> 0,
-   "totalPensionSavingCharges" -> 0,
-   "pensionLumpSumAmount" -> 0,
-   "pensionLumpSumRate" -> 0,
-   "statePensionLumpSumAmount" -> 0,
-   "remittanceBasisChargeForNonDomiciles" -> 0,
-   "additionalTaxDueOnPensions" -> 0,
-   "additionalTaxReliefDueOnPensions" -> 0,
-   "incomeTaxDueAfterPensionDeductions" -> 0,
-   "employmentsPensionsAndBenefits" -> 0,
-   "outstandingDebtCollectedThroughPaye" -> 0,
-   "payeTaxBalance" -> 0,
-   "cisAndTradingIncome" -> 0,
-   "partnerships" -> 0,
-   "ukLandAndPropertyTaxPaid" -> 0,
-   "foreignIncomeTaxPaid" -> 0,
-   "trustAndEstatesTaxPaid" -> 0,
-   "overseasIncomeTaxPaid" -> 0,
-   "interestReceivedTaxPaid" -> 0,
-   "voidISAs" -> 0,
-   "otherIncomeTaxPaid" -> 0,
-   "underpaidTaxForPriorYear" -> 0,
-   "totalTaxDeducted" -> 0,
-   "incomeTaxOverpaid" -> 0,
-   "incomeTaxDueAfterDeductions" -> 0,
-   "propertyFinanceTaxDeduction" -> 0,
-   "taxableCapitalGains" -> 0,
-   "capitalGainAtEntrepreneurRate" -> 0,
-   "incomeTaxOnCapitalGainAtEntrepreneurRate" -> 0,
-   "capitalGrainsAtLowerRate" -> 0,
-   "incomeTaxOnCapitalGainAtLowerRate" -> 0,
-   "capitalGainAtHigherRate" -> 0,
-   "incomeTaxOnCapitalGainAtHigherTax" -> 0,
-   "capitalGainsTaxAdjustment" -> 0,
-   "foreignTaxCreditReliefOnCapitalGains" -> 0,
-   "liabilityFromOffShoreTrusts" -> 0,
-   "taxOnGainsAlreadyCharged" -> 0,
-   "totalCapitalGainsTax" -> 0,
-   "incomeAndCapitalGainsTaxDue" -> 0,
-   "taxRefundedInYear" -> 0,
-   "unpaidTaxCalculatedForEarlierYears" -> 0,
-   "marriageAllowanceTransferAmount" -> 0,
-   "marriageAllowanceTransferRelief" -> 0,
-   "marriageAllowanceTransferMaximumAllowable" -> 0,
-   "nationalRegime" -> "0",
-   "allowance" -> 0,
-   "limitBRT" -> 0,
-   "limitHRT" -> 0,
-   "rateBRT" -> 20,
-   "rateHRT" -> 40,
-   "rateART" -> 45,
-   "limitAIA" -> 0,
-   "limitAIA" -> 0,
-   "allowanceBRT" -> 0,
-   "interestAllowanceHRT" -> 0,
-   "interestAllowanceBRT" -> 0,
-   "dividendAllowance" -> 5000,
-   "dividendBRT" -> 7.5,
-   "dividendHRT" -> 37.5,
-   "dividendART" -> 38.1,
-   "class2NICsLimit" -> 0,
-   "class2NICsPerWeek" -> 0,
-   "class4NICsLimitBR" -> 0,
-   "class4NICsLimitHR" -> 0,
-   "class4NICsBRT" -> 0,
-   "class4NICsHRT" -> 0,
-   "proportionAllowance" -> 11500,
-   "proportionLimitBRT" -> 0,
-   "proportionLimitHRT" -> 0,
-   "proportionalTaxDue" -> 0,
-   "proportionInterestAllowanceBRT" -> 0,
-   "proportionInterestAllowanceHRT" -> 0,
-   "proportionDividendAllowance" -> 0,
-   "proportionPayPensionsProfitAtART" -> 0,
-   "proportionIncomeTaxOnPayPensionsProfitAtART" -> 0,
-   "proportionPayPensionsProfitAtBRT" -> 0,
-   "proportionIncomeTaxOnPayPensionsProfitAtBRT" -> 0,
-   "proportionPayPensionsProfitAtHRT" -> 0,
-   "proportionIncomeTaxOnPayPensionsProfitAtHRT" -> 0,
-   "proportionInterestReceivedAtZeroRate" -> 0,
-   "proportionIncomeTaxOnInterestReceivedAtZeroRate" -> 0,
-   "proportionInterestReceivedAtBRT" -> 0,
-   "proportionIncomeTaxOnInterestReceivedAtBRT" -> 0,
-   "proportionInterestReceivedAtHRT" -> 0,
-   "proportionIncomeTaxOnInterestReceivedAtHRT" -> 0,
-   "proportionInterestReceivedAtART" -> 0,
-   "proportionIncomeTaxOnInterestReceivedAtART" -> 0,
-   "proportionDividendsAtZeroRate" -> 0,
-   "proportionIncomeTaxOnDividendsAtZeroRate" -> 0,
-   "proportionDividendsAtBRT" -> 0,
-   "proportionIncomeTaxOnDividendsAtBRT" -> 0,
-   "proportionDividendsAtHRT" -> 0,
-   "proportionIncomeTaxOnDividendsAtHRT" -> 0,
-   "proportionDividendsAtART" -> 0,
-   "proportionIncomeTaxOnDividendsAtART" -> 0,
-   "proportionClass2NICsLimit" -> 0,
-   "proportionClass4NICsLimitBR" -> 0,
-   "proportionClass4NICsLimitHR" -> 0,
-   "proportionReducedAllowanceLimit" -> 0,
-   "eoyEstimate" -> Json.obj(
-     "selfEmployment" -> Json.arr(
-       Json.obj(
-         "id" -> "selfEmploymentId1",
-         "taxableIncome" -> 89999999.99,
-         "supplied" -> true,
-         "finalised" -> true
-       ),
-       Json.obj(
-         "id" -> "selfEmploymentId2",
-         "taxableIncome" -> 89999999.99,
-         "supplied" -> true,
-         "finalised" -> true
-       )
-     ),
-     "ukProperty" -> Json.arr(
-       Json.obj(
-         "taxableIncome" -> 89999999.99,
-         "supplied" -> true,
-         "finalised" -> true
-       )
-     ),
-     "totalTaxableIncome" -> 89999999.99,
-     "incomeTaxAmount" -> 89999999.99,
-     "nic2" -> 89999999.99,
-     "nic4" -> 89999999.99,
-     "totalNicAmount" -> 9999999.99,
-     "incomeTaxNicAmount" -> 66000.00
-   )
+    "incomeTaxYTD" -> 90500.00,
+    "incomeTaxThisPeriod" -> 20.00,
+    "payFromAllEmployments" -> 0.00,
+    "totalIncomeAllowancesUsed" -> 12005.00,
+    "benefitsAndExpensesReceived" -> 0.00,
+    "allowableExpenses" -> 0.00,
+    "payFromAllEmploymentsAfterExpenses" -> 0.00,
+    "shareSchemes" -> 0.00,
+    "profitFromSelfEmployment" -> 200000.00,
+    "profitFromPartnerships" -> 0.00,
+    "profitFromUkLandAndProperty" -> 10000.00,
+    "dividendsFromForeignCompanies" -> 0.00,
+    "foreignIncome" -> 0.00,
+    "trustsAndEstates" -> 0.00,
+    "interestReceivedFromUkBanksAndBuildingSocieties" -> 1999.00,
+    "dividendsFromUkCompanies" -> 10000.00,
+    "ukPensionsAndStateBenefits" -> 0.00,
+    "gainsOnLifeInsurance" -> 0.00,
+    "otherIncome" -> 0.00,
+    "totalIncomeReceived" -> 230000.00,
+    "paymentsIntoARetirementAnnuity" -> 0.00,
+    "foreignTaxOnEstates" -> 0.00,
+    "incomeTaxRelief" -> 0.00,
+    "incomeTaxReliefReducedToMaximumAllowable" -> 0.00,
+    "annuities" -> 0.00,
+    "giftOfInvestmentsAndPropertyToCharity" -> 0.00,
+    "personalAllowance" -> 11500.00,
+    "marriageAllowanceTransfer" -> 0.00,
+    "blindPersonAllowance" -> 0.00,
+    "blindPersonSurplusAllowanceFromSpouse" -> 0.00,
+    "incomeExcluded" -> 0.00,
+    "totalIncomeOnWhichTaxIsDue" -> 198500.00,
+    "payPensionsExtender" -> 0.00,
+    "giftExtender" -> 0.00,
+    "extendedBR" -> 0.00,
+    "payPensionsProfitAtBRT" -> 20000.00,
+    "incomeTaxOnPayPensionsProfitAtBRT" -> 4000.00,
+    "payPensionsProfitAtHRT" -> 100000.00,
+    "incomeTaxOnPayPensionsProfitAtHRT" -> 40000.00,
+    "payPensionsProfitAtART" -> 50000.00,
+    "incomeTaxOnPayPensionsProfitAtART" -> 22500.00,
+    "netPropertyFinanceCosts" -> 0.00,
+    "interestReceivedAtStartingRate" -> 1.00,
+    "incomeTaxOnInterestReceivedAtStartingRate" -> 0.00,
+    "interestReceivedAtZeroRate" -> 20.00,
+    "incomeTaxOnInterestReceivedAtZeroRate" -> 0.00,
+    "interestReceivedAtBRT" -> 0.00,
+    "incomeTaxOnInterestReceivedAtBRT" -> 0.00,
+    "interestReceivedAtHRT" -> 0.00,
+    "incomeTaxOnInterestReceivedAtHRT" -> 0.00,
+    "interestReceivedAtART" -> 0.00,
+    "incomeTaxOnInterestReceivedAtART" -> 0.00,
+    "dividendsAtZeroRate" -> 0.00,
+    "incomeTaxOnDividendsAtZeroRate" -> 0.00,
+    "dividendsAtBRT" -> 1000.00,
+    "incomeTaxOnDividendsAtBRT" -> 75.00,
+    "dividendsAtHRT" -> 2000.00,
+    "incomeTaxOnDividendsAtHRT" -> 750.00,
+    "dividendsAtART" -> 3000.00,
+    "incomeTaxOnDividendsAtART" -> 1143.00,
+    "totalIncomeOnWhichTaxHasBeenCharged" -> 0.00,
+    "taxOnOtherIncome" -> 0.00,
+    "incomeTaxDue" -> 66500.00,
+    "incomeTaxCharged" -> 0.00,
+    "deficiencyRelief" -> 0.00,
+    "topSlicingRelief" -> 0.00,
+    "ventureCapitalTrustRelief" -> 0.00,
+    "enterpriseInvestmentSchemeRelief" -> 0.00,
+    "seedEnterpriseInvestmentSchemeRelief" -> 0.00,
+    "communityInvestmentTaxRelief" -> 0.00,
+    "socialInvestmentTaxRelief" -> 0.00,
+    "maintenanceAndAlimonyPaid" -> 0.00,
+    "marriedCouplesAllowance" -> 0.00,
+    "marriedCouplesAllowanceRelief" -> 0.00,
+    "surplusMarriedCouplesAllowance" -> 0.00,
+    "surplusMarriedCouplesAllowanceRelief" -> 0.00,
+    "notionalTaxFromLifePolicies" -> 0.00,
+    "notionalTaxFromDividendsAndOtherIncome" -> 0.00,
+    "foreignTaxCreditRelief" -> 0.00,
+    "incomeTaxDueAfterAllowancesAndReliefs" -> 0.00,
+    "giftAidPaymentsAmount" -> 0.00,
+    "giftAidTaxDue" -> 0.00,
+    "capitalGainsTaxDue" -> 0.00,
+    "remittanceForNonDomiciles" -> 0.00,
+    "highIncomeChildBenefitCharge" -> 0.00,
+    "totalGiftAidTaxReduced" -> 0.00,
+    "incomeTaxDueAfterGiftAidReduction" -> 0.00,
+    "annuityAmount" -> 0.00,
+    "taxDueOnAnnuity" -> 0.00,
+    "taxCreditsOnDividendsFromUkCompanies" -> 0.00,
+    "incomeTaxDueAfterDividendTaxCredits" -> 0.00,
+    "nationalInsuranceContributionAmount" -> 0.00,
+    "nationalInsuranceContributionCharge" -> 0.00,
+    "nationalInsuranceContributionSupAmount" -> 0.00,
+    "nationalInsuranceContributionSupCharge" -> 0.00,
+    "totalClass4Charge" -> 14000.00,
+    "nationalInsuranceClass1Amount" -> 0.00,
+    "nationalInsuranceClass2Amount" -> 10000.00,
+    "nicTotal" -> 24000.00,
+    "underpaidTaxForPreviousYears" -> 0.00,
+    "studentLoanRepayments" -> 0.00,
+    "pensionChargesGross" -> 0.00,
+    "pensionChargesTaxPaid" -> 0.00,
+    "totalPensionSavingCharges" -> 0.00,
+    "pensionLumpSumAmount" -> 0.00,
+    "pensionLumpSumRate" -> 0.00,
+    "statePensionLumpSumAmount" -> 0.00,
+    "remittanceBasisChargeForNonDomiciles" -> 0.00,
+    "additionalTaxDueOnPensions" -> 0.00,
+    "additionalTaxReliefDueOnPensions" -> 0.00,
+    "incomeTaxDueAfterPensionDeductions" -> 0.00,
+    "employmentsPensionsAndBenefits" -> 0.00,
+    "outstandingDebtCollectedThroughPaye" -> 0.00,
+    "payeTaxBalance" -> 0.00,
+    "cisAndTradingIncome" -> 0.00,
+    "partnerships" -> 0.00,
+    "ukLandAndPropertyTaxPaid" -> 0.00,
+    "foreignIncomeTaxPaid" -> 0.00,
+    "trustAndEstatesTaxPaid" -> 0.00,
+    "overseasIncomeTaxPaid" -> 0.00,
+    "interestReceivedTaxPaid" -> 0.00,
+    "voidISAs" -> 0.00,
+    "otherIncomeTaxPaid" -> 0.00,
+    "underpaidTaxForPriorYear" -> 0.00,
+    "totalTaxDeducted" -> 0.00,
+    "incomeTaxOverpaid" -> 0.00,
+    "incomeTaxDueAfterDeductions" -> 0.00,
+    "propertyFinanceTaxDeduction" -> 0.00,
+    "taxableCapitalGains" -> 0.00,
+    "capitalGainAtEntrepreneurRate" -> 0.00,
+    "incomeTaxOnCapitalGainAtEntrepreneurRate" -> 0.00,
+    "capitalGrainsAtLowerRate" -> 0.00,
+    "incomeTaxOnCapitalGainAtLowerRate" -> 0.00,
+    "capitalGainAtHigherRate" -> 0.00,
+    "incomeTaxOnCapitalGainAtHigherTax" -> 0.00,
+    "capitalGainsTaxAdjustment" -> 0.00,
+    "foreignTaxCreditReliefOnCapitalGains" -> 0.00,
+    "liabilityFromOffShoreTrusts" -> 0.00,
+    "taxOnGainsAlreadyCharged" -> 0.00,
+    "totalCapitalGainsTax" -> 0.00,
+    "incomeAndCapitalGainsTaxDue" -> 0.00,
+    "taxRefundedInYear" -> 0.00,
+    "unpaidTaxCalculatedForEarlierYears" -> 0.00,
+    "marriageAllowanceTransferAmount" -> 0.00,
+    "marriageAllowanceTransferRelief" -> 0.00,
+    "marriageAllowanceTransferMaximumAllowable" -> 0.00,
+    "nationalRegime" -> "0",
+    "allowance" -> 0.00,
+    "limitBRT" -> 0.00,
+    "limitHRT" -> 0.00,
+    "rateBRT" -> 20.00,
+    "rateHRT" -> 40.00,
+    "rateART" -> 45.00,
+    "limitAIA" -> 0.00,
+    "limitAIA" -> 0.00,
+    "allowanceBRT" -> 0.00,
+    "interestAllowanceHRT" -> 0.00,
+    "interestAllowanceBRT" -> 0.00,
+    "dividendAllowance" -> 5000.00,
+    "dividendBRT" -> 7.5,
+    "dividendHRT" -> 37.5,
+    "dividendART" -> 38.1,
+    "class2NICsLimit" -> 0.00,
+    "class2NICsPerWeek" -> 0.00,
+    "class4NICsLimitBR" -> 0.00,
+    "class4NICsLimitHR" -> 0.00,
+    "class4NICsBRT" -> 0.00,
+    "class4NICsHRT" -> 0.00,
+    "proportionAllowance" -> 11500.00,
+    "proportionLimitBRT" -> 0.00,
+    "proportionLimitHRT" -> 0.00,
+    "proportionalTaxDue" -> 0.00,
+    "proportionInterestAllowanceBRT" -> 0.00,
+    "proportionInterestAllowanceHRT" -> 0.00,
+    "proportionDividendAllowance" -> 0.00,
+    "proportionPayPensionsProfitAtART" -> 0.00,
+    "proportionIncomeTaxOnPayPensionsProfitAtART" -> 0.00,
+    "proportionPayPensionsProfitAtBRT" -> 0.00,
+    "proportionIncomeTaxOnPayPensionsProfitAtBRT" -> 0.00,
+    "proportionPayPensionsProfitAtHRT" -> 0.00,
+    "proportionIncomeTaxOnPayPensionsProfitAtHRT" -> 0.00,
+    "proportionInterestReceivedAtZeroRate" -> 0.00,
+    "proportionIncomeTaxOnInterestReceivedAtZeroRate" -> 0.00,
+    "proportionInterestReceivedAtBRT" -> 0.00,
+    "proportionIncomeTaxOnInterestReceivedAtBRT" -> 0.00,
+    "proportionInterestReceivedAtHRT" -> 0.00,
+    "proportionIncomeTaxOnInterestReceivedAtHRT" -> 0.00,
+    "proportionInterestReceivedAtART" -> 0.00,
+    "proportionIncomeTaxOnInterestReceivedAtART" -> 0.00,
+    "proportionDividendsAtZeroRate" -> 0.00,
+    "proportionIncomeTaxOnDividendsAtZeroRate" -> 0.00,
+    "proportionDividendsAtBRT" -> 0.00,
+    "proportionIncomeTaxOnDividendsAtBRT" -> 0.00,
+    "proportionDividendsAtHRT" -> 0.00,
+    "proportionIncomeTaxOnDividendsAtHRT" -> 0.00,
+    "proportionDividendsAtART" -> 0.00,
+    "proportionIncomeTaxOnDividendsAtART" -> 0.00,
+    "proportionClass2NICsLimit" -> 0.00,
+    "proportionClass4NICsLimitBR" -> 0.00,
+    "proportionClass4NICsLimitHR" -> 0.00,
+    "proportionReducedAllowanceLimit" -> 0.00,
+    "eoyEstimate" -> Json.obj(
+      "selfEmployment" -> Json.arr(
+        Json.obj(
+          "id" -> "selfEmploymentId1",
+          "taxableIncome" -> 89999999.99,
+          "supplied" -> true,
+          "finalised" -> true
+        ),
+        Json.obj(
+          "id" -> "selfEmploymentId2",
+          "taxableIncome" -> 89999999.99,
+          "supplied" -> true,
+          "finalised" -> true
+        )
+      ),
+      "ukProperty" -> Json.arr(
+        Json.obj(
+          "taxableIncome" -> 89999999.99,
+          "supplied" -> true,
+          "finalised" -> true
+        )
+      ),
+      "totalTaxableIncome" -> 89999999.99,
+      "incomeTaxAmount" -> 89999999.99,
+      "nic2" -> 89999999.99,
+      "nic4" -> 89999999.99,
+      "totalNicAmount" -> 9999999.99,
+      "incomeTaxNicAmount" -> 66000.00
+    ),
+    "incomeTax" -> Json.obj(
+      "payAndPensionsProfit" -> Json.obj(
+        "band" -> Json.arr(Json.obj(
+          "name" -> "BRT",
+          "rate" -> 20.0,
+          "income" -> 20000.00,
+          "amount" -> 4000.00
+        ), Json.obj(
+          "name" -> "HRT",
+          "rate" -> 40.0,
+          "income" -> 100000.00,
+          "amount" -> 40000.00
+        ), Json.obj(
+          "name" -> "ART",
+          "rate" -> 45.0,
+          "income" -> 50000.00,
+          "amount" -> 22500.00
+        )
+        )
+      )
+    )
   )
 
 

--- a/test/models/CalculationDataResponseModelSpec.scala
+++ b/test/models/CalculationDataResponseModelSpec.scala
@@ -18,7 +18,7 @@ package models
 
 import assets.BaseTestConstants._
 import assets.CalcBreakdownTestConstants._
-import models.calculation.{CalculationDataErrorModel, CalculationDataModel}
+import models.calculation.{CalculationDataErrorModel, CalculationDataModel, TaxBandModel}
 import org.scalatest.Matchers
 import play.api.libs.json.{JsSuccess, Json}
 import uk.gov.hmrc.play.test.UnitSpec
@@ -42,17 +42,11 @@ class CalculationDataResponseModelSpec extends UnitSpec with Matchers {
 
         calculationDataSuccessModel.taxReliefs shouldBe 0
 
-        calculationDataSuccessModel.payPensionsProfit.basicBand.taxableIncome shouldBe 20000
-        calculationDataSuccessModel.payPensionsProfit.basicBand.taxRate shouldBe 20
-        calculationDataSuccessModel.payPensionsProfit.basicBand.taxAmount shouldBe 4000
-
-        calculationDataSuccessModel.payPensionsProfit.higherBand.taxableIncome shouldBe 100000
-        calculationDataSuccessModel.payPensionsProfit.higherBand.taxRate shouldBe 40
-        calculationDataSuccessModel.payPensionsProfit.higherBand.taxAmount shouldBe 40000
-
-        calculationDataSuccessModel.payPensionsProfit.additionalBand.taxableIncome shouldBe 50000
-        calculationDataSuccessModel.payPensionsProfit.additionalBand.taxRate shouldBe 45
-        calculationDataSuccessModel.payPensionsProfit.additionalBand.taxAmount shouldBe 22500
+        calculationDataSuccessModel.payAndPensionsProfitBands shouldBe List(
+          TaxBandModel("BRT", 20.0, 20000.00, 4000.00),
+          TaxBandModel("HRT", 40.0, 100000.00, 40000.00),
+          TaxBandModel("ART", 45.0, 50000.00, 22500.00)
+        )
 
         calculationDataSuccessModel.savingsAndGains.startBand.taxableIncome shouldBe 1
         calculationDataSuccessModel.savingsAndGains.startBand.taxRate shouldBe 0

--- a/test/models/CalculationResponseModelSpec.scala
+++ b/test/models/CalculationResponseModelSpec.scala
@@ -55,11 +55,12 @@ class CalculationResponseModelSpec extends UnitSpec with Matchers with ImplicitD
         calculationDataSuccessModel.taxReliefs: BigDecimal,
         calculationDataSuccessModel.totalIncomeAllowancesUsed: BigDecimal,
         incomeReceived: IncomeReceivedModel,
-        calculationDataSuccessModel.payPensionsProfit,
         calculationDataSuccessModel.savingsAndGains,
         calculationDataSuccessModel.dividends,
         calculationDataSuccessModel.nic,
-        calculationDataSuccessModel.eoyEstimate)
+        calculationDataSuccessModel.eoyEstimate,
+        calculationDataSuccessModel.payAndPensionsProfitBands
+      )
 
       val calcDataModel: Option[CalculationDataModel] = Some(calculationDataModel)
 
@@ -74,16 +75,17 @@ class CalculationResponseModelSpec extends UnitSpec with Matchers with ImplicitD
         calculationDataSuccessModel.incomeReceived.ukDividends)
 
      CalculationDataModel(calculationDataSuccessModel.totalIncomeTaxNicYtd,
-        calculationDataSuccessModel.totalTaxableIncome: BigDecimal,
-        calculationDataSuccessModel.personalAllowance: BigDecimal,
-        calculationDataSuccessModel.taxReliefs: BigDecimal,
-        calculationDataSuccessModel.totalIncomeAllowancesUsed: BigDecimal,
-        incomeReceived: IncomeReceivedModel,
-        calculationDataSuccessModel.payPensionsProfit,
-        calculationDataSuccessModel.savingsAndGains,
-        calculationDataSuccessModel.dividends,
-        calculationDataSuccessModel.nic,
-        calculationDataSuccessModel.eoyEstimate)
+       calculationDataSuccessModel.totalTaxableIncome: BigDecimal,
+       calculationDataSuccessModel.personalAllowance: BigDecimal,
+       calculationDataSuccessModel.taxReliefs: BigDecimal,
+       calculationDataSuccessModel.totalIncomeAllowancesUsed: BigDecimal,
+       incomeReceived: IncomeReceivedModel,
+       calculationDataSuccessModel.savingsAndGains,
+       calculationDataSuccessModel.dividends,
+       calculationDataSuccessModel.nic,
+       calculationDataSuccessModel.eoyEstimate,
+       calculationDataSuccessModel.payAndPensionsProfitBands
+     )
 
     }
 
@@ -100,11 +102,12 @@ class CalculationResponseModelSpec extends UnitSpec with Matchers with ImplicitD
         calculationDataSuccessModel.taxReliefs: BigDecimal,
         calculationDataSuccessModel.totalIncomeAllowancesUsed: BigDecimal,
         incomeReceived: IncomeReceivedModel,
-        calculationDataSuccessModel.payPensionsProfit,
         calculationDataSuccessModel.savingsAndGains,
         calculationDataSuccessModel.dividends,
         calculationDataSuccessModel.nic,
-        calculationDataSuccessModel.eoyEstimate)
+        calculationDataSuccessModel.eoyEstimate,
+        calculationDataSuccessModel.payAndPensionsProfitBands
+      )
 
     }
 

--- a/test/views/helpers/CalcBreakdownHelperSpec.scala
+++ b/test/views/helpers/CalcBreakdownHelperSpec.scala
@@ -66,7 +66,65 @@ class CalcBreakdownHelperSpec extends TestSupport {
 
       "for users with both a property and a business" which {
 
-        "have just the basic rate of tax" should {
+        "have just the starter rate of tax" should {
+          val setup = pageSetup(scottishBandModelJustSRT, bizAndPropertyUser)
+          import setup._
+
+          val total = (
+            model.incomeReceived.selfEmployment +
+              model.incomeReceived.ukProperty +
+              model.incomeReceived.bankBuildingSocietyInterest
+            ).toCurrencyString
+
+          s"have a business profit section amount of $total" in {
+            document.getElementById("business-profit-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.businessProfit
+            document.getElementById("business-profit").text shouldBe total
+          }
+
+          s"have a personal allowance amount of ${model.personalAllowance}" in {
+            document.getElementById("personal-allowance-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.personalAllowance
+            document.getElementById("personal-allowance").text shouldBe personalAllowanceTotal
+          }
+
+          "not show the additional allowances section" in {
+            document.getElementById("additionalAllowances") shouldBe null
+          }
+
+          s"have a taxable income amount of ${model.taxableIncomeTaxIncome.toCurrencyString}" in {
+            document.getElementById("taxable-income-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.yourTaxableIncome
+            document.getElementById("taxable-income").text shouldBe model.taxableIncomeTaxIncome.toCurrencyString
+          }
+
+          s"have an Income Tax section" which {
+            val srtBand = model.payAndPensionsProfitBands.find(_.name == "SRT").get
+
+            "has the correct amount of income taxed at SRT" in {
+              document.getElementById("SRT-it-calc-heading").text shouldBe s"Income Tax (${srtBand.income.toCurrencyString} at ${srtBand.rate}%)"
+            }
+            "has the correct tax charged at SRT" in {
+              document.getElementById("SRT-amount").text shouldBe srtBand.amount.toCurrencyString
+            }
+          }
+          s"have a National Insurance Class 2 amount of ${model.nic.class2}" in {
+            document.getElementById("nic2-amount-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.nic2
+            document.getElementById("nic2-amount").text shouldBe model.nic.class2.toCurrencyString
+          }
+          s"have a National Insurance Class 4 amount of ${model.nic.class4}" in {
+            document.getElementById("nic4-amount-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.nic4
+            document.getElementById("nic4-amount").text shouldBe model.nic.class4.toCurrencyString
+          }
+          s"have a Tax reliefs amount of ${model.taxReliefs}" in {
+            document.getElementById("tax-relief-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.reliefs
+            document.getElementById("tax-relief").text shouldBe "-" + model.taxReliefs.toCurrencyString
+          }
+          s"have a total tax estimate of ${model.totalIncomeTaxNicYtd}" in {
+
+            document.getElementById("total-estimate-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.total
+            document.getElementById("total-estimate").text shouldBe model.totalIncomeTaxNicYtd.toCurrencyString
+          }
+        }
+
+        "have the basic rate of tax" should {
 
           val setup = pageSetup(busPropBRTCalcDataModel, bizAndPropertyUser)
           import setup._
@@ -92,16 +150,79 @@ class CalcBreakdownHelperSpec extends TestSupport {
           }
 
           s"have an Income Tax section" which {
+            val brtBand = model.payAndPensionsProfitBands.find(_.name == "BRT").get
+
             "has the correct amount of income taxed at BRT" in {
-              document.getElementById("brt-it-calc").text shouldBe
-                (model.payPensionsProfit.basicBand.taxableIncome + model.savingsAndGains.basicBand.taxableIncome).toCurrencyString
-            }
-            "has the correct BRT rate" in {
-              document.getElementById("brt-rate").text shouldBe model.payPensionsProfit.basicBand.taxRate.toString
+              document.getElementById("BRT-it-calc-heading").text shouldBe s"Income Tax (${brtBand.income.toCurrencyString} at ${brtBand.rate}%)"
             }
             "has the correct tax charged at BRT" in {
-              document.getElementById("brt-amount").text shouldBe
-                (model.payPensionsProfit.basicBand.taxAmount + model.savingsAndGains.basicBand.taxAmount).toCurrencyString
+              document.getElementById("BRT-amount").text shouldBe brtBand.amount.toCurrencyString
+            }
+          }
+          s"have a National Insurance Class 2 amount of ${model.nic.class2}" in {
+            document.getElementById("nic2-amount-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.nic2
+            document.getElementById("nic2-amount").text shouldBe model.nic.class2.toCurrencyString
+          }
+          s"have a National Insurance Class 4 amount of ${model.nic.class4}" in {
+            document.getElementById("nic4-amount-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.nic4
+            document.getElementById("nic4-amount").text shouldBe model.nic.class4.toCurrencyString
+          }
+          s"have a Tax reliefs amount of ${model.taxReliefs}" in {
+            document.getElementById("tax-relief-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.reliefs
+            document.getElementById("tax-relief").text shouldBe "-" + model.taxReliefs.toCurrencyString
+          }
+          s"have a total tax estimate of ${model.totalIncomeTaxNicYtd}" in {
+
+            document.getElementById("total-estimate-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.total
+            document.getElementById("total-estimate").text shouldBe model.totalIncomeTaxNicYtd.toCurrencyString
+          }
+        }
+
+        "have just the IRT rate of tax" should {
+          val setup = pageSetup(scottishBandModelIRT, bizAndPropertyUser)
+          import setup._
+
+          val total = (
+            model.incomeReceived.selfEmployment +
+              model.incomeReceived.ukProperty +
+              model.incomeReceived.bankBuildingSocietyInterest
+            ).toCurrencyString
+
+          s"have a business profit section amount of $total" in {
+            document.getElementById("business-profit-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.businessProfit
+            document.getElementById("business-profit").text shouldBe total
+          }
+
+          s"have a personal allowance amount of ${model.personalAllowance}" in {
+            document.getElementById("personal-allowance-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.personalAllowance
+            document.getElementById("personal-allowance").text shouldBe personalAllowanceTotal
+          }
+
+          "not show the additional allowances section" in {
+            document.getElementById("additionalAllowances") shouldBe null
+          }
+
+          s"have a taxable income amount of ${model.taxableIncomeTaxIncome.toCurrencyString}" in {
+            document.getElementById("taxable-income-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.yourTaxableIncome
+            document.getElementById("taxable-income").text shouldBe model.taxableIncomeTaxIncome.toCurrencyString
+          }
+
+          s"have an Income Tax section" which {
+            val irtBand = model.payAndPensionsProfitBands.find(_.name == "IRT").get
+
+            "has a SRT section" in {
+              document.getElementById("SRT-section") should not be null
+            }
+
+            "has a BRT section" in {
+              document.getElementById("BRT-section") should not be null
+            }
+
+            "has the correct amount of income taxed at IRT" in {
+              document.getElementById("IRT-it-calc-heading").text shouldBe s"Income Tax (${irtBand.income.toCurrencyString} at ${irtBand.rate}%)"
+            }
+            "has the correct tax charged at IRT" in {
+              document.getElementById("IRT-amount").text shouldBe irtBand.amount.toCurrencyString
             }
           }
           s"have a National Insurance Class 2 amount of ${model.nic.class2}" in {
@@ -125,25 +246,25 @@ class CalcBreakdownHelperSpec extends TestSupport {
 
         "have the higher rate of tax" should {
           val setup = pageSetup(busBropHRTCalcDataModel, bizAndPropertyUser)
-          import implicits.ImplicitCurrencyFormatter._
           import setup._
 
           s"have an Income Tax section" which {
+
+            val hrtBand = model.payAndPensionsProfitBands.find(_.name == "HRT").get
+
+            "has a SRT section" in {
+              document.getElementById("BRT-section") should not be null
+            }
+
             "has a BRT section" in {
-              document.getElementById("brt-section") should not be null
+              document.getElementById("BRT-section") should not be null
             }
 
             "has the correct amount of income taxed at HRT" in {
-              document.getElementById("hrt-it-calc").text shouldBe
-                (model.payPensionsProfit.higherBand.taxableIncome + model.savingsAndGains.higherBand.taxableIncome).toCurrencyString
-            }
-            "has the correct HRT rate" in {
-              document.getElementById("hrt-rate").text shouldBe model.payPensionsProfit.higherBand.taxRate.toString
+              document.getElementById("HRT-it-calc-heading").text shouldBe s"Income Tax (${hrtBand.income.toCurrencyString} at ${hrtBand.rate}%)"
             }
             "has the correct tax charged at HRT" in {
-              document.getElementById("hrt-amount").text shouldBe
-                (model.payPensionsProfit.higherBand.taxAmount + model.savingsAndGains.higherBand.taxAmount).toCurrencyString
-
+              document.getElementById("HRT-amount").text shouldBe hrtBand.amount.toCurrencyString
             }
 
             "does not have an ART section" in {
@@ -154,26 +275,48 @@ class CalcBreakdownHelperSpec extends TestSupport {
 
         "have the additional rate of tax" should {
           val setup = pageSetup(busPropARTCalcDataModel, bizAndPropertyUser)
-          import implicits.ImplicitCurrencyFormatter._
           import setup._
+
           s"have an Income Tax section" which {
+
+            val artBand = model.payAndPensionsProfitBands.find(_.name == "ART").get
+
             "has a BRT section" in {
-              document.getElementById("brt-section") should not be null
+              document.getElementById("BRT-section") should not be null
             }
             "has a HRT section" in {
-              document.getElementById("hrt-section") should not be null
+              document.getElementById("HRT-section") should not be null
             }
 
             "has the correct amount of income taxed at ART" in {
-              document.getElementById("art-it-calc").text shouldBe
-                (model.payPensionsProfit.additionalBand.taxableIncome + model.savingsAndGains.additionalBand.taxableIncome).toCurrencyString
-            }
-            "has the correct ART rate" in {
-              document.getElementById("art-rate").text shouldBe model.payPensionsProfit.additionalBand.taxRate.toString
+              document.getElementById("ART-it-calc-heading").text shouldBe s"Income Tax (${artBand.income.toCurrencyString} at ${artBand.rate}%)"
             }
             "has the correct tax charged at ART" in {
-              document.getElementById("art-amount").text shouldBe
-                (model.payPensionsProfit.additionalBand.taxAmount + model.savingsAndGains.additionalBand.taxAmount).toCurrencyString
+              document.getElementById("ART-amount").text shouldBe artBand.amount.toCurrencyString
+            }
+          }
+        }
+
+        "have all the tax bands including scotish" should {
+          val setup = pageSetup(scottishBandModelAllIncomeBands, bizAndPropertyUser)
+          import setup._
+
+          s"have an Income Tax section" which {
+
+            "has a SRT section" in {
+              document.getElementById("SRT-section") should not be null
+            }
+            "has a BRT section" in {
+              document.getElementById("BRT-section") should not be null
+            }
+            "has a IRT section" in {
+              document.getElementById("IRT-section") should not be null
+            }
+            "has a HRT section" in {
+              document.getElementById("HRT-section") should not be null
+            }
+            "has a ART section" in {
+              document.getElementById("ART-section") should not be null
             }
           }
         }


### PR DESCRIPTION
Updated to receive and use new structure for income tax bands
Changed how income tax bands were displayed to allow any number of bands
Updated with new tests for scottish rates with SRT and IRT