### PR TITLE
SASS-1564: Update V&C page URLs

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -127,9 +127,9 @@ class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, val config
   // This URL has a set year and environment. Please use submissionFrontendTaxOverviewUrl instead.
   lazy val submissionFrontendUrl: String = servicesConfig.getString("income-tax-submission-frontend.url")
   lazy val submissionFrontendTaxOverviewUrl: Int => String = taxYear =>
-    servicesConfig.getString("income-tax-submission-frontend.host") + s"/income-through-software/return/$taxYear/view"
+    servicesConfig.getString("income-tax-submission-frontend.host") + s"/update-and-submit-income-tax-return/$taxYear/view"
   lazy val submissionFrontendFinalDeclarationUrl: Int => String = taxYear =>
-    servicesConfig.getString("income-tax-submission-frontend.host") + s"/income-through-software/return/$taxYear/declaration"
+    servicesConfig.getString("income-tax-submission-frontend.host") + s"/update-and-submit-income-tax-return/$taxYear/declaration"
 
   // Disagree with a tax decision
   lazy val taxAppealsUrl: String = servicesConfig.getString("tax-appeals.url")

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -264,7 +264,7 @@ payment-history {
 }
 
 income-tax-submission-frontend {
-  url = "http://localhost:9302/income-through-software/return/2022/start"
+  url = "http://localhost:9302/update-and-submit-income-tax-return/2022/start"
   host = "http://localhost:9302"
 }
 

--- a/it/controllers/FinalTaxCalculationControllerISpec.scala
+++ b/it/controllers/FinalTaxCalculationControllerISpec.scala
@@ -84,7 +84,7 @@ class FinalTaxCalculationControllerISpec extends ComponentSpecBase {
 
     val insetTextFull = "If you think this information is incorrect, you can check your Income Tax Return."
     val insetTextLink = "check your Income Tax Return."
-    val insetLinkHref = "http://localhost:9302/income-through-software/return/2018/view"
+    val insetLinkHref = "http://localhost:9302/update-and-submit-income-tax-return/2018/view"
 
     val incomeText = "Income"
     val incomeAmount = "£199,505.00"
@@ -431,7 +431,7 @@ class FinalTaxCalculationControllerISpec extends ComponentSpecBase {
       }
       
       "has the correct redirect url" in {
-        result.headers("Location").head shouldBe "http://localhost:9302/income-through-software/return/2018/declaration"
+        result.headers("Location").head shouldBe "http://localhost:9302/update-and-submit-income-tax-return/2018/declaration"
       }
       
     }

--- a/it/controllers/agent/FinalTaxCalculationControllerISpec.scala
+++ b/it/controllers/agent/FinalTaxCalculationControllerISpec.scala
@@ -85,7 +85,7 @@ class FinalTaxCalculationControllerISpec extends ComponentSpecBase with SessionC
 
     val insetTextFull = "If you think this information is incorrect, you can check your client’s Income Tax Return."
     val insetTextLink = "check your client’s Income Tax Return."
-    val insetLinkHref = "http://localhost:9302/income-through-software/return/2018/view"
+    val insetLinkHref = "http://localhost:9302/update-and-submit-income-tax-return/2018/view"
 
     val incomeText = "Income"
     val incomeAmount = "£199,505.00"
@@ -485,7 +485,7 @@ class FinalTaxCalculationControllerISpec extends ComponentSpecBase with SessionC
       }
 
       "has the correct redirect url" in {
-        result.headers("Location").head shouldBe "http://localhost:9302/income-through-software/return/2018/declaration"
+        result.headers("Location").head shouldBe "http://localhost:9302/update-and-submit-income-tax-return/2018/declaration"
       }
 
     }

--- a/test/views/HomePageViewSpec.scala
+++ b/test/views/HomePageViewSpec.scala
@@ -183,7 +183,7 @@ class HomePageViewSpec extends TestSupport {
     }
     "has a link to the send updates page" in new Setup {
       val link: Option[Elements] = getElementById("submit-your-returns-tile").map(_.select("a"))
-      link.map(_.attr("href")) shouldBe Some("http://localhost:9302/income-through-software/return/2022/start")
+      link.map(_.attr("href")) shouldBe Some("http://localhost:9302/update-and-submit-income-tax-return/2022/start")
       document.getElementById("submit-your-returns").text() shouldBe homeMessages.submitYourReturnsLink
     }
 

--- a/test/views/agent/HomePageViewSpec.scala
+++ b/test/views/agent/HomePageViewSpec.scala
@@ -193,7 +193,7 @@ class HomePageViewSpec extends TestSupport with FeatureSwitching with ViewSpec {
         }
         "has a link to the send updates page" in new Setup {
           val link: Option[Elements] = getElementById("submit-your-returns-tile").map(_.select("a"))
-          link.map(_.attr("href")) shouldBe Some("http://localhost:9302/income-through-software/return/2022/start")
+          link.map(_.attr("href")) shouldBe Some("http://localhost:9302/update-and-submit-income-tax-return/2022/start")
           link.map(_.text) shouldBe Some(homeMessages.submitYourReturnsLink)
         }
       }


### PR DESCRIPTION
Change all `/income-through-software/return/` strings to `/update-and-submit-income-tax-return/`

[SASS-1564](https://jira.tools.tax.service.gov.uk/browse/SASS-1564)