### PR TITLE
MISUV-2172 Language and Back links made skippable

### DIFF
--- a/app/config/ItvcErrorHandler.scala
+++ b/app/config/ItvcErrorHandler.scala
@@ -26,7 +26,7 @@ import views.html.templates.ErrorTemplate
 import javax.inject.Inject
 
 class ItvcErrorHandler @Inject()(val errorTemplate: ErrorTemplate,
-                                 val messagesApi: MessagesApi)(implicit val appConfig: FrontendAppConfig) extends FrontendErrorHandler with I18nSupport {
+                                 val messagesApi: MessagesApi) extends FrontendErrorHandler with I18nSupport {
 
   override def standardErrorTemplate(pageTitle: String, heading: String, message: String)(implicit r: Request[_]): Html =
     errorTemplate(pageTitle, heading, message)

--- a/app/controllers/errors/AgentErrorController.scala
+++ b/app/controllers/errors/AgentErrorController.scala
@@ -17,7 +17,6 @@
 package controllers.errors
 
 import com.google.inject.{Inject, Singleton}
-import config.FrontendAppConfig
 import controllers.BaseController
 import controllers.predicates.{AuthenticationPredicate, SessionTimeoutPredicate}
 import play.api.i18n.I18nSupport
@@ -31,8 +30,7 @@ class AgentErrorController @Inject()(checkSessionTimeout: SessionTimeoutPredicat
                                      authenticate: AuthenticationPredicate,
                                      agentErrorView: AgentError)
                                     (implicit override val executionContext: ExecutionContext,
-                                     mcc: MessagesControllerComponents,
-                                     appConfig: FrontendAppConfig) extends BaseController with I18nSupport {
+                                     mcc: MessagesControllerComponents) extends BaseController with I18nSupport {
   val show: Action[AnyContent] = (checkSessionTimeout andThen authenticate) { implicit request =>
     Ok(agentErrorView())
   }

--- a/app/controllers/errors/NotEnrolledController.scala
+++ b/app/controllers/errors/NotEnrolledController.scala
@@ -17,7 +17,6 @@
 package controllers.errors
 
 import com.google.inject.{Inject, Singleton}
-import config.FrontendAppConfig
 import play.api.mvc._
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.notEnrolled.NotEnrolled
@@ -26,8 +25,7 @@ import scala.concurrent.Future
 
 @Singleton
 class NotEnrolledController @Inject()(notEnrolled: NotEnrolled)
-                                     (implicit val config: FrontendAppConfig,
-                                      mcc: MessagesControllerComponents) extends FrontendController(mcc){
+                                     (implicit mcc: MessagesControllerComponents) extends FrontendController(mcc){
   val show: Action[AnyContent] = Action.async { implicit request =>
     Future.successful(Ok(notEnrolled()))
   }

--- a/app/controllers/errors/UpliftFailedController.scala
+++ b/app/controllers/errors/UpliftFailedController.scala
@@ -18,7 +18,6 @@ package controllers.errors
 
 import audit.AuditingService
 import audit.models.IvOutcomeFailureAuditModel
-import config.FrontendAppConfig
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.errorPages.UpliftFailed
@@ -29,8 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class UpliftFailedController @Inject()(upliftFailedView: UpliftFailed,
                                        mcc: MessagesControllerComponents,
                                        auditingService: AuditingService)
-                                      (implicit ec: ExecutionContext,
-                                       implicit val config: FrontendAppConfig) extends FrontendController(mcc) {
+                                      (implicit ec: ExecutionContext) extends FrontendController(mcc) {
   def show(): Action[AnyContent] = Action.async { implicit request =>
     val journeyId = request.getQueryString("journeyId")
     if (journeyId.isDefined) {

--- a/app/views/ChargeSummary.scala.html
+++ b/app/views/ChargeSummary.scala.html
@@ -19,7 +19,6 @@
 @import models.financialDetails.DocumentDetail
 @import models.financialDetails.FinancialDetail
 @import models.financialDetails.PaymentsWithChargeType
-@import views.html.helpers.injected.BackLink
 @import views.html.templates.MainTemplate
 
 @import java.time.LocalDate
@@ -28,7 +27,6 @@
 
 @this(
     mainTemplate: MainTemplate,
-    backLink: BackLink,
     appConfig: config.FrontendAppConfig,
     implicitDateFormatter: ImplicitDateFormatterImpl
 )
@@ -44,9 +42,7 @@
 
 @hasAccruedInterest = @{ paymentBreakdown.exists(_.hasAccruedInterest) }
 
-@mainTemplate(title = messages(if (latePaymentInterestCharge) s"chargeSummary.lpi.${documentDetail.getChargeTypeKey}" else s"chargeSummary.${documentDetail.getChargeTypeKey}"),bodyClasses = None, scriptElem = None) {
-
-    @backLink(backUrl)
+@mainTemplate(title = messages(if (latePaymentInterestCharge) s"chargeSummary.lpi.${documentDetail.getChargeTypeKey}" else s"chargeSummary.${documentDetail.getChargeTypeKey}"),bodyClasses = None, backUrl = Some(backUrl), scriptElem = None) {
 
     @if(hasDunningLocks) {
         <br>

--- a/app/views/DeductionBreakdown.scala.html
+++ b/app/views/DeductionBreakdown.scala.html
@@ -17,11 +17,9 @@
 @import models.calculation.CalcDisplayModel
 @import views.html.templates.MainTemplate
 @import implicits.ImplicitCurrencyFormatter._
-@import views.html.helpers.injected.BackLink
 
 @this(
-        mainTemplate: MainTemplate,
-        backLink: BackLink
+        mainTemplate: MainTemplate
 )
 
 @(calcModel: CalcDisplayModel, taxYear: Int, backUrl: String)(implicit request: Request[_], messages: Messages)
@@ -35,10 +33,7 @@
     }
 }
 
-@mainTemplate(messages("deduction_breakdown.heading")
-) {
-
-@backLink(backUrl)
+@mainTemplate(title = messages("deduction_breakdown.heading"), backUrl = Some(backUrl)) {
 
     <h1 class="heading-xlarge">
         <span class="heading-secondary">@messages("deduction_breakdown.dates", s"${taxYear-1}", s"$taxYear")</span>

--- a/app/views/IncomeBreakdown.scala.html
+++ b/app/views/IncomeBreakdown.scala.html
@@ -17,9 +17,8 @@
 @import implicits.ImplicitCurrencyFormatter._
 @import models.calculation.CalcDisplayModel
 @import views.html.templates.MainTemplate
-@import views.html.helpers.injected.BackLink
 
-@this(mainTemplate: MainTemplate, backLink: BackLink)
+@this(mainTemplate: MainTemplate)
 
 @(calcModel: CalcDisplayModel, taxYear: Int, backUrl: String)(implicit request: Request[_], messages: Messages)
 
@@ -35,10 +34,7 @@
 }
 }
 
-@mainTemplate(messages("income_breakdown.heading", s"${taxYear - 1}", s"$taxYear")
-) {
-
-    @backLink(backUrl)
+@mainTemplate(title = messages("income_breakdown.heading", s"${taxYear - 1}", s"$taxYear"), backUrl = Some(backUrl)) {
 
     <h1 class="heading-xlarge">
         <span class="heading-secondary">@messages("income_breakdown.dates", s"${taxYear - 1}", s"$taxYear")</span>

--- a/app/views/NextUpdates.scala.html
+++ b/app/views/NextUpdates.scala.html
@@ -18,11 +18,9 @@
 @import models.reportDeadlines.ObligationsModel
 
 @import views.html.helpers.injected.obligations.NextUpdatesHelper
-@import views.html.helpers.injected.BackLink
 
 @this(
 	mainTemplate: MainTemplate,
-	backLinkHelper: BackLink,
 	nextUpdatesHelper: NextUpdatesHelper
 )
 
@@ -32,8 +30,8 @@
 
 @mainTemplate(
 	title = messages("nextUpdates.heading"),
-	bodyClasses = None) {
-@backLinkHelper(backUrl)
+	backUrl = Some(backUrl)
+) {
 
 	<h1 id="page-heading" class="heading-xlarge"> @messages("nextUpdates.heading")</h1>
 

--- a/app/views/NoReportDeadlines.scala.html
+++ b/app/views/NoReportDeadlines.scala.html
@@ -15,18 +15,15 @@
  *@
 
 @import views.html.templates.MainTemplate
-@import views.html.helpers.injected.BackLink
 
-@this(mainTemplate: MainTemplate, backLink: BackLink)
+@this(mainTemplate: MainTemplate)
 
 @(backUrl: String)(implicit request: Request[_], messages: Messages)
 
 @mainTemplate(
     title = messages("obligations.heading"),
-    bodyClasses = None,
+    backUrl = Some(backUrl)
 ) {
-
-@backLink(backUrl)
 
 
     <section id="estimated-tax">

--- a/app/views/Obligations.scala.html
+++ b/app/views/Obligations.scala.html
@@ -19,12 +19,10 @@
 
 @import views.html.helpers.injected.obligations.CurrentObligationsHelper
 @import views.html.helpers.injected.obligations.PreviousObligationsHelper
-@import views.html.helpers.injected.BackLink
 
 
 @this(
     mainTemplate: MainTemplate,
-    backLinkHelper: BackLink,
     currentObligationsHelper: CurrentObligationsHelper,
     previousObligationsHelper: PreviousObligationsHelper
 )
@@ -32,12 +30,9 @@
 @(currentObligations: ObligationsModel, previousObligations: ObligationsModel, backUrl: String)(implicit request: Request[_], messages: Messages, user: auth.MtdItUser[_])
 
 @mainTemplate(
-title = messages("obligations.heading.v2"),
-bodyClasses = None,
-
+    title = messages("obligations.heading.v2"),
+    backUrl = Some(backUrl)
 ) {
-
-@backLinkHelper(backUrl)
 
 <h1 id="page-heading" class="heading-xlarge"> @messages("obligations.heading.v2")</h1>
 <div class="govuk-tabs" data-module="govuk-tabs">

--- a/app/views/PaymentAllocation.scala.html
+++ b/app/views/PaymentAllocation.scala.html
@@ -17,22 +17,18 @@
 
 @import implicits.ImplicitCurrencyFormatter._
 @import views.html.templates.MainTemplate
-@import views.html.helpers.injected.BackLink
 @import implicits.ImplicitDateFormatterImpl
 
-@this(mainTemplate: MainTemplate, backLink: BackLink, implicitDateFormatter: ImplicitDateFormatterImpl)
+@this(mainTemplate: MainTemplate, implicitDateFormatter: ImplicitDateFormatterImpl)
 
 @(paymentAllocations: models.paymentAllocationCharges.PaymentAllocationViewModel, backUrl: String)(implicit request: Request[_], messages: Messages)
 
 @import implicitDateFormatter._
 
 @mainTemplate(
-title = messages("paymentAllocation.heading"),
-bodyClasses = None,
-scriptElem = None
+    title = messages("paymentAllocation.heading"),
+    backUrl = Some(backUrl)
 ) {
-
-@backLink(backUrl)
 
 <h1 id="page-heading" class="heading-xlarge"> @messages("paymentAllocation.heading")</h1>
 

--- a/app/views/PaymentHistory.scala.html
+++ b/app/views/PaymentHistory.scala.html
@@ -18,13 +18,11 @@
 @import java.time.LocalDate
 @import implicits.ImplicitCurrencyFormatter._
 @import implicits.ImplicitDateFormatter
-@import views.html.helpers.injected.BackLink
 @import views.html.templates.MainTemplate
 @import implicits.ImplicitDateFormatterImpl
 
 @this(
       mainTemplate: MainTemplate,
-      backLink: BackLink,
       appConfig: config.FrontendAppConfig,
       implicitDateFormatter: ImplicitDateFormatterImpl
 )
@@ -37,10 +35,9 @@ payments.groupBy[Int]{payment => LocalDate.parse(payment.date.get).getYear}.toLi
 }
 
 @mainTemplate(
- title = messages("paymentHistory.heading")
+    title = messages("paymentHistory.heading"),
+    backUrl = Some(backUrl)
 ) {
-
-@backLink(backUrl)
 
 <h1 id="page-heading" class="heading-xlarge"> @messages("paymentHistory.heading")</h1>
 

--- a/app/views/TaxCalcBreakdown.scala.html
+++ b/app/views/TaxCalcBreakdown.scala.html
@@ -17,13 +17,11 @@
 @import models.calculation.{CalcDisplayModel, TaxBand}
 @import views.html.templates.MainTemplate
 @import implicits.ImplicitCurrencyFormatter._
-@import views.html.helpers.injected.BackLink
 @import views.html.partials.taxcalcbreakdown.CapitalGainsTaxTable
 @import views.html.partials.taxcalcbreakdown.TableRow
 
 @this(
     mainTemplate: MainTemplate,
-    backLink: BackLink,
     tableRow: TableRow,
     capitalGainsTaxTable: CapitalGainsTaxTable
 )
@@ -55,9 +53,7 @@
     }
 }
 
-@mainTemplate(title = messages("taxCal_breakdown.heading")) {
-
-    @backLink(backUrl)
+@mainTemplate(title = messages("taxCal_breakdown.heading"), backUrl = Some(backUrl)) {
 
     <h1 class="heading-xlarge">
         <span class="heading-secondary">@messages("taxCal_breakdown.dates", s"${taxYear - 1}", s"$taxYear")</span>

--- a/app/views/TaxYearOverview.scala.html
+++ b/app/views/TaxYearOverview.scala.html
@@ -19,12 +19,11 @@
 @import models.calculation.CalcOverview
 @import models.reportDeadlines.ObligationsModel
 @import models.financialDetails.DocumentDetailWithDueDate
-@import views.html.helpers.injected.BackLink
 @import views.html.templates.MainTemplate
 @import implicits.ImplicitDateFormatterImpl
 @import views.html.partials.taxOverviewBreakdownPartial
 
-@this(mainTemplate: MainTemplate, backLink: BackLink, implicitDateFormatter: ImplicitDateFormatterImpl, breakdownPartial: taxOverviewBreakdownPartial)
+@this(mainTemplate: MainTemplate, implicitDateFormatter: ImplicitDateFormatterImpl, breakdownPartial: taxOverviewBreakdownPartial)
 
 @(taxYear: Int, overviewOpt: Option[CalcOverview], charges: List[DocumentDetailWithDueDate], obligations: ObligationsModel, backUrl: String)(implicit request: Request[_], messages: Messages, user: auth.MtdItUser[_])
 
@@ -150,9 +149,7 @@
     }
 }
 
-@mainTemplate(title = heading) {
-
-    @backLink(backUrl)
+@mainTemplate(title = heading, backUrl = Some(backUrl)) {
 
     <header class="hmrc-page-heading heading-xlarge">
         <h1 class="heading-xlarge">@heading</h1>

--- a/app/views/TaxYears.scala.html
+++ b/app/views/TaxYears.scala.html
@@ -15,9 +15,8 @@
  *@
 
 @import views.html.templates.MainTemplate
-@import views.html.helpers.injected.BackLink
 @import models.calculation.CalculationResponseModelWithYear
-@this(mainTemplate: MainTemplate, backLinkHelper: BackLink, appConfig: config.FrontendAppConfig)
+@this(mainTemplate: MainTemplate, appConfig: config.FrontendAppConfig)
 
 @(taxYears: List[CalculationResponseModelWithYear], backUrl: String, itsaSubmissionIntegrationEnabled: Boolean)(implicit request: Request[_], messages: Messages)
 
@@ -54,9 +53,7 @@
     </tr>
 }
 
-@mainTemplate(title = messages("taxYears.heading"), bodyClasses = None) {
-
-@backLinkHelper(backUrl)
+@mainTemplate(title = messages("taxYears.heading"), backUrl = Some(backUrl)) {
 
     <header class="page-heading">
         <h1 class="heading-xlarge" id="heading">@messages("taxYears.heading")</h1>

--- a/app/views/WhatYouOwe.scala.html
+++ b/app/views/WhatYouOwe.scala.html
@@ -19,12 +19,10 @@
 @import models.financialDetails.WhatYouOweChargesList
 @import views.html.templates.MainTemplate
 @import java.time.LocalDate
-@import views.html.helpers.injected.BackLink
 @import models.financialDetails.DocumentDetailWithDueDate
 
 @this(
     mainTemplate: MainTemplate,
-    backLink: BackLink,
     implicitDateFormatter: ImplicitDateFormatterImpl,
     appConfig: config.FrontendAppConfig
 )
@@ -144,11 +142,8 @@
 
 @mainTemplate(
     title = messages("whatYouOwe.heading"),
-    bodyClasses = None,
-    scriptElem = None
+    backUrl = Some(backUrl)
 ) {
-
-    @backLink(backUrl)
 
     <header class="page-heading">
         <h1 class="heading-xlarge" id="page-heading">@messages("whatYouOwe.heading")</h1>

--- a/app/views/agent/AgentsPaymentHistory.scala.html
+++ b/app/views/agent/AgentsPaymentHistory.scala.html
@@ -19,10 +19,9 @@
 @import java.time.LocalDate
 @import implicits.ImplicitCurrencyFormatter._
 @import implicits.ImplicitDateFormatter
-@import views.html.helpers.injected.BackLink
 
 
-@this(mainTemplate: MainTemplate, backLink: BackLink)
+@this(mainTemplate: MainTemplate)
 @(payments: List[Payment],  implicitDateFormatter: ImplicitDateFormatter, backUrl: String, saUtr: Option[String])(implicit request: Request[_], messages: Messages, appConfig: config.FrontendAppConfig)
 @import implicitDateFormatter.longDate
 
@@ -31,10 +30,9 @@ payments.groupBy[Int]{payment => LocalDate.parse(payment.date.get).getYear}.toLi
 }
 
 @mainTemplate(
-title = messages("paymentHistory.heading"),bodyClasses = None
+    title = messages("paymentHistory.heading"),
+    backUrl = Some(backUrl)
 ) {
-
-@backLink(backUrl)
 
 <h1 id="page-heading" class="heading-xlarge"> @messages("paymentHistory.heading")</h1>
 

--- a/app/views/agent/ChargeSummary.scala.html
+++ b/app/views/agent/ChargeSummary.scala.html
@@ -16,7 +16,6 @@
 
 @import views.html.templates.agent.MainTemplate
 @import implicits.ImplicitCurrencyFormatter.CurrencyFormatter
-@import views.html.helpers.injected.BackLink
 @import implicits.ImplicitDateFormatter
 @import models.chargeHistory.ChargeHistoryModel
 @import models.financialDetails.DocumentDetailWithDueDate
@@ -24,7 +23,7 @@
 @import models.financialDetails.FinancialDetail
 @import models.financialDetails.FinancialDetailsModel
 
-@this(mainTemplate: MainTemplate, backLink: BackLink)
+@this(mainTemplate: MainTemplate)
 @(documentDetailWithDueDate: DocumentDetailWithDueDate, chargeHistoryOpt: Option[List[ChargeHistoryModel]],
 		backUrl: String, paymentAllocations: List[PaymentsWithChargeType], paymentBreakdown: List[FinancialDetail], payments: FinancialDetailsModel,
 		latePaymentInterestCharge: Boolean, paymentAllocationEnabled: Boolean)(implicit request: Request[_], messages: Messages, appConfig: config.FrontendAppConfig,
@@ -49,8 +48,7 @@
 	</tr>
 }
 
-@mainTemplate(title = messages(if (latePaymentInterestCharge) s"chargeSummary.lpi.${documentDetail.getChargeTypeKey}" else s"chargeSummary.${documentDetail.getChargeTypeKey}"), bodyClasses = None){
-	@backLink(backUrl)
+@mainTemplate(title = messages(if (latePaymentInterestCharge) s"chargeSummary.lpi.${documentDetail.getChargeTypeKey}" else s"chargeSummary.${documentDetail.getChargeTypeKey}"), backUrl = Some(backUrl)){
 
 	@if(hasDunningLocks) {
 		<br>

--- a/app/views/agent/DeductionBreakdown.scala.html
+++ b/app/views/agent/DeductionBreakdown.scala.html
@@ -17,9 +17,8 @@
 @import models.calculation.CalcDisplayModel
 @import views.html.templates.agent.MainTemplate
 @import implicits.ImplicitCurrencyFormatter._
-@import views.html.helpers.injected.BackLink
 
-@this(mainTemplate: MainTemplate, backLink: BackLink)
+@this(mainTemplate: MainTemplate)
 @(calcModel: CalcDisplayModel, taxYear: Int, backUrl: String)(implicit request: Request[_], messages: Messages, appConfig: config.FrontendAppConfig, user: auth.MtdItUser[_])
 
 @tableRow(messageCode: String, dataItem: Option[BigDecimal], isNegative: Boolean = false) = {
@@ -31,10 +30,7 @@
     }
 }
 
-@mainTemplate(messages("deduction_breakdown.heading")
-) {
-
-@backLink(backUrl)
+@mainTemplate(title = messages("deduction_breakdown.heading"), backUrl = Some(backUrl)) {
 
     <h1 class="heading-xlarge">
         <span class="heading-secondary">@messages("deduction_breakdown.dates", s"${taxYear-1}", s"$taxYear")</span>

--- a/app/views/agent/EnterClientsUTR.scala.html
+++ b/app/views/agent/EnterClientsUTR.scala.html
@@ -18,7 +18,6 @@
 @import views.html.templates.agent.MainTemplate
 @import views.html.helpers.injected.InputHelper
 @import views.html.helpers.injected.ContinueButton
-@import views.html.helpers.injected.BackLink
 @import views.html.helpers.injected.ErrorSummary
 @import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 
@@ -26,7 +25,6 @@
         mainTemplate: MainTemplate,
         inputHelper: InputHelper,
         continueButton: ContinueButton,
-        backLink: BackLink,
         form: FormWithCSRF,
         errorSummary: ErrorSummary
 )

--- a/app/views/agent/IncomeBreakdown.scala.html
+++ b/app/views/agent/IncomeBreakdown.scala.html
@@ -17,9 +17,8 @@
 @import implicits.ImplicitCurrencyFormatter._
 @import models.calculation.CalcDisplayModel
 @import views.html.templates.agent.MainTemplate
-@import views.html.helpers.injected.BackLink
 
-@this(mainTemplate: MainTemplate, backLink: BackLink)
+@this(mainTemplate: MainTemplate)
 
 @(calcModel: CalcDisplayModel, taxYear: Int, backUrl: String)(implicit request: Request[_], messages: Messages, appConfig: config.FrontendAppConfig, user: auth.MtdItUser[_])
 
@@ -39,9 +38,7 @@
     }
 }
 
-@mainTemplate(title = heading){
-
-    @backLink(backUrl)
+@mainTemplate(title = heading, backUrl = Some(backUrl)){
 
     <h1 class="heading-xlarge">
         <span class="heading-secondary">@messages("income_breakdown.dates", s"${taxYear - 1}", s"$taxYear")</span>

--- a/app/views/agent/NextUpdates.scala.html
+++ b/app/views/agent/NextUpdates.scala.html
@@ -16,9 +16,8 @@
 
 @import views.html.helpers.injected.obligations.NextUpdatesHelper
 @import views.html.templates.agent.MainTemplate
-@import views.html.helpers.injected.BackLink
 
-@this(mainTemplate: MainTemplate, backLink: BackLink, nextUpdatesHelper: NextUpdatesHelper)
+@this(mainTemplate: MainTemplate, nextUpdatesHelper: NextUpdatesHelper)
 
 @(currentObligations: models.reportDeadlines.ObligationsModel, backUrl: String)(implicit messages: Messages, user: auth.MtdItUser[_])
 
@@ -26,9 +25,7 @@
 	messages("agent.nextUpdates.heading")
 }
 
-@mainTemplate(title = heading) {
-
-	@backLink(backUrl)
+@mainTemplate(title = heading, backUrl = Some(backUrl)) {
 
 	<h1 id="page-heading" class="heading-xlarge"> @messages("agent.nextUpdates.heading")</h1>
 

--- a/app/views/agent/PaymentAllocation.scala.html
+++ b/app/views/agent/PaymentAllocation.scala.html
@@ -15,12 +15,11 @@
  *@
 
 @import views.html.templates.agent.MainTemplate
-@import views.html.helpers.injected.BackLink
 @import models.paymentAllocationCharges.PaymentAllocationViewModel
 @import implicits.ImplicitCurrencyFormatter._
 @import implicits.ImplicitDateFormatterImpl
 
-@this(mainTemplate: MainTemplate, backLink: BackLink, implicitDateFormatter: ImplicitDateFormatterImpl)
+@this(mainTemplate: MainTemplate, implicitDateFormatter: ImplicitDateFormatterImpl)
 
 @(viewModel: PaymentAllocationViewModel, backUrl: String)(implicit request: Request[_], messages: Messages)
 
@@ -29,10 +28,9 @@
 @import viewModel.originalPaymentAllocationWithClearingDate
 
 @mainTemplate(
-    title = messages("paymentAllocation.heading")
+    title = messages("paymentAllocation.heading"),
+    backUrl = Some(backUrl)
 ) {
-
-    @backLink(backUrl)
 
     <h1 id="page-heading" class="heading-xlarge"> @messages("paymentAllocation.heading")</h1>
 

--- a/app/views/agent/TaxCalcBreakdown.scala.html
+++ b/app/views/agent/TaxCalcBreakdown.scala.html
@@ -17,13 +17,11 @@
 @import models.calculation.{CalcDisplayModel, TaxBand}
 @import implicits.ImplicitCurrencyFormatter._
 @import views.html.templates.agent.MainTemplate
-@import views.html.helpers.injected.BackLink
 @import views.html.partials.taxcalcbreakdown.CapitalGainsTaxTable
 @import views.html.partials.taxcalcbreakdown.TableRow
 
 @this(
     mainTemplate: MainTemplate,
-    backLink: BackLink,
     tableRow: TableRow,
     capitalGainsTaxTable: CapitalGainsTaxTable
 )
@@ -55,9 +53,7 @@
     }
 }
 
-@mainTemplate(title = messages("taxCal_breakdown.heading")){
-
-    @backLink(backUrl)
+@mainTemplate(title = messages("taxCal_breakdown.heading"), backUrl = Some(backUrl)){
 
     <h1 class="heading-xlarge">
         <span class="heading-secondary">@messages("taxCal_breakdown.dates", s"${taxYear - 1}", s"$taxYear")</span>

--- a/app/views/agent/TaxYearOverview.scala.html
+++ b/app/views/agent/TaxYearOverview.scala.html
@@ -17,13 +17,12 @@
 @import views.html.templates.agent.MainTemplate
 @import implicits.ImplicitCurrencyFormatter._
 @import implicits.ImplicitDateFormatterImpl
-@import views.html.helpers.injected.BackLink
 @import models.calculation.CalcOverview
 @import models.reportDeadlines.ObligationsModel
 @import java.time.LocalDate
 @import models.financialDetails.DocumentDetailWithDueDate
 
-@this(mainTemplate: MainTemplate, backLink: BackLink, implicitDateFormatter: ImplicitDateFormatterImpl)
+@this(mainTemplate: MainTemplate, implicitDateFormatter: ImplicitDateFormatterImpl)
 
 @(taxYear: Int, overviewOpt: Option[CalcOverview], documentDetailsWithDueDates: List[DocumentDetailWithDueDate], obligations: ObligationsModel, backUrl: String)(implicit messages: Messages, user: auth.MtdItUser[_])
 
@@ -182,9 +181,7 @@
     }
 }
 
-@mainTemplate(title = heading){
-
-    @backLink(backUrl)
+@mainTemplate(title = heading, backUrl = Some(backUrl)){
 
     <header class="hmrc-page-heading heading-xlarge">
         <h1 class="heading-xlarge">@heading</h1>

--- a/app/views/agent/TaxYears.scala.html
+++ b/app/views/agent/TaxYears.scala.html
@@ -15,9 +15,8 @@
  *@
 
 @import views.html.templates.agent.MainTemplate
-@import views.html.helpers.injected.BackLink
 
-@this(mainTemplate: MainTemplate, backLink: BackLink)
+@this(mainTemplate: MainTemplate)
 
 @(taxYears: Seq[Int], backUrl: String, itsaSubmissionIntegrationEnabled: Boolean)(implicit request: Request[_], messages: Messages, appConfig: config.FrontendAppConfig)
 
@@ -55,9 +54,7 @@
 }
 
 
-@mainTemplate(title = messages("taxYears.heading")){
-
-	@backLink(backUrl)
+@mainTemplate(title = messages("taxYears.heading"), backUrl = Some(backUrl)){
 
 	<header class="page-heading">
 		<h1 class="heading-xlarge" id="heading">@messages("taxYears.heading")</h1>

--- a/app/views/agent/WhatYouOwe.scala.html
+++ b/app/views/agent/WhatYouOwe.scala.html
@@ -17,12 +17,11 @@
 @import implicits.ImplicitDateFormatterImpl
 @import implicits.ImplicitCurrencyFormatter._
 @import models.financialDetails.WhatYouOweChargesList
-@import views.html.helpers.injected.BackLink
 @import views.html.templates.agent.MainTemplate
 @import java.time.LocalDate
 @import models.financialDetails.DocumentDetailWithDueDate
 
-@this(mainTemplate: MainTemplate, backLink: BackLink, appConfig: config.FrontendAppConfig, implicitDateFormatter: ImplicitDateFormatterImpl)
+@this(mainTemplate: MainTemplate, appConfig: config.FrontendAppConfig, implicitDateFormatter: ImplicitDateFormatterImpl)
 @(chargesList: WhatYouOweChargesList, currentTaxYear: Int, backUrl: String, utr: Option[String])(implicit request: Request[_], messages: Messages)
 @import implicitDateFormatter.longDate
 
@@ -129,9 +128,7 @@
 </tr>
 }
 
-@mainTemplate(title = messages("agent.paymentDue.heading")){
-
-    @backLink(backUrl)
+@mainTemplate(title = messages("agent.paymentDue.heading"), backUrl = Some(backUrl)){
 
     <header class="page-heading">
         <h1 class="heading-xlarge" id="page-heading">@messages("agent.paymentDue.heading")</h1>

--- a/app/views/agent/confirmClient.scala.html
+++ b/app/views/agent/confirmClient.scala.html
@@ -15,21 +15,19 @@
  *@
 
 @import views.html.templates.agent.MainTemplate
-@import views.html.helpers.injected.BackLink
 @import views.html.helpers.injected.ContinueButton
 @import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 
 
-@this(mainTemplate: MainTemplate, backLink: BackLink, continueButton: ContinueButton, form: FormWithCSRF)
+@this(mainTemplate: MainTemplate, continueButton: ContinueButton, form: FormWithCSRF)
 
 @(clientName: Option[String], clientUtr: Option[String], postAction: Call, backUrl: String)(implicit request: Request[_], messages: Messages, appConfig: config.FrontendAppConfig)
 
 
 @mainTemplate(
-  title = messages("agent.confirmClient.heading")
+    title = messages("agent.confirmClient.heading"),
+    backUrl = Some(backUrl)
 ) {
-
-    @backLink(backUrl)
 
     <h1>@messages("agent.confirmClient.heading")</h1>
 

--- a/app/views/components/back_link.scala.html
+++ b/app/views/components/back_link.scala.html
@@ -14,11 +14,7 @@
  * limitations under the License.
  *@
 
-@this(standardError: StandardError)
+@this()
+@(href: String)(implicit messages: Messages)
 
-@()(implicit request : Request[_], messages: Messages)
-
-@standardError(
-    messages("notFound.heading"),
-    messages("notFound.message")
-)
+<a id="back" class="govuk-back-link" href="@href">@messages("base.back")</a>

--- a/app/views/components/data_metric_p.scala.html
+++ b/app/views/components/data_metric_p.scala.html
@@ -17,6 +17,6 @@
 
 @this()
 
-@(content: String)(implicit messages: Messages)
+@(content: String)
 
 <p data-metrics="handledError:serviceError:shownErrorPage" class="govuk-body" >@content</p>

--- a/app/views/components/p.scala.html
+++ b/app/views/components/p.scala.html
@@ -16,10 +16,10 @@
 
 @this()
 
-@(content: Html, classes: String = "govuk-body", id: Option[String] = None)(implicit messages: Messages)
+@(content: Html, classes: String = "govuk-body", id: Option[String] = None)
 
 @if(id.isDefined){
-<p class="@classes", id ="@id">@content</p>
+<p class="@classes" id="@id">@content</p>
 } else {
 <p class="@classes">@content</p>
 }

--- a/app/views/components/phaseBanner.scala.html
+++ b/app/views/components/phaseBanner.scala.html
@@ -19,9 +19,9 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
 @import uk.gov.hmrc.hmrcfrontend.views.html.components._
 
-@this(govukPhaseBanner: GovukPhaseBanner)
+@this(govukPhaseBanner: GovukPhaseBanner, appConfig: config.FrontendAppConfig)
 
-@(phase: String)(implicit request: Request[_], messages: Messages, appConfig: config.FrontendAppConfig)
+@(phase: String)(implicit messages: Messages)
 
 @feedbackBanner = {
 @messages("betaBanner.newService")

--- a/app/views/errorPages/AgentError.scala.html
+++ b/app/views/errorPages/AgentError.scala.html
@@ -23,7 +23,7 @@
         p: p,
         link: link)
 
-@()(implicit request : Request[_], messages: Messages, appConfig: config.FrontendAppConfig)
+@()(implicit request : Request[_], messages: Messages)
 
 @mainTemplate(
     pageTitle = messages("agent-error.heading")

--- a/app/views/errorPages/StandardError.scala.html
+++ b/app/views/errorPages/StandardError.scala.html
@@ -21,7 +21,7 @@
         h1: h1,
         p: p)
 
-@(heading: String, message: String)(implicit request : Request[_], messages: Messages, appConfig: config.FrontendAppConfig)
+@(heading: String, message: String)(implicit request : Request[_], messages: Messages)
 
 @contentHeader = {
     @h1(heading)

--- a/app/views/errorPages/UpliftFailed.scala.html
+++ b/app/views/errorPages/UpliftFailed.scala.html
@@ -23,7 +23,7 @@
         link: link,
         list: bulletPointList)
 
-@()(implicit request : Request[_], messages: Messages, appConfig: config.FrontendAppConfig)
+@()(implicit request : Request[_], messages: Messages)
 
 @()(implicit messages: Messages)
 

--- a/app/views/layouts/agent/layout.scala.html
+++ b/app/views/layouts/agent/layout.scala.html
@@ -5,31 +5,31 @@
 @import uk.gov.hmrc.hmrcfrontend.views.html.components._
 @import uk.gov.hmrc.hmrcfrontend.views.html.components.{Header => HmrcHeaderArgs}
 @import uk.gov.hmrc.play.views.html.helpers.ReportAProblemLink
-@import views.html.helpers.injected.LanguageSelection
 @this(
-reportAProblemLink: ReportAProblemLink,
-hmrcBanner: HmrcBanner,
-govukBackLink: GovukBackLink,
-govukLayout: GovukLayout,
-hmrcHeader:  HmrcHeader,
-phaseBanner: components.phaseBanner,
-footerLinks: HmrcStandardFooter,
-hmrcTimeoutDialog: HmrcTimeoutDialog,
-hmrcTrackingConsentSnippet: HmrcTrackingConsentSnippet,
-languageSelection: components.languageSelection
+    appConfig: config.FrontendAppConfig,
+    reportAProblemLink: ReportAProblemLink,
+    hmrcBanner: HmrcBanner,
+    govukBackLink: GovukBackLink,
+    govukLayout: GovukLayout,
+    hmrcHeader:  HmrcHeader,
+    phaseBanner: components.phaseBanner,
+    footerLinks: HmrcStandardFooter,
+    hmrcTimeoutDialog: HmrcTimeoutDialog,
+    hmrcTrackingConsentSnippet: HmrcTrackingConsentSnippet,
+    backLink: components.back_link,
+    languageSelection: components.languageSelection
 )
 
-@(pageTitle: Option[String] = None, beforeContentBlock: Option[Html] = None, signOutLink: Boolean = true, timeout: Boolean = true)(contentBlock: Html)(implicit request : Request[_], messages: Messages, appConfig: config.FrontendAppConfig)
+@(pageTitle: Option[String] = None, backUrl: Option[String] = None, signOutLink: Boolean = true, timeout: Boolean = true)(contentBlock: Html)(implicit request : Request[_], messages: Messages)
 
 @siteHeader = {
     @hmrcHeader(HmrcHeaderArgs(
-    homepageUrl = controllers.routes.HomeController.home.url,
-    serviceName = Some(messages("base.service_name")),
-    serviceUrl = controllers.routes.HomeController.home.url,
-    containerClasses = "govuk-width-container",
-    signOutHref = Some(controllers.routes.SignOutController.signOut.url)
-))
-
+        homepageUrl = controllers.routes.HomeController.home.url,
+        serviceName = Some(messages("base.service_name")),
+        serviceUrl = controllers.routes.HomeController.home.url,
+        containerClasses = "govuk-width-container",
+        signOutHref = Some(controllers.routes.SignOutController.signOut.url)
+    ))
 }
 
 @hmrcTrackingConsentSnippet()
@@ -38,25 +38,25 @@ languageSelection: components.languageSelection
 <!--[if lte IE 8]><link href=' @controllers.routes.Assets.at("stylesheets/application-ie-8.css")' rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if gt IE 8]><!--> <link href='@controllers.routes.Assets.at("stylesheets/application.css")' media="screen" rel="stylesheet" type="text/css" />
 <!--<![endif]-->
-@if(timeout) {
-    @hmrcTimeoutDialog(TimeoutDialog(
-    language = Some("en"),
-    timeout = Option(900),
-    countdown = Option(120),
-    keepAliveUrl = Some("@controllers.timeout.routes.SessionTimeoutController.keepAlive().url"),
-    signOutUrl = Some(controllers.routes.SignOutController.signOut.url),
-    keepAliveButtonText = Some(messages("button.continue"))
-    ))
-}
+    @if(timeout) {
+        @hmrcTimeoutDialog(TimeoutDialog(
+            language = Some("en"),
+            timeout = Option(900),
+            countdown = Option(120),
+            keepAliveUrl = Some("@controllers.timeout.routes.SessionTimeoutController.keepAlive().url"),
+            signOutUrl = Some(controllers.routes.SignOutController.signOut.url),
+            keepAliveButtonText = Some(messages("button.continue"))
+        ))
+    }
 }
 
 @getHelpForm = @{reportAProblemLink(appConfig.reportAProblemPartialUrl, appConfig.reportAProblemNonJSUrl)}
 
 @beforeContentBlock = {
-@phaseBanner("beta")
-@hmrcBanner(Banner(if(messages.lang.code == "cy") {Cy} else {En}))
-@languageSelection()
-
+    @phaseBanner("beta")
+    @hmrcBanner(Banner(if(messages.lang.code == "cy") {Cy} else {En}))
+    @languageSelection()
+    @backUrl.map(backLink(_))
 }
 
 @scripts = {
@@ -81,11 +81,11 @@ languageSelection: components.languageSelection
 }
 
 @govukLayout(
-pageTitle = pageTitle,
-headBlock = Some(head),
-beforeContentBlock = Some(beforeContentBlock),
-bodyEndBlock = None,
-headerBlock = Some(siteHeader),
-footerBlock = Some(footerLinks()),
-scriptsBlock = Some(scripts)
+    pageTitle = pageTitle,
+    headBlock = Some(head),
+    beforeContentBlock = Some(beforeContentBlock),
+    bodyEndBlock = None,
+    headerBlock = Some(siteHeader),
+    footerBlock = Some(footerLinks()),
+    scriptsBlock = Some(scripts)
 )(content)

--- a/app/views/layouts/layout.scala.html
+++ b/app/views/layouts/layout.scala.html
@@ -5,31 +5,31 @@
 @import uk.gov.hmrc.hmrcfrontend.views.html.components._
 @import uk.gov.hmrc.hmrcfrontend.views.html.components.{Header => HmrcHeaderArgs}
 @import uk.gov.hmrc.play.views.html.helpers.ReportAProblemLink
-@import views.html.helpers.injected.LanguageSelection
 @this(
-reportAProblemLink: ReportAProblemLink,
-hmrcBanner: HmrcBanner,
-govukBackLink: GovukBackLink,
-govukLayout: GovukLayout,
-hmrcHeader:  HmrcHeader,
-phaseBanner: components.phaseBanner,
-footerLinks: HmrcStandardFooter,
-hmrcTimeoutDialog: HmrcTimeoutDialog,
-hmrcTrackingConsentSnippet: HmrcTrackingConsentSnippet,
-languageSelection: components.languageSelection
+    appConfig: config.FrontendAppConfig,
+    reportAProblemLink: ReportAProblemLink,
+    hmrcBanner: HmrcBanner,
+    govukBackLink: GovukBackLink,
+    govukLayout: GovukLayout,
+    hmrcHeader:  HmrcHeader,
+    phaseBanner: components.phaseBanner,
+    footerLinks: HmrcStandardFooter,
+    hmrcTimeoutDialog: HmrcTimeoutDialog,
+    hmrcTrackingConsentSnippet: HmrcTrackingConsentSnippet,
+    backLink: components.back_link,
+    languageSelection: components.languageSelection
 )
 
-@(pageTitle: String, beforeContentBlock: Option[Html] = None, signOutLink: Boolean = true, timeout: Boolean = true)(contentBlock: Html)(implicit request : Request[_], messages: Messages, appConfig: config.FrontendAppConfig)
+@(pageTitle: String, backUrl: Option[String] = None, signOutLink: Boolean = true, timeout: Boolean = true)(contentBlock: Html)(implicit request : Request[_], messages: Messages)
 
 @siteHeader = {
     @hmrcHeader(HmrcHeaderArgs(
-    homepageUrl = controllers.routes.HomeController.home.url,
-    serviceName = Some(messages("base.service_name")),
-    serviceUrl = controllers.routes.HomeController.home.url,
-    containerClasses = "govuk-width-container",
-    signOutHref = Some(controllers.routes.SignOutController.signOut.url)
-))
-
+        homepageUrl = controllers.routes.HomeController.home.url,
+        serviceName = Some(messages("base.service_name")),
+        serviceUrl = controllers.routes.HomeController.home.url,
+        containerClasses = "govuk-width-container",
+        signOutHref = Some(controllers.routes.SignOutController.signOut.url)
+    ))
 }
 
 @hmrcTrackingConsentSnippet()
@@ -39,25 +39,25 @@ languageSelection: components.languageSelection
 <!--[if gt IE 8]><!--> <link href='@controllers.routes.Assets.at("stylesheets/application.css")' media="screen" rel="stylesheet" type="text/css" />
 <!--<![endif]-->
 
-@if(timeout) {
-    @hmrcTimeoutDialog(TimeoutDialog(
-    language = Some("en"),
-    timeout = Option(900),
-    countdown = Option(120),
-    keepAliveUrl = Some("@controllers.timeout.routes.SessionTimeoutController.keepAlive().url"),
-    signOutUrl = Some(controllers.routes.SignOutController.signOut.url),
-    keepAliveButtonText = Some(messages("button.continue"))
-    ))
+    @if(timeout) {
+        @hmrcTimeoutDialog(TimeoutDialog(
+            language = Some("en"),
+            timeout = Option(900),
+            countdown = Option(120),
+            keepAliveUrl = Some("@controllers.timeout.routes.SessionTimeoutController.keepAlive().url"),
+            signOutUrl = Some(controllers.routes.SignOutController.signOut.url),
+            keepAliveButtonText = Some(messages("button.continue"))
+        ))
     }
 }
 
 @getHelpForm = @{reportAProblemLink(appConfig.reportAProblemPartialUrl, appConfig.reportAProblemNonJSUrl)}
 
 @beforeContentBlock = {
-@phaseBanner("beta")
-@hmrcBanner(Banner(if(messages.lang.code == "cy") {Cy} else {En}))
-@languageSelection()
-
+    @phaseBanner("beta")
+    @hmrcBanner(Banner(if(messages.lang.code == "cy") {Cy} else {En}))
+    @languageSelection()
+    @backUrl.map(backLink(_))
 }
 
 @scripts = {
@@ -82,11 +82,11 @@ languageSelection: components.languageSelection
 }
 
 @govukLayout(
-pageTitle = Some(messages("titlePattern.serviceName.govUk", pageTitle)),
-headBlock = Some(head),
-beforeContentBlock = Some(beforeContentBlock),
-bodyEndBlock = None,
-headerBlock = Some(siteHeader),
-footerBlock = Some(footerLinks()),
-scriptsBlock = Some(scripts)
+    pageTitle = Some(messages("titlePattern.serviceName.govUk", pageTitle)),
+    headBlock = Some(head),
+    beforeContentBlock = Some(beforeContentBlock),
+    bodyEndBlock = None,
+    headerBlock = Some(siteHeader),
+    footerBlock = Some(footerLinks()),
+    scriptsBlock = Some(scripts)
 )(content)

--- a/app/views/templates/ErrorTemplate.scala.html
+++ b/app/views/templates/ErrorTemplate.scala.html
@@ -23,7 +23,7 @@
       p: data_metric_p
 )
 
-@(pageTitle: String, heading: String, message: String)(implicit request : Request[_], messages: Messages, appConfig: config.FrontendAppConfig)
+@(pageTitle: String, heading: String, message: String)(implicit request : Request[_], messages: Messages)
 
 @mainTemplate(pageTitle = pageTitle) {
 

--- a/app/views/templates/GovUkWrapper.scala.html
+++ b/app/views/templates/GovUkWrapper.scala.html
@@ -15,6 +15,7 @@
  *@
 
 @import views.html.layouts.GovUkTemplate
+@import views.html.helpers.injected.BackLink
 @import views.html.helpers.injected.BetaBanner
 @import views.html.helpers.injected.LanguageSelection
 @import views.html.helpers.injected.RecruitmentBannerHelper
@@ -38,6 +39,7 @@
         headerNav: HeaderNav,
         recruitmentBannerHelper: RecruitmentBannerHelper,
         betaBanner: BetaBanner,
+        backLink: BackLink,
         languageSelection: LanguageSelection,
         headWithTrackingConsent: HeadWithTrackingConsent
 )
@@ -50,6 +52,7 @@
   mainContent: Html = HtmlFormat.empty,
   serviceInfoContent: Html = HtmlFormat.empty,
   scriptElem: Option[Html] = None,
+  backUrl: Option[String] = None,
   showLogout: Boolean = true)(implicit request: Request[_], messages: Messages)
 
 @linksElem = {
@@ -100,14 +103,15 @@
       includeHMRCBranding = true,
       setLang = messages.lang.code
     )
+
+    @languageSelection()
+    @backUrl.map(backLink(_))
 }
 
 @mainContentHeader = {
-
     @if(contentHeader.isDefined) {
         <header class="page-header inline-block">@contentHeader.get</header>
     }
-    @languageSelection()
 }
 
 @getHelpForm = @{reportAProblemLink(appConfig.reportAProblemPartialUrl, appConfig.reportAProblemNonJSUrl)}

--- a/app/views/templates/MainTemplate.scala.html
+++ b/app/views/templates/MainTemplate.scala.html
@@ -28,6 +28,7 @@
   bodyClasses: Option[String] = None,
   mainClass: Option[String] = None,
   scriptElem: Option[Html] = None,
+  backUrl: Option[String] = None,
   showLogout: Boolean = true,
   showBtaHeader: Boolean = true,
   serviceInfo: Html = Html(""),
@@ -77,6 +78,7 @@
                mainContent = article(mainContentWithGA),
                serviceInfoContent = serviceInfo,
                scriptElem = Some(defaultScriptElem),
+               backUrl = backUrl,
                showLogout = showLogout
 )
 

--- a/app/views/templates/agent/GovUkWrapper.scala.html
+++ b/app/views/templates/agent/GovUkWrapper.scala.html
@@ -14,6 +14,7 @@
  * limitations under the License.
  *@
 
+@import views.html.helpers.injected.BackLink
 @import views.html.helpers.injected.BetaBanner
 @import views.html.helpers.injected.LanguageSelection
 @import views.html.helpers.injected.RecruitmentBannerHelper
@@ -30,6 +31,7 @@
 @this(
         appConfig: config.FrontendAppConfig,
         betaBanner: BetaBanner,
+        backLink: BackLink,
         languageSelection: LanguageSelection,
         recruitmentBannerHelper: RecruitmentBannerHelper,
         govUkTemplate: GovUkTemplate,
@@ -50,6 +52,7 @@
   mainContent: Html = HtmlFormat.empty,
   serviceInfoContent: Html = HtmlFormat.empty,
   scriptElem: Option[Html] = None,
+  backUrl: Option[String] = None,
   showLogout: Boolean = true,
   form: Option[Form[_]] = None
 )(implicit request : Request[_], messages: Messages)
@@ -109,14 +112,15 @@
       includeHMRCBranding = true,
       setLang = messages.lang.code
     )
+
+    @languageSelection()
+    @backUrl.map(backLink(_))
 }
 
 @mainContentHeader = {
-
     @if(contentHeader.isDefined) {
         <header class="page-header inline-block">@contentHeader.get</header>
     }
-        @languageSelection()
 }
 
 @getHelpForm = @{reportAProblemLink(appConfig.reportAProblemPartialUrl, appConfig.reportAProblemNonJSUrl)}

--- a/app/views/templates/agent/MainTemplate.scala.html
+++ b/app/views/templates/agent/MainTemplate.scala.html
@@ -28,6 +28,7 @@
         bodyClasses: Option[String] = None,
         mainClass: Option[String] = None,
         scriptElem: Option[Html] = None,
+        backUrl: Option[String] = None,
         showLogout: Boolean = true,
         serviceInfo: Html = Html(""),
         timeout: Boolean = true,
@@ -77,6 +78,7 @@
                mainContent = article(mainContentWithGA),
                serviceInfoContent = serviceInfo,
                scriptElem = Some(defaultScriptElem),
+               backUrl = backUrl,
                showLogout = showLogout,
                form = form
 )

--- a/test/controllers/NotEnrolledControllerSpec.scala
+++ b/test/controllers/NotEnrolledControllerSpec.scala
@@ -17,7 +17,6 @@
 package controllers
 
 import assets.MessagesLookUp.{NotEnrolled => notEnrolleMessages}
-import config.FrontendAppConfig
 import controllers.errors.NotEnrolledController
 import org.jsoup.Jsoup
 import play.api.http.Status
@@ -28,7 +27,6 @@ import views.html.notEnrolled.NotEnrolled
 class NotEnrolledControllerSpec extends TestSupport {
 
   object TestNotEnrolledController extends NotEnrolledController(app.injector.instanceOf[NotEnrolled])(
-    app.injector.instanceOf[FrontendAppConfig],
     app.injector.instanceOf[MessagesControllerComponents]
   )
 

--- a/test/controllers/errors/AgentErrorControllerSpec.scala
+++ b/test/controllers/errors/AgentErrorControllerSpec.scala
@@ -17,7 +17,6 @@
 package controllers.errors
 
 import assets.MessagesLookUp.{AgentErrorMessages => pageMessages}
-import config.FrontendAppConfig
 import controllers.predicates.SessionTimeoutPredicate
 import mocks.controllers.predicates.MockAuthenticationPredicate
 import org.jsoup.Jsoup
@@ -34,8 +33,7 @@ class AgentErrorControllerSpec extends TestSupport with MockAuthenticationPredic
     app.injector.instanceOf[AgentError]
   )(
     ec,
-    app.injector.instanceOf[MessagesControllerComponents],
-    app.injector.instanceOf[FrontendAppConfig]
+    app.injector.instanceOf[MessagesControllerComponents]
   )
 
   "Calling the show action of the NotAnAgentController" should {

--- a/test/testUtils/ViewSpec.scala
+++ b/test/testUtils/ViewSpec.scala
@@ -43,7 +43,7 @@ trait ViewSpec extends TestSupport {
     val h1: String = "h1"
     val h2: String = "h2"
     val h3: String = "h3"
-    val backLink: String = ".link-back"
+    val backLink: String = id("back")
     val backToHome: String = "back"
     val form: String = "form"
     val summaryError: String = "#error-summary-display ul a"

--- a/test/views/agent/ConfirmClientViewSpec.scala
+++ b/test/views/agent/ConfirmClientViewSpec.scala
@@ -59,8 +59,9 @@ class ConfirmClientViewSpec extends ViewSpec {
     }
 
     s"have a back link" in new Setup(confirmClientView) {
-      content.backLink.text shouldBe confirmClientMessages.backLink
-      content.hasBackLinkTo(controllers.agent.routes.EnterClientsUTRController.show().url)
+      content.doesNotHave(Selectors.backLink)
+      document.backLink.text shouldBe confirmClientMessages.backLink
+      document.hasBackLinkTo(controllers.agent.routes.EnterClientsUTRController.show().url)
     }
 
     s"have the sub heading ${confirmClientMessages.clientNameHeading}" in new Setup(confirmClientView) {

--- a/test/views/agent/TaxYearOverviewViewSpec.scala
+++ b/test/views/agent/TaxYearOverviewViewSpec.scala
@@ -240,7 +240,8 @@ class TaxYearOverviewViewSpec extends ViewSpec with FeatureSwitching {
     }
 
     "have a back link" in new Setup(view()) {
-      val backLink: Element = content.backLink
+      content.doesNotHave(Selectors.backLink)
+      val backLink: Element = document.backLink
       backLink.text shouldBe TaxYearOverviewMessages.back
       backLink.attr("href") shouldBe "/testBack"
     }

--- a/test/views/agent/TaxYearsViewSpec.scala
+++ b/test/views/agent/TaxYearsViewSpec.scala
@@ -56,8 +56,9 @@ class TaxYearsViewSpec extends ViewSpec {
     }
 
     "have a back link" in new Setup(view()) {
-      content.backLink.text shouldBe TaxYearsMessages.back
-      content.hasBackLinkTo(testBackUrl)
+      content.doesNotHave(Selectors.backLink)
+      document.backLink.text shouldBe TaxYearsMessages.back
+      document.hasBackLinkTo(testBackUrl)
     }
 
     "have a message that there are no calculations" when {


### PR DESCRIPTION
The language toggle and back links were inside the (div id="content") element which prevents the skip link from bypassing repeated navigation elements on the page.
Resolved: Moved the language toggle and back links outside (above) of the (div id="content") element.