### PR TITLE
SASS-2500 accessibility fix hmrc banner

### DIFF
--- a/app/views/layouts/layout.scala.html
+++ b/app/views/layouts/layout.scala.html
@@ -86,7 +86,7 @@
 
 @beforeContentBlock = {
     @phaseBanner("beta")
-    @hmrcBanner(Banner(CurrentLanguage()))
+    @{if(itsaTaxYear.isDefined) None else hmrcBanner(Banner(CurrentLanguage()))}
     @{btaNavPartial.getOrElse(())}
         <div class="nav-bar-wrapper">
             @languageSelection()
@@ -102,7 +102,7 @@
     <div class="govuk-body app-get-help-link">
         <a lang="en" hreflang="en" class="govuk-link" rel="noreferrer noopener" target="_blank" href="@{appConfig.reportAProblemNonJSUrl}">
             @messages("getpagehelp.linkText")
-            @messages("pagehelp.opensInNewTabText")
+            @{if(itsaTaxYear.isDefined) None else messages("pagehelp.opensInNewTabText")}
         </a>
     </div>
 


### PR DESCRIPTION
SASS-2499
Accessibility fixes
 - hide HMRC banner on in year tax estimate & final tax overview pages
 - update help link text on in year tax estimate & final tax overview pages