### PR TITLE
Mit 32:User Subject to Non-UK Rates of Income Tax

### DIFF
--- a/app/models/calculation/CalculationDataResponseModel.scala
+++ b/app/models/calculation/CalculationDataResponseModel.scala
@@ -17,6 +17,7 @@
 package models.calculation
 
 import models._
+import play.api.Logger
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
 import play.api.libs.json.{Json, _}
@@ -91,8 +92,13 @@ case class EoyEstimate(incomeTaxNicAmount: BigDecimal)
 
 object CalculationDataModel {
   val defaultZero: JsPath => Reads[BigDecimal] = _.read[BigDecimal].orElse(Reads.pure[BigDecimal](0.00))
+  val logFieldError: JsPath => Reads[Option[String]] = _.readNullable[String] map {
+    case None => Logger.error(s"[CalculationDataResponseModel][CalculationDataModel] - National Regime field is missing from json");None
+    case data => data
+  }
+
   implicit val reads: Reads[CalculationDataModel] = (
-    (__ \ "nationalRegime").readNullable[String] and
+    logFieldError(__ \ "nationalRegime") and
     defaultZero(__ \ "totalIncomeOnWhichTaxIsDue") and
       (__ \ "incomeTaxYTD").read[BigDecimal] and
       defaultZero(__ \ "proportionAllowance") and

--- a/app/models/calculation/CalculationDataResponseModel.scala
+++ b/app/models/calculation/CalculationDataResponseModel.scala
@@ -24,6 +24,7 @@ import play.api.libs.json.{Json, _}
 sealed trait CalculationDataResponseModel
 
 case class CalculationDataModel(
+                                 nationalRegime: Option[String] = None,
                                  totalTaxableIncome: BigDecimal,
                                  totalIncomeTaxNicYtd: BigDecimal,
                                  personalAllowance: BigDecimal,
@@ -95,6 +96,7 @@ case class EoyEstimate(incomeTaxNicAmount: BigDecimal)
 object CalculationDataModel {
   val defaultZero: JsPath => Reads[BigDecimal] = _.read[BigDecimal].orElse(Reads.pure[BigDecimal](BigDecimal(0)))
   implicit val reads: Reads[CalculationDataModel] = (
+    (__ \ "nationalRegime").readNullable[String] and
     defaultZero(__ \ "totalIncomeOnWhichTaxIsDue") and
       (__ \ "incomeTaxYTD").read[BigDecimal] and
       defaultZero(__ \ "proportionAllowance") and

--- a/app/views/helpers/calcBreakdownHelper.scala.html
+++ b/app/views/helpers/calcBreakdownHelper.scala.html
@@ -25,6 +25,12 @@
     <table class="itvc-table">
         <tbody>
 
+        @if(breakdown.nationalRegime.nonEmpty){
+            <tr id="national-regime-section"  class="no-border-bottom">
+                <td id="national-regime-heading">@messages("estimated_tax_liability.calc-breakdown.nationalRegime")</td>
+                <td id="national-regime" class="summary-data">@breakdown.nationalRegime</td>
+            </tr>
+        }
         <tr id="business-profit-section" class="no-border-bottom">
             <td id="business-profit-heading">
                 @{

--- a/conf/messages
+++ b/conf/messages
@@ -80,6 +80,7 @@ estimated_tax_liability.inYearEstimate.whyThisMayChange.p1      = Your estimates
 estimated_tax_liability.inYearEstimate.whyThisMayChange.bullet1 = rates and allowances will not be applied in full until the end of the tax year
 estimated_tax_liability.inYearEstimate.whyThisMayChange.bullet2 = you may earn more money
 estimated_tax_liability.inYearEstimate.whyThisMayChange.bullet3 = you may have income that is not reported in your accounting software
+estimated_tax_liability.calc-breakdown.nationalRegime           = National Regime
 
 ## ReportDeadlines Page ##
 obligations.title                                               = Report deadlines

--- a/test/assets/CalcBreakdownTestConstants.scala
+++ b/test/assets/CalcBreakdownTestConstants.scala
@@ -269,6 +269,7 @@ object CalcBreakdownTestConstants {
 
 
   val busPropBRTCalcDataModel = CalculationDataModel(
+    nationalRegime = Some("Scotland"),
     totalIncomeTaxNicYtd = 149.86,
     totalTaxableIncome = 132.00,
     personalAllowance = 2868.00,

--- a/test/assets/CalcBreakdownTestConstants.scala
+++ b/test/assets/CalcBreakdownTestConstants.scala
@@ -26,6 +26,7 @@ import play.api.libs.json.{JsValue, Json}
 object CalcBreakdownTestConstants {
 
   val calculationDataSuccessModel = CalculationDataModel(
+    nationalRegime = Some("UK"),
     totalIncomeTaxNicYtd = 90500.00,
     totalTaxableIncome = 198500.00,
     personalAllowance = 11500.00,
@@ -1079,6 +1080,7 @@ object CalcBreakdownTestConstants {
   )
 
   val calculationDataSuccessJson: JsValue = Json.obj(
+    "nationalRegime" -> "UK",
     "totalTaxableIncome" -> 198500,
     "totalIncomeTaxNicYtd" -> 90500,
     "personalAllowance" -> 11500,
@@ -1161,8 +1163,8 @@ object CalcBreakdownTestConstants {
      )
   )
 
-
   val calculationDataFullJson: JsValue = Json.obj(
+    "nationalRegime" -> "UK",
    "incomeTaxYTD" -> 90500,
    "incomeTaxThisPeriod" -> 20,
    "payFromAllEmployments" -> 0,
@@ -1309,7 +1311,6 @@ object CalcBreakdownTestConstants {
    "marriageAllowanceTransferAmount" -> 0,
    "marriageAllowanceTransferRelief" -> 0,
    "marriageAllowanceTransferMaximumAllowable" -> 0,
-   "nationalRegime" -> "0",
    "allowance" -> 0,
    "limitBRT" -> 0,
    "limitHRT" -> 0,

--- a/test/assets/Messages.scala
+++ b/test/assets/Messages.scala
@@ -91,6 +91,7 @@ object Messages {
       val p1: String => String = calcDate => s"This is for 6 April ${taxYear-1} to $calcDate."
       object CalculationBreakdown {
         val heading = "How we calculated this estimate"
+        val nationalRegime = "National Regime"
         val businessProfit = "Business profit"
         val propertyProfit = "Property profit"
         val personalAllowance = "Personal Allowance (for period reported)"

--- a/test/models/CalculationResponseModelSpec.scala
+++ b/test/models/CalculationResponseModelSpec.scala
@@ -49,7 +49,8 @@ class CalculationResponseModelSpec extends UnitSpec with Matchers with ImplicitD
         bankBuildingSocietyInterest,
         calculationDataSuccessModel.incomeReceived.ukDividends)
 
-      val calculationDataModel = CalculationDataModel(calculationDataSuccessModel.totalIncomeTaxNicYtd,
+      val calculationDataModel = CalculationDataModel(calculationDataSuccessModel.nationalRegime,
+        calculationDataSuccessModel.totalIncomeTaxNicYtd,
         calculationDataSuccessModel.totalTaxableIncome: BigDecimal,
         calculationDataSuccessModel.personalAllowance: BigDecimal,
         calculationDataSuccessModel.taxReliefs: BigDecimal,
@@ -73,7 +74,8 @@ class CalculationResponseModelSpec extends UnitSpec with Matchers with ImplicitD
         calculationDataSuccessModel.incomeReceived.bankBuildingSocietyInterest,
         calculationDataSuccessModel.incomeReceived.ukDividends)
 
-     CalculationDataModel(calculationDataSuccessModel.totalIncomeTaxNicYtd,
+     CalculationDataModel(calculationDataSuccessModel.nationalRegime,
+        calculationDataSuccessModel.totalIncomeTaxNicYtd,
         calculationDataSuccessModel.totalTaxableIncome: BigDecimal,
         calculationDataSuccessModel.personalAllowance: BigDecimal,
         calculationDataSuccessModel.taxReliefs: BigDecimal,
@@ -94,7 +96,8 @@ class CalculationResponseModelSpec extends UnitSpec with Matchers with ImplicitD
         calculationDataSuccessModel.incomeReceived.bankBuildingSocietyInterest,
         calculationDataSuccessModel.incomeReceived.ukDividends)
 
-      CalculationDataModel(calculationDataSuccessModel.totalIncomeTaxNicYtd,
+      CalculationDataModel(calculationDataSuccessModel.nationalRegime,
+        calculationDataSuccessModel.totalIncomeTaxNicYtd,
         calculationDataSuccessModel.totalTaxableIncome: BigDecimal,
         calculationDataSuccessModel.personalAllowance: BigDecimal,
         calculationDataSuccessModel.taxReliefs: BigDecimal,

--- a/test/views/helpers/CalcBreakdownHelperSpec.scala
+++ b/test/views/helpers/CalcBreakdownHelperSpec.scala
@@ -72,6 +72,11 @@ class CalcBreakdownHelperSpec extends TestSupport {
           import setup._
           val total = (model.incomeReceived.selfEmployment + model.incomeReceived.ukProperty + model.incomeReceived.bankBuildingSocietyInterest).toCurrencyString
 
+          s"have a national regime section" in {
+            document.getElementById("national-regime-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.nationalRegime
+            document.getElementById("national-regime").text shouldBe "Scotland"
+          }
+
           s"have a business profit section amount of $total" in {
             document.getElementById("business-profit-heading").text shouldBe messages.InYearEstimate.CalculationBreakdown.businessProfit
             document.getElementById("business-profit").text shouldBe total


### PR DESCRIPTION
User should be able to see national Regime on estimate page
Add new attribute national regime to model and display it on UI and fix model and UI tests