### PR TITLE
MISUV-1394: Remove the Enable Report Deadlines Feature switch

### DIFF
--- a/app/config/featureswitch/FeatureSwitch.scala
+++ b/app/config/featureswitch/FeatureSwitch.scala
@@ -28,7 +28,6 @@ object FeatureSwitch {
 
   val switches: Set[FeatureSwitch] = Set(
     Payment,
-    ReportDeadlines,
     ObligationsPage,
     IncomeBreakdown,
     DeductionBreakdown,
@@ -55,11 +54,6 @@ object FeatureSwitch {
 case object Payment extends FeatureSwitch {
   override val name = s"$prefix.enable-payment"
   override val displayText = "Enable Payment functionality"
-}
-
-case object ReportDeadlines extends FeatureSwitch {
-  override val name = s"$prefix.enable-report-deadlines"
-  override val displayText = "Enable Report Deadlines Feature"
 }
 
 case object ObligationsPage extends FeatureSwitch {

--- a/app/config/featureswitch/FeatureSwitching.scala
+++ b/app/config/featureswitch/FeatureSwitching.scala
@@ -33,4 +33,11 @@ trait FeatureSwitching  {
 
   def disable(featureSwitch: FeatureSwitch): Unit =
     sys.props += featureSwitch.name -> FEATURE_SWITCH_OFF
+
+  protected implicit class FeatureOps(feature: FeatureSwitch) {
+    def fold[T](ifEnabled: => T, ifDisabled: => T): T = {
+      if (isEnabled(feature)) ifEnabled
+      else ifDisabled
+    }
+  }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -153,7 +153,6 @@ microservice {
 
 feature-switch {
   enable-payment = true
-  enable-report-deadlines = true
   enable-obligations-page = false
   enable-calculation-income-breakdown = false
   enable-calculation-deduction-breakdown = false

--- a/it/controllers/ReportDeadlinesControllerISpec.scala
+++ b/it/controllers/ReportDeadlinesControllerISpec.scala
@@ -17,13 +17,12 @@ package controllers
 
 import assets.BaseIntegrationTestConstants._
 import assets.IncomeSourceIntegrationTestConstants._
-import assets.ReportDeadlinesIntegrationTestConstants._
 import assets.PreviousObligationsIntegrationTestConstants._
+import assets.ReportDeadlinesIntegrationTestConstants._
 import assets.messages.{ReportDeadlinesMessages => obligationsMessages}
-import config.featureswitch.{FeatureSwitching, ObligationsPage, ReportDeadlines}
+import config.featureswitch.ObligationsPage
 import helpers.ComponentSpecBase
 import helpers.servicemocks.IncomeTaxViewChangeStub
-import implicits.ImplicitDateFormatter
 import models.reportDeadlines.ObligationsModel
 import play.api.http.Status._
 
@@ -31,14 +30,12 @@ class ReportDeadlinesControllerISpec extends ComponentSpecBase {
 
   "Calling the ReportDeadlinesController" when {
 
-    "the ReportDeadlines Feature is enabled" when {
-
       unauthorisedTest("/obligations")
 
       "the obligations feature switch is enabled" when {
 
         "the user has a eops property income obligation only and no previous obligations" in {
-          enable(ReportDeadlines)
+          enable(ObligationsPage)
 
           IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, propertyOnlyResponse)
 
@@ -525,35 +522,6 @@ class ReportDeadlinesControllerISpec extends ComponentSpecBase {
           )
         }
       }
-    }
-
-    "the ReportDeadlines Feature is disabled" should {
-
-      "Redirect to the Income Tax View Change Home Page" in {
-
-
-        disable(ReportDeadlines)
-
-        And("I wiremock stub a successful Income Source Details response with 1 Business and Property income")
-        IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponse)
-
-        And("I wiremock stub a single business obligation response")
-        IncomeTaxViewChangeStub.stubGetReportDeadlines(testNino, ObligationsModel(Seq(singleObligationOverdueModel(testSelfEmploymentId))))
-
-        When("I call GET /report-quarterly/income-and-expenses/view/obligations")
-        val res = IncomeTaxViewChangeFrontend.getReportDeadlines
-
-        verifyIncomeSourceDetailsCall(testMtditid)
-        verifyReportDeadlinesCall(testNino)
-
-        Then("the result should have a HTTP status of SEE_OTHER (303) and redirect to the Income Tax home page")
-        res should have(
-          httpStatus(SEE_OTHER),
-          redirectURI(controllers.routes.HomeController.home().url)
-        )
-      }
-
-    }
 
   }
 }

--- a/test/config/featureswitch/FeatureSwitchingSpec.scala
+++ b/test/config/featureswitch/FeatureSwitchingSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config.featureswitch
+
+import testUtils.TestSupport
+
+class FeatureSwitchingSpec extends TestSupport with FeatureSwitching {
+
+  val enabledInConfig: Set[FeatureSwitch] = Set(Payment)
+  val expectedDisabledFeatures: Set[FeatureSwitch] = FeatureSwitch.switches -- enabledInConfig
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    FeatureSwitch.switches.map(_.name).foreach(sys.props.remove)
+  }
+
+  "Features" should {
+    "be initially enabled as per application config" in {
+      def verifyFeature(expectedState: Boolean)(feature: FeatureSwitch): Unit = {
+        withClue(s"Feature $feature expected state [$expectedState]:") {
+          isEnabled(feature) shouldBe expectedState
+        }
+      }
+
+      enabledInConfig should not be empty
+      enabledInConfig.foreach(verifyFeature(expectedState = true))
+      expectedDisabledFeatures.foreach(verifyFeature(expectedState = false))
+    }
+
+    "fold depending on its state, calling the respective branch only" when {
+      trait FoldSetup {
+        val aValue = 123987
+        var hasBeenCalled = false
+        def expectedBranch(): Int = {
+          hasBeenCalled = true
+          aValue
+        }
+        def unexpectedBranch(): Int = throw new IllegalStateException
+      }
+
+      "a feature is enabled" in new FoldSetup {
+        enabledInConfig.head.fold(
+          ifEnabled = expectedBranch(),
+          ifDisabled = unexpectedBranch()) shouldBe aValue
+        hasBeenCalled shouldBe true
+      }
+      "a feature is disabled" in new FoldSetup {
+        expectedDisabledFeatures.head.fold(
+          ifEnabled = unexpectedBranch(),
+          ifDisabled = expectedBranch()) shouldBe aValue
+        hasBeenCalled shouldBe true
+      }
+    }
+
+  }
+}

--- a/test/controllers/ReportDeadlinesControllerSpec.scala
+++ b/test/controllers/ReportDeadlinesControllerSpec.scala
@@ -16,16 +16,13 @@
 
 package controllers
 
-import java.time.LocalDate
-
-import assets.MessagesLookUp.{NoReportDeadlines, Obligations => obligationsMessages}
 import assets.BaseTestConstants
+import assets.MessagesLookUp.{NoReportDeadlines, Obligations => obligationsMessages}
 import audit.AuditingService
-import config.featureswitch.{FeatureSwitching, NextUpdates, ObligationsPage, ReportDeadlines}
+import config.featureswitch.{FeatureSwitching, NextUpdates}
 import config.{FrontendAppConfig, ItvcErrorHandler}
 import controllers.predicates.{NinoPredicate, SessionTimeoutPredicate}
-import implicits.{ImplicitDateFormatter, ImplicitDateFormatterImpl}
-import javax.inject.Inject
+import implicits.ImplicitDateFormatterImpl
 import mocks.controllers.predicates.{MockAuthenticationPredicate, MockIncomeSourceDetailsPredicate}
 import mocks.services.MockReportDeadlinesService
 import models.reportDeadlines.{ObligationsModel, ReportDeadlineModel, ReportDeadlinesModel, ReportDeadlinesResponseModel}
@@ -34,12 +31,11 @@ import org.mockito.ArgumentMatchers.{any, eq => matches}
 import org.mockito.Mockito.when
 import org.mockito.stubbing.OngoingStubbing
 import play.api.http.Status
-import play.api.i18n.MessagesApi
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.ReportDeadlinesService
-import uk.gov.hmrc.play.language.LanguageUtils
 
+import java.time.LocalDate
 import scala.concurrent.Future
 
 class ReportDeadlinesControllerSpec extends MockAuthenticationPredicate with MockIncomeSourceDetailsPredicate
@@ -79,29 +75,10 @@ class ReportDeadlinesControllerSpec extends MockAuthenticationPredicate with Moc
 
   "The ReportDeadlinesController.getReportDeadlines function" when {
 
-    "the Report Deadlines feature is disabled" should {
-
-      lazy val result = TestReportDeadlinesController.getReportDeadlines()(fakeRequestWithActiveSession)
-
-      "return Redirect (303)" in {
-        mockSingleBusinessIncomeSource()
-        disable(ReportDeadlines)
-        status(result) shouldBe Status.SEE_OTHER
-      }
-
-      "redirect to the Income Tax Home Page" in {
-        redirectLocation(result) shouldBe Some(controllers.routes.HomeController.home().url)
-      }
-    }
-
-    "the Report Deadlines feature is enabled" should {
+    "the Next Updates feature switch is disabled" should {
 
       lazy val result = TestReportDeadlinesController.getReportDeadlines()(fakeRequestWithActiveSession)
       lazy val document = Jsoup.parse(bodyOf(result))
-
-      "set Report Deadlines enabled" in {
-        enable(ReportDeadlines)
-      }
 
       "called with an Authenticated HMRC-MTD-IT user with NINO" which {
 
@@ -288,8 +265,7 @@ class ReportDeadlinesControllerSpec extends MockAuthenticationPredicate with Moc
 			lazy val result = TestReportDeadlinesController.getReportDeadlines()(fakeRequestWithActiveSession)
 			lazy val document = Jsoup.parse(bodyOf(result))
 
-			"set Report Deadlines enabled" in {
-				enable(ReportDeadlines)
+			"set Next Updates enabled" in {
 				enable(NextUpdates)
 			}
 


### PR DESCRIPTION
- behavior left as if the switch was enabled
- switch removed from code and application.conf file
- removed tests for a "disabled" state of the switch
- refactoring of the ReportDeadlinesController