### PR TITLE
Display latest obligation deadline and links

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -18,25 +18,28 @@ package controllers
 
 import javax.inject.{Inject, Singleton}
 
-import auth.MtdItUserWithNino
 import config.{FrontendAppConfig, ItvcHeaderCarrierForPartialsConverter}
-import controllers.predicates.{AuthenticationPredicate, NinoPredicate, SessionTimeoutPredicate}
+import controllers.predicates.{AuthenticationPredicate, IncomeSourceDetailsPredicate, NinoPredicate, SessionTimeoutPredicate}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
+import services.ReportDeadlinesService
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
-
-import scala.concurrent.Future
 
 @Singleton
 class HomeController @Inject()(val checkSessionTimeout: SessionTimeoutPredicate,
                                val authenticate: AuthenticationPredicate,
                                val retrieveNino: NinoPredicate,
+                               val retrieveIncomeSources: IncomeSourceDetailsPredicate,
+                               val reportDeadlinesService: ReportDeadlinesService,
                                val itvcHeaderCarrierForPartialsConverter: ItvcHeaderCarrierForPartialsConverter,
                                implicit val config: FrontendAppConfig,
                                val messagesApi: MessagesApi) extends FrontendController with I18nSupport {
 
-  val home: Action[AnyContent] = (checkSessionTimeout andThen authenticate andThen retrieveNino).async {
-    implicit user => Future.successful(Ok(views.html.home()))
+  val home: Action[AnyContent] = (checkSessionTimeout andThen authenticate andThen retrieveNino andThen retrieveIncomeSources).async {
+    implicit user =>
+      reportDeadlinesService.getNextDeadlineDueDate(user.incomeSources).map { latestDeadlineDate =>
+        Ok(views.html.home(latestDeadlineDate))
+      }
   }
 
 }

--- a/app/views/home.scala.html
+++ b/app/views/home.scala.html
@@ -14,15 +14,16 @@
  * limitations under the License.
  *@
 
-@import views.html.templates.main_template
+@import java.time.LocalDate
+
 @import implicits.ImplicitCurrencyFormatter._
 @import implicits.ImplicitDateFormatter._
-@import views.html.helpers.accordionHelper
 @import models.core.breadcrumb.{Breadcrumb, BreadcrumbItem}
+@import views.html.templates.main_template
 @import views.helpers.EstimatesPage
-@import views.html.helpers.{calcBreakdownHelper, breadcrumbHelper}
+@import views.html.helpers.{calcBreakdownHelper, breadcrumbHelper, accordionHelper}
 
-@()(implicit request: Request[_], messages: Messages, appConfig: config.FrontendAppConfig, user: auth.MtdItUserWithNino[_])
+@(nextUpdate: LocalDate)(implicit request: Request[_], messages: Messages, appConfig: config.FrontendAppConfig, user: auth.MtdItUser[_])
 
 @breadcrumb = {
     @breadcrumbHelper(Breadcrumb(Vector(
@@ -46,6 +47,39 @@
         </header>
 
         <div class="flex-container grid-row">
+            <div class="column-half">
+                <div id="updates-card" class="card">
+                    <div class="card-header">
+                        <h3 id="updates-card-heading" class="heading-small">
+                            @messages("home.updates.heading")
+                        </h3>
+                    </div>
+                    <div class="card-content">
+                        <h3 class="heading-large">
+                            <span id="updates-card-body-heading" class="heading-secondary">@messages("home.updates.body.heading")</span>
+                            <span id="updates-card-body-date">@{nextUpdate.toLongDate}<span>
+                        </h3>
+                        @if(appConfig.features.reportDeadlinesEnabled()){
+                        <p>
+                            <a id="deadlines-link" data-journey-click="HomePage:ClickLink:ViewYourDeadlines" href="@{controllers.routes.ReportDeadlinesController.getReportDeadlines().url}">
+                                @messages("home.updates.body.updatesLink")
+                            </a>
+                        </p>
+                        }
+                        <hr>
+                        @if(appConfig.features.estimatesEnabled()){
+                        <p>
+                            <a id="estimates-link" data-journey-click="HomePage:ClickLink:ViewYourEstimates" href="@{controllers.routes.EstimatesController.viewEstimateCalculations().url}">
+                                @messages("home.updates.body.estimatesLink")
+                            </a>
+                        </p>
+                        }
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="flex-container grid-row">
 
             @if(appConfig.features.billsEnabled()){
                 <div id="bills-section" class="column-one-half">
@@ -57,32 +91,6 @@
                         </a>
                     </h3>
                     <p id="bills-text">@messages("home.bills.text")</p>
-                </div>
-            }
-
-            @if(appConfig.features.estimatesEnabled()){
-            <div id="estimates-section" class="column-one-half">
-                <h3 id="estimates-heading" class="heading-small">
-                    <a id="estimates-link"
-                       data-journey-click="HomePage:ClickLink:ViewYourEstimates"
-                       href="@{controllers.routes.EstimatesController.viewEstimateCalculations().url}">
-                        @messages("home.estimates.heading")
-                    </a>
-                </h3>
-                <p id="estimates-text">@messages("home.estimates.text")</p>
-            </div>
-            }
-
-            @if(appConfig.features.reportDeadlinesEnabled()){
-                <div id="deadlines-section" class="column-one-half">
-                    <h3 id="deadlines-heading" class="heading-small">
-                        <a id="deadlines-link"
-                           data-journey-click="HomePage:ClickLink:ViewYourDeadlines"
-                           href="@{controllers.routes.ReportDeadlinesController.getReportDeadlines().url}">
-                            @messages("home.deadlines.heading")
-                        </a>
-                    </h3>
-                    <p id="deadlines-text">@messages("home.deadlines.text")</p>
                 </div>
             }
 

--- a/conf/messages
+++ b/conf/messages
@@ -21,14 +21,15 @@ home.heading                                                    = Income Tax
 home.unique.tax.reference                                       = Unique Tax Reference
 home.bills.heading                                              = Bills
 home.bills.text                                                 = View your current and previous Income Tax bills.
-home.estimates.heading                                          = Estimates
-home.estimates.text                                             = Check what you might owe, based on figures you have submitted.
-home.deadlines.heading                                          = Report deadlines
-home.deadlines.text                                             = Check when your reports are due.
 home.statements.heading                                         = Statements
 home.statements.text                                            = View your Income Tax transactions, including charges and payments.
 home.accounts.heading                                           = Account details
 home.accounts.text                                              = See contact information and other details we have for your businesses.
+
+home.updates.heading                                            = Updates
+home.updates.body.heading                                       = Next update due
+home.updates.body.updatesLink                                   = View details for updates
+home.updates.body.estimatesLink                                 = Estimates
 
 ## Recruitment Banner ##
 banner.recruitment.text                                         = Help improve this service

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -21,14 +21,12 @@ home.heading                                                    = Treth Incwm
 home.unique.tax.reference                                       = Cyfeirnod Treth Unigryw
 home.bills.heading                                              = Billau
 home.bills.text                                                 = Gweld eich biliau Treth Incwm presennol a blaenorol.
-home.estimates.heading                                          = Amcangyfrifon
-home.estimates.text                                             = Gwirio''r swm y gallai fod arnoch, yn seiliedig ar y ffigurau rydych wedi''u cyflwyno.
-home.deadlines.heading                                          = Dyddiadau cau ar gyfer adroddiadau
-home.deadlines.text                                             = Gwirio erbyn pryd y dylech gyflwyno''ch adroddiadau.
 home.statements.heading                                         = Datganiadau
 home.statements.text                                            = Bwrw golwg ar eich trafodiadau Treth Incwm, gan gynnwys costau a thaliadau.
 home.accounts.heading                                           = Manylion y cyfrif
 home.accounts.text                                              = Gweld y manylion cyswllt a''r manylion eraill sydd gennym ar gyfer eich busnesau.
+
+home.updates.body.estimatesLink                                 = Amcangyfrifon
 
 ## Recruitment Banner ##
 banner.recruitment.text                                         = Helpu i wella''r gwasanaeth hwn

--- a/it/assets/ReportDeadlinesIntegrationTestConstants.scala
+++ b/it/assets/ReportDeadlinesIntegrationTestConstants.scala
@@ -85,6 +85,8 @@ object ReportDeadlinesIntegrationTestConstants {
   val singleObligationEnd = "2017-07-05"
   val singleObligationDue = "2018-01-01"
 
+  val overdueDate: LocalDate = LocalDate.now().minusDays(1)
+
   val singleObligationQuarterlyReturnModel = ReportDeadlinesModel(List(
     ReportDeadlineModel(
       start = singleObligationStart,
@@ -94,11 +96,22 @@ object ReportDeadlinesIntegrationTestConstants {
     )
   ))
 
+  val veryOverdueDate: LocalDate = LocalDate.of(2017, 5, 5)
+
+  val singleObligationCrystallisationModel = ReportDeadlinesModel(List(
+    ReportDeadlineModel(
+      start = singleObligationStart,
+      end = singleObligationEndQuarter,
+      due = veryOverdueDate,
+      periodKey = "periodKey"
+    )
+  ))
+
   val singleObligationOverdueModel = ReportDeadlinesModel(List(
     ReportDeadlineModel(
       start = singleObligationStart,
       end = singleObligationEnd,
-      due = LocalDate.now().minusDays(1),
+      due = overdueDate,
       periodKey = "periodKey"
     )
   ))

--- a/test/assets/ReportDeadlinesTestConstants.scala
+++ b/test/assets/ReportDeadlinesTestConstants.scala
@@ -48,6 +48,13 @@ object ReportDeadlinesTestConstants extends ImplicitDateFormatter {
     periodKey = "#003"
   ))
 
+  val crystallisedObligation = fakeReportDeadlinesModel(ReportDeadlineModel(
+    start = "2017-2-1",
+    end = "2018-1-31",
+    due = "2018-1-31",
+    periodKey = "Crystallisation"
+  ))
+
   val secondQuarterlyObligation = fakeReportDeadlinesModel(ReportDeadlineModel(
     start = "2017-10-1",
     end = "2017-12-30",
@@ -109,6 +116,9 @@ object ReportDeadlinesTestConstants extends ImplicitDateFormatter {
 
 
   val obligationsEOPSDataSuccessModel: ReportDeadlinesModel = ReportDeadlinesModel(List(overdueEOPSObligation, openEOPSObligation))
+
+  val obligationsCrystallisedSuccessModel: ReportDeadlinesModel = ReportDeadlinesModel(List(crystallisedObligation))
+  val obligationsCrystallisedEmptySuccessModel: ReportDeadlinesModel = ReportDeadlinesModel(List())
 
   val reportDeadlineEOPSOverdueJson: JsValue = Json.obj(
     "start" -> "2017-04-06",

--- a/test/services/ReportDeadlinesServiceSpec.scala
+++ b/test/services/ReportDeadlinesServiceSpec.scala
@@ -16,12 +16,14 @@
 
 package services
 
+import java.time.LocalDate
+
 import assets.BaseTestConstants._
 import assets.BusinessDetailsTestConstants.{obligationsDataSuccessModel => _, _}
 import assets.IncomeSourceDetailsTestConstants._
 import assets.IncomeSourcesWithDeadlinesTestConstants._
 import assets.PropertyDetailsTestConstants.{propertyDetails, propertyIncomeModel}
-import assets.ReportDeadlinesTestConstants._
+import assets.ReportDeadlinesTestConstants.{obligationsCrystallisedSuccessModel, _}
 import mocks.connectors.MockIncomeTaxViewChangeConnector
 import models.incomeSourcesWithDeadlines._
 import testUtils.TestSupport
@@ -29,6 +31,80 @@ import testUtils.TestSupport
 class ReportDeadlinesServiceSpec extends TestSupport with MockIncomeTaxViewChangeConnector {
 
   object TestReportDeadlinesService extends ReportDeadlinesService(mockIncomeTaxViewChangeConnector)
+
+  class Setup extends ReportDeadlinesService(mockIncomeTaxViewChangeConnector)
+
+  "getNextDeadlineDueDate" should {
+    "return the next report deadline due date" when {
+      "there are income sources from property, business with crystallisation" in new Setup {
+        setupMockReportDeadlines(testSelfEmploymentId)(obligationsDataSuccessModel)
+        setupMockReportDeadlines(testPropertyIncomeId)(obligationsEOPSDataSuccessModel)
+        setupMockReportDeadlines(testNino)(obligationsCrystallisedSuccessModel)
+
+        await(getNextDeadlineDueDate(businessAndPropertyAligned)) shouldBe LocalDate.of(2017, 10, 1)
+      }
+      "there is just one report deadline from property" in new Setup {
+        setupMockReportDeadlines(testPropertyIncomeId)(obligationsEOPSDataSuccessModel)
+        setupMockReportDeadlines(testNino)(obligationsCrystallisedEmptySuccessModel)
+
+        await(getNextDeadlineDueDate(propertyIncomeOnly)) shouldBe LocalDate.of(2017, 10, 1)
+      }
+      "there is just one report deadline from business" in new Setup {
+        setupMockReportDeadlines(testSelfEmploymentId)(obligationsDataSuccessModel)
+        setupMockReportDeadlines(testNino)(obligationsCrystallisedEmptySuccessModel)
+
+        await(getNextDeadlineDueDate(singleBusinessIncome)) shouldBe LocalDate.of(2017, 10, 30)
+      }
+      "there is just a crystallisation deadline" in new Setup {
+        setupMockReportDeadlines(testNino)(obligationsCrystallisedSuccessModel)
+
+        await(getNextDeadlineDueDate(noIncomeDetails)) shouldBe LocalDate.of(2018, 1, 31)
+      }
+      "one of the report deadlines returned back an error model" in new Setup {
+        setupMockReportDeadlines(testSelfEmploymentId)(obligationsDataSuccessModel)
+        setupMockReportDeadlines(testSelfEmploymentId2)(obligationsDataSuccessModel)
+        setupMockReportDeadlines(testPropertyIncomeId)(obligationsDataErrorModel)
+        setupMockReportDeadlines(testNino)(obligationsCrystallisedEmptySuccessModel)
+
+        await(getNextDeadlineDueDate(businessesAndPropertyIncome)) shouldBe LocalDate.of(2017, 10, 30)
+      }
+    }
+  }
+
+  "getAllDeadlines" should {
+    "return all the deadlines for any property and business income sources with crystallisation" in new Setup {
+      setupMockReportDeadlines(testSelfEmploymentId)(obligationsDataSuccessModel)
+      setupMockReportDeadlines(testPropertyIncomeId)(obligationsEOPSDataSuccessModel)
+      setupMockReportDeadlines(testNino)(obligationsCrystallisedSuccessModel)
+
+      await(getAllDeadlines(businessAndPropertyAligned)) shouldBe obligationsDataSuccessModel.obligations ++
+        obligationsEOPSDataSuccessModel.obligations ++
+        obligationsCrystallisedSuccessModel.obligations
+    }
+    "return only the non errored deadlines for any property and business income sources with crystallisation" when {
+      "property is errored" in new Setup {
+        setupMockReportDeadlines(testSelfEmploymentId)(obligationsDataSuccessModel)
+        setupMockReportDeadlines(testPropertyIncomeId)(obligationsDataErrorModel)
+        setupMockReportDeadlines(testNino)(obligationsCrystallisedSuccessModel)
+
+        await(getAllDeadlines(businessAndPropertyAligned)) shouldBe obligationsDataSuccessModel.obligations ++ obligationsCrystallisedSuccessModel.obligations
+      }
+      "business is errored" in new Setup {
+        setupMockReportDeadlines(testSelfEmploymentId)(obligationsDataErrorModel)
+        setupMockReportDeadlines(testPropertyIncomeId)(obligationsDataSuccessModel)
+        setupMockReportDeadlines(testNino)(obligationsCrystallisedSuccessModel)
+
+        await(getAllDeadlines(businessAndPropertyAligned)) shouldBe obligationsDataSuccessModel.obligations ++ obligationsCrystallisedSuccessModel.obligations
+      }
+      "crystallisation is errored" in new Setup {
+        setupMockReportDeadlines(testSelfEmploymentId)(obligationsDataSuccessModel)
+        setupMockReportDeadlines(testPropertyIncomeId)(obligationsEOPSDataSuccessModel)
+        setupMockReportDeadlines(testNino)(obligationsDataErrorModel)
+
+        await(getAllDeadlines(businessAndPropertyAligned)) shouldBe obligationsDataSuccessModel.obligations ++ obligationsEOPSDataSuccessModel.obligations
+      }
+    }
+  }
 
   "The ReportDeadlinesService.getReportDeadlines method" when {
 


### PR DESCRIPTION
Updated home page with updates section containing:
- next update due date
- link to the updates page
- link to estimates page

Removed the links added to the updates section from the rest of the page