### PR TITLE
SASS-2499a accessibility fixes to banner, heading & link

### DIFF
--- a/app/views/FinalTaxCalculationView.scala.html
+++ b/app/views/FinalTaxCalculationView.scala.html
@@ -30,7 +30,7 @@
       form: FormWithCSRF,
       continueButton: ContinueButton,
       p: p,
-      h1Caption: h1_caption,
+      h1Caption: h1_itsa,
       govukInsetText : GovukInsetText
 )
 
@@ -49,7 +49,7 @@
 }
 
 @insetContent = {
-    @messages("final-tax-overview.inset.1") <a href=@{appConfig.submissionFrontendTaxOverviewUrl(taxYear)}>@messages(s"final-tax-overview.${if(isAgent) "agent" else "individual"}.inset.2")</a>
+    @messages("final-tax-overview.inset.1") <a class="govuk-link" href=@{appConfig.submissionFrontendTaxOverviewUrl(taxYear)}>@messages(s"final-tax-overview.${if(isAgent) "agent" else "individual"}.inset.2")</a>
 }
 
 @formCall = @{

--- a/app/views/InYearTaxCalculationView.scala.html
+++ b/app/views/InYearTaxCalculationView.scala.html
@@ -31,7 +31,7 @@
       form: FormWithCSRF,
       continueButton: ContinueButton,
       p: p,
-      h1Caption: h1_caption,
+      h1Caption: h1_itsa,
       govukInsetText : GovukInsetText
 )
 

--- a/app/views/components/h1_itsa.scala.html
+++ b/app/views/components/h1_itsa.scala.html
@@ -1,0 +1,24 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(heading: String, subheading: Option[String])(implicit messages: Messages)
+
+<header class="hmrc-page-heading govuk-!-margin-0 govuk-!-margin-bottom-5">
+ <h1 class="govuk-heading-xl govuk-!-margin-0 govuk-!-margin-bottom-5">@heading</h1>
+ <p class="govuk-caption-xl hmrc-caption-xl">@subheading</p>
+</header>

--- a/app/views/layouts/layout.scala.html
+++ b/app/views/layouts/layout.scala.html
@@ -61,7 +61,7 @@
         containerClasses = "govuk-width-container",
         language = CurrentLanguage(),
         signOutHref = Some(controllers.routes.SignOutController.signOut.url),
-        userResearchBanner =  Some(UserResearchBanner(url = appConfig.enterSurveyUrl))
+        userResearchBanner =  {if(itsaTaxYear.isDefined) None else Some(UserResearchBanner(url = appConfig.enterSurveyUrl))}
     ))
 }
 

--- a/it/controllers/FinalTaxCalculationControllerISpec.scala
+++ b/it/controllers/FinalTaxCalculationControllerISpec.scala
@@ -49,7 +49,7 @@ class FinalTaxCalculationControllerISpec extends ComponentSpecBase {
   }
 
   object Selectors {
-    val caption = "h1 > span"
+    val caption = "#main-content > div > div > div > header > p"
     val title = "h1"
 
     val insetText = "#main-content > div > div > div > p.govuk-inset-text"

--- a/it/controllers/InYearTaxCalculationControllerISpec.scala
+++ b/it/controllers/InYearTaxCalculationControllerISpec.scala
@@ -80,7 +80,7 @@ class InYearTaxCalculationControllerISpec extends ComponentSpecBase {
   }
 
   object Selectors {
-    val caption = "h1 > span"
+    val caption = "#main-content > div > div > div > header > p"
     val title = "h1"
 
     val insetText = "#main-content > div > div > div > p"

--- a/it/controllers/agent/FinalTaxCalculationControllerISpec.scala
+++ b/it/controllers/agent/FinalTaxCalculationControllerISpec.scala
@@ -51,7 +51,7 @@ class FinalTaxCalculationControllerISpec extends ComponentSpecBase with SessionC
   }
 
   object Selectors {
-    val caption = "h1 > span"
+    val caption = "#main-content > div > div > div > header > p"
     val title = "h1"
 
     val insetText = "#main-content > div > div > div > p.govuk-inset-text"

--- a/it/controllers/agent/InYearTaxCalculationControllerISpec.scala
+++ b/it/controllers/agent/InYearTaxCalculationControllerISpec.scala
@@ -101,7 +101,7 @@ class InYearTaxCalculationControllerISpec extends ComponentSpecBase {
   )
 
   object Selectors {
-    val caption = "h1 > span"
+    val caption = "#main-content > div > div > div > header > p"
     val title = "h1"
 
     val insetText = "#main-content > div > div > div > p"


### PR DESCRIPTION
SASS-2499 

Accessibility fixes from ticket [SASS-2499](https://jira.tools.tax.service.gov.uk/browse/SASS-2499)

Final Tax Overview Page: Link missing gov.uk style
Final Tax Overview and In year estimate Page: Heading structure
Final Tax Overview and In Year Tax Estimate Page: Remove the HMRC Banner
 