### PR TITLE
MISUV-3711: change home page link based on the migration status

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -62,7 +62,6 @@ class HomeController @Inject()(val homeView: views.html.Home,
                    overDueUpdatesCount: Option[Int], dunningLockExists: Boolean, currentTaxYear: Int, isAgent: Boolean,
                    origin : Option[String] = None)
                   (implicit user: MtdItUser[_]): Html = {
-    val userMigrated = user.incomeSources.yearOfMigration.isDefined
     homeView(
       nextPaymentDueDate = nextPaymentDueDate,
       nextUpdate = nextUpdate,
@@ -75,7 +74,7 @@ class HomeController @Inject()(val homeView: views.html.Home,
       isAgent = isAgent,
       origin = origin,
       creditAndRefundEnabled = isEnabled(CreditsRefundsRepay),
-      isUserMigrated = userMigrated
+      isUserMigrated = user.incomeSources.yearOfMigration.isDefined
     )
   }
 

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -62,6 +62,7 @@ class HomeController @Inject()(val homeView: views.html.Home,
                    overDueUpdatesCount: Option[Int], dunningLockExists: Boolean, currentTaxYear: Int, isAgent: Boolean,
                    origin : Option[String] = None)
                   (implicit user: MtdItUser[_]): Html = {
+    val userMigrated = user.incomeSources.yearOfMigration.isDefined
     homeView(
       nextPaymentDueDate = nextPaymentDueDate,
       nextUpdate = nextUpdate,
@@ -73,7 +74,8 @@ class HomeController @Inject()(val homeView: views.html.Home,
       currentTaxYear = currentTaxYear,
       isAgent = isAgent,
       origin = origin,
-      creditAndRefundEnabled = isEnabled(CreditsRefundsRepay)
+      creditAndRefundEnabled = isEnabled(CreditsRefundsRepay),
+      isUserMigrated = userMigrated
     )
   }
 

--- a/app/views/Home.scala.html
+++ b/app/views/Home.scala.html
@@ -107,8 +107,6 @@
         }
     }
 
-
-
     @tiles() = {
         <div class="grid-row">
             <div class="flex-container govuk-!-padding-0">

--- a/app/views/Home.scala.html
+++ b/app/views/Home.scala.html
@@ -47,7 +47,9 @@
   	currentTaxYear: Int,
     isAgent: Boolean,
     origin: Option[String] = None,
-    creditAndRefundEnabled: Boolean)(
+    creditAndRefundEnabled: Boolean,
+    isUserMigrated: Boolean = false
+)(
   	implicit request: Request[_],
 	messages: Messages,
   	user: auth.MtdItUser[_],
@@ -94,12 +96,18 @@
     }
 
     @creditAndRefundsControllerURL = @{
+        if (isUserMigrated) {
            if(isAgent) {
                controllers.routes.CreditAndRefundController.showAgent().url
            } else {
                controllers.routes.CreditAndRefundController.show().url
             }
+        } else {
+            ""
+        }
     }
+
+
 
     @tiles() = {
         <div class="grid-row">
@@ -246,10 +254,17 @@
     }
 
     @if(creditAndRefundEnabled) {
-        @link(
-            link = creditAndRefundsControllerURL,
-            messageKey = "home.credAndRefund.view"
-        )
+        @if(isUserMigrated) {
+            @link(
+                link = creditAndRefundsControllerURL,
+                messageKey = "home.credAndRefund.view"
+            )
+        } else {
+            @link(
+                link = creditAndRefundsControllerURL,
+                messageKey = "home.credAndRefund_howToClaim.view"
+            )
+        }
     }
 }
 }

--- a/conf/messages
+++ b/conf/messages
@@ -116,6 +116,7 @@ home.your-returns.updatesLink                                   = Update and sub
 home.returns.viewLink                                           = View your current {0} to {1} return
 home.self-assessment.description                                = Use this service to view your earlier tax year information before you signed up for Making Tax Digital for Income Tax.
 home.credAndRefund.view                                         = Claim a refund
+home.credAndRefund_howToClaim.view                              = How to claim a refund
 
 home.overdue.message.dunningLock.true                           = You have overdue payments and one or more of your tax decisions are being reviewed. You may be charged interest on these until they are paid in full.
 home.overdue.message.dunningLock.false                          = You have overdue payments. You may be charged interest on these until they are paid in full.

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -106,6 +106,7 @@ home.updates.overdue.payments                                   = {0} TALIADAU S
 home.updates.overdue.updates                                    = {0} YN HWYR Diweddariadau
 home.self-assessment.description                                = Defnyddiwch y gwasanaeth hwn i fwrw golwg dros eich gwybodaeth am flynyddoedd treth cynharach cyn i chi gofrestru ar gyfer y cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm.
 home.credAndRefund.view                                         = Hawlio ad-daliad
+home.credAndRefund_howToClaim.view                              = Sut i hawlio ad-daliad
 
 
 ## Recruitment Banner ##


### PR DESCRIPTION
  * dynamically change 'claim and refund link' on the home page, depending on the user migration status;
  * add required english/welsh resource for link title;
  * fix broken unit tests + add addition tests to cover case where user not migrated;