### PR TITLE
MISUV-3860: CreditHistoryService rework number 2

### DIFF
--- a/app/models/CreditDetailModel.scala
+++ b/app/models/CreditDetailModel.scala
@@ -19,22 +19,12 @@ package models
 import models.financialDetails.{DocumentDetail, FinancialDetailsModel}
 import models.paymentAllocationCharges.FinancialDetailsWithDocumentDetailsModel
 
-case class CreditDetailModel(documentDetail: DocumentDetail, creditType: CreditType)
+import java.time.LocalDate
+
+case class CreditDetailModel(date: LocalDate , documentDetail: DocumentDetail, creditType: CreditType)
 
 sealed trait CreditType
 
 case object MfaCreditType extends CreditType
 
 case object CutOverCreditType extends CreditType
-
-object CreditDetailModel {
-
-  implicit def financialDetailsWithDocumentDetailsModelToCreditDetailsModel(document: FinancialDetailsWithDocumentDetailsModel): List[CreditDetailModel] = {
-    document.documentDetails.map(documentDetail => CreditDetailModel(documentDetail = documentDetail, creditType = CutOverCreditType))
-  }
-
-  implicit def financialDetailsModelToCreditModel(document: FinancialDetailsModel): List[CreditDetailModel] = {
-    document.documentDetails.map(documentDetail => CreditDetailModel(documentDetail = documentDetail, creditType = MfaCreditType))
-  }
-
-}

--- a/app/services/CreditHistoryService.scala
+++ b/app/services/CreditHistoryService.scala
@@ -51,12 +51,14 @@ class CreditHistoryService @Inject()(incomeTaxViewChangeConnector: IncomeTaxView
                   .map(dueDate => CreditDetailModel(date = dueDate, document, CutOverCreditType))
               case (true, true) =>
                 // Is this a bug ? we have MFA credits with properties of CutOver redits
-                // TODO: this is might be to do with the data we have, we might need to have a strict distinction between MFA and CutOver creds
+                // TODO: raise a story to tidy up these data.
                 Some(CreditDetailModel(date = document.documentDate, document, MfaCreditType))
-              case (_, _) => None
+              case (_, _) =>
+                None
             }
           }.flatten
           Future {
+            println(fdRes)
             Right(fdRes)
           }
         case _ =>

--- a/app/services/CreditHistoryService.scala
+++ b/app/services/CreditHistoryService.scala
@@ -58,7 +58,6 @@ class CreditHistoryService @Inject()(incomeTaxViewChangeConnector: IncomeTaxView
             }
           }.flatten
           Future {
-            println(fdRes)
             Right(fdRes)
           }
         case _ =>

--- a/app/services/CreditHistoryService.scala
+++ b/app/services/CreditHistoryService.scala
@@ -19,13 +19,14 @@ package services
 import auth.MtdItUser
 import config.FrontendAppConfig
 import connectors.IncomeTaxViewChangeConnector
-import models.CreditDetailModel
+import models.{CreditDetailModel, CreditType, CutOverCreditType, MfaCreditType}
 import models.core.Nino
 import models.financialDetails.{FinancialDetailsErrorModel, FinancialDetailsModel, Payments, PaymentsError}
 import models.paymentAllocationCharges.FinancialDetailsWithDocumentDetailsModel
 import services.CreditHistoryService.CreditHistoryError
 import uk.gov.hmrc.http.HeaderCarrier
 
+import java.time.LocalDate
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -33,85 +34,47 @@ class CreditHistoryService @Inject()(incomeTaxViewChangeConnector: IncomeTaxView
                                      val appConfig: FrontendAppConfig)
                                     (implicit ec: ExecutionContext) {
 
-  // A: list of documentNumbers for CutOver Credits for the given tax year
-  private def getCutOverDocumentNumbersByTaxYear(taxYear: Int)
-                                                (implicit hc: HeaderCarrier, user: MtdItUser[_]): Future[Either[CreditHistoryError.type, List[String]]] = {
-    for {
-      paymentsResponse <- incomeTaxViewChangeConnector.getPayments(taxYear)
-      payments = paymentsResponse match {
-        case Payments(payments) => Right(Payments(payments))
-        case PaymentsError(status, _) if status == 404 => Left(CreditHistoryError)
-        case PaymentsError(_, _) => Left(CreditHistoryError)
-      }
-    } yield payments match {
-      case Right(payments) =>
-        val documentNumbers: List[String] = payments
-          .payments
-          .filter(_.credit.isDefined)
-          .map(_.transactionId)
-          .filter(_.isDefined)
-          .map(_.get)
-          .toList
-        Right(documentNumbers)
-      case Left(errors) => Left(errors)
-    }
-  }
-
-  // B: Get cutOver credits models for the given tax year and Nino
-  private def getAllCutOverCreditsByTaxYear(taxYear: Int, nino: String)
-                                           (implicit hc: HeaderCarrier, user: MtdItUser[_]): Future[Either[CreditHistoryError.type, List[CreditDetailModel]]] = {
-    import CreditDetailModel._
-    getCutOverDocumentNumbersByTaxYear(taxYear).flatMap { result =>
-      result match {
-        case Right(documentIds) =>
-          val futureCreditModels = Future.sequence(
-            for {
-              creditModel <- documentIds.map { documentNumber =>
-                incomeTaxViewChangeConnector
-                  .getFinancialDetailsByDocumentId(Nino(nino), documentNumber)
-                  .map {
-                    case document: FinancialDetailsWithDocumentDetailsModel =>
-                      val creditDetailsModel: List[CreditDetailModel] = document
-                      creditDetailsModel
-                    case _ =>
-                      throw new Exception("CreditHistoryService::ERROR::CutOverCredits")
-                  }
-              }
-            } yield creditModel
-          )
-          futureCreditModels.flatMap(e => Future {
-            Right(e.flatten)
-          })
-        case Left(error) =>
-          Future {
-            Left(error)
-          }
-      }
-    }
-  }
-
-  // C: Get all credits (MFA + CutOver one) by tax year (and given Nino)
-  def getCreditsHistory(taxYear: Int, nino: String)
-                       (implicit hc: HeaderCarrier, user: MtdItUser[_]): Future[Either[CreditHistoryError.type, List[CreditDetailModel]]] = {
-    incomeTaxViewChangeConnector.getFinancialDetails(taxYear, nino).map {
+  // This logic is based on the findings in => RepaymentHistoryUtils.combinePaymentHistoryData method
+  // Problem: we need to get list of credits (MFA + CutOver) and filter it out by calendar year
+  // MFA credits are driven by documentDate
+  // CutOver credit by dueDate found in financialDetails related to the corresponding documentDetail (see getDueDateFor)
+  private def getCreditsByTaxYear(taxYear: Int, nino: String)
+                         (implicit hc: HeaderCarrier, user: MtdItUser[_]): Future[Either[CreditHistoryError.type, List[CreditDetailModel]]] = {
+    incomeTaxViewChangeConnector.getFinancialDetails(taxYear, nino) match {
       case financialDetails: FinancialDetailsModel =>
-        for {
-          x <- getAllCutOverCreditsByTaxYear(taxYear, nino).flatMap { result =>
-            result match {
-              case Right(creditModels) => Future {
-                val mfaCredits: List[CreditDetailModel] = financialDetails
-                // merge cutOver credits with MFA credits
-                Right(creditModels ++ mfaCredits)
-              }
-              case e@Left(_) => Future {
-                e
-              }
-            }
+        val creditModels = financialDetails.documentDetails.map{ document =>
+          (document.validMFACreditDescription(), document.credit.isDefined ) match {
+            case (true, false) =>
+              Some(CreditDetailModel(date = document.documentDate, document, MfaCreditType))
+            case (false, true) =>
+              // if we didn't find CutOverCredit dueDate then we "lost" this document
+              financialDetails
+                .getDueDateFor(document)
+                .map(dueDate => CreditDetailModel(date = dueDate, document, CutOverCreditType))
+            case (_, _) => None
           }
-        } yield x
-      case _: FinancialDetailsErrorModel =>
-        Future(Left(CreditHistoryError))
-    }.flatten
+        }.flatten
+        Future{ Right(creditModels) }
+      case _ =>
+        Future{ Left(CreditHistoryError) }
+    }
+  }
+
+  def getCreditsHistory(calendarYear: Int, nino: String)
+                       (implicit hc: HeaderCarrier, user: MtdItUser[_]): Future[Either[CreditHistoryError.type, List[CreditDetailModel]]] = {
+    for {
+      creditModelForTaxYear <- getCreditsByTaxYear(calendarYear, nino)
+      creditModelForTaxYearPlusOne <- getCreditsByTaxYear(calendarYear + 1, nino)
+    } yield (creditModelForTaxYear,  creditModelForTaxYearPlusOne) match {
+      case (Right(creditModelTY), Right(creditModelTYandOne)) =>
+        Right((creditModelTY ++ creditModelTYandOne).filter(_.date.getYear == calendarYear))
+      case (Right(creditModelTY), Left(_)) =>
+        Right(creditModelTY.filter(_.date.getYear == calendarYear))
+      case (Left(_), Right(creditModelTYandOne)) =>
+        Right( creditModelTYandOne.filter(_.date.getYear == calendarYear))
+      case (_, _) =>
+        Left(CreditHistoryError)
+    }
   }
 
 }

--- a/test/services/CreditHistoryServiceSpec.scala
+++ b/test/services/CreditHistoryServiceSpec.scala
@@ -60,7 +60,7 @@ class CreditHistoryServiceSpec extends TestSupport with MockIncomeTaxViewChangeC
     }
 
     "a successful response returned from the connector" should {
-      "return a list of MFA credits only" in {
+      "return a list of MFA and CutOver credits" in {
         setupMockGetFinancialDetails(taxYear, nino)(taxYearFinancialDetails)
         setupMockGetFinancialDetails(taxYear + 1, nino)(taxYearFinancialDetails_PlusOneYear)
         val futureResult = TestCreditHistoryService.getCreditsHistory(taxYear, nino)

--- a/test/services/CreditHistoryServiceSpec.scala
+++ b/test/services/CreditHistoryServiceSpec.scala
@@ -65,7 +65,7 @@ class CreditHistoryServiceSpec extends TestSupport with MockIncomeTaxViewChangeC
         setupMockGetFinancialDetails(taxYear + 1, nino)(taxYearFinancialDetails_PlusOneYear)
         val futureResult = TestCreditHistoryService.getCreditsHistory(taxYear, nino)
         whenReady(futureResult) { result =>
-          result shouldBe Right(List(creditDetailModel))
+          result shouldBe Right(List(creditDetailModelasCutOver, creditDetailModelasMfa))
         }
       }
     }

--- a/test/services/CreditHistoryServiceSpec.scala
+++ b/test/services/CreditHistoryServiceSpec.scala
@@ -52,47 +52,23 @@ class CreditHistoryServiceSpec extends TestSupport with MockIncomeTaxViewChangeC
 
     "an error is returned from the connector" should {
 
-      "return a credit history error (~GetFinancialDetails failed)" in {
+      "return a credit history error (~getFinancialDetails failed)" in {
         setupMockGetFinancialDetails(taxYear, nino)(FinancialDetailsErrorModel(500, "ERROR"))
         setupMockGetFinancialDetails(taxYear + 1, nino)(FinancialDetailsErrorModel(500, "ERROR"))
         TestCreditHistoryService.getCreditsHistory(taxYear, nino).futureValue shouldBe Left(CreditHistoryError)
       }
+    }
 
-      "return a credit history error (~getFinancialDetailsByDocumentId failed)" in {
+    "a successful response returned from the connector" should {
+      "return a list of MFA credits only" in {
         setupMockGetFinancialDetails(taxYear, nino)(taxYearFinancialDetails)
         setupMockGetFinancialDetails(taxYear + 1, nino)(taxYearFinancialDetails_PlusOneYear)
         val futureResult = TestCreditHistoryService.getCreditsHistory(taxYear, nino)
-        futureResult.isCompleted shouldBe false
+        whenReady(futureResult) { result =>
+          result shouldBe Right(List(creditDetailModel))
+        }
+      }
     }
-
-//    "a successful Payment/Credit History response is returned from the connector" should {
-//      "return a list of MFA credits only" in {
-//        setupGetPayments(taxYear)(Payments(paymentsForTheGivenTaxYear))
-//        setupMockGetFinancialDetails(taxYear, nino)(taxYearFinancialDetails)
-//        val mfaCreditModels = TestCreditHistoryService.getCreditsHistory(taxYear, nino).futureValue
-//        mfaCreditModels shouldBe Right(creditModels)
-//        mfaCreditModels.right.foreach { ds =>
-//          ds.foreach{ d =>
-//            d.creditType shouldBe MfaCreditType
-//          }
-//        }
-//      }
-//
-//      "return a list of MFA and CutOver credits" in {
-//        setupGetPayments(taxYear)(Payments(creditsForTheGivenTaxYear))
-//        setupMockGetFinancialDetails(taxYear, nino)(taxYearFinancialDetails)
-//        setupGetPaymentAllocationCharges(nino, documentIdA)(cutOverCreditsAsFinancialDocumentA)
-//        setupGetPaymentAllocationCharges(nino, documentIdB)(cutOverCreditsAsFinancialDocumentB)
-//        val cs = TestCreditHistoryService.getCreditsHistory(taxYear, nino).futureValue
-//        cs shouldBe Right(cutOverCreditA ++ cutOverCreditB ++ creditModels)
-//        cs.right.foreach { ds =>
-//          ds.filter(_.creditType == CutOverCreditType).length shouldBe (cutOverCreditA ++ cutOverCreditB).length
-//          ds.filter(_.creditType == MfaCreditType).length shouldBe creditModels.length
-//        }
-//      }
-
-    }
-
   }
 
 }

--- a/test/services/CreditHistoryServiceSpec.scala
+++ b/test/services/CreditHistoryServiceSpec.scala
@@ -19,9 +19,7 @@ package services
 import auth.MtdItUser
 import config.featureswitch.FeatureSwitching
 import mocks.connectors.MockIncomeTaxViewChangeConnector
-import models.financialDetails.{FinancialDetailsErrorModel, Payments}
-import models.paymentAllocationCharges.FinancialDetailsWithDocumentDetailsErrorModel
-import models.{CutOverCreditType, MfaCreditType}
+import models.financialDetails.FinancialDetailsErrorModel
 import play.api.test.FakeRequest
 import services.CreditHistoryService.CreditHistoryError
 import services.helpers.CreditHistoryDataHelper
@@ -56,46 +54,42 @@ class CreditHistoryServiceSpec extends TestSupport with MockIncomeTaxViewChangeC
 
       "return a credit history error (~GetFinancialDetails failed)" in {
         setupMockGetFinancialDetails(taxYear, nino)(FinancialDetailsErrorModel(500, "ERROR"))
+        setupMockGetFinancialDetails(taxYear + 1, nino)(FinancialDetailsErrorModel(500, "ERROR"))
         TestCreditHistoryService.getCreditsHistory(taxYear, nino).futureValue shouldBe Left(CreditHistoryError)
       }
 
       "return a credit history error (~getFinancialDetailsByDocumentId failed)" in {
-        setupGetPayments(taxYear)(Payments(creditsForTheGivenTaxYear))
         setupMockGetFinancialDetails(taxYear, nino)(taxYearFinancialDetails)
-        setupGetPaymentAllocationCharges(nino, documentIdA)(FinancialDetailsWithDocumentDetailsErrorModel(0, "error-1"))
-        setupGetPaymentAllocationCharges(nino, documentIdB)(FinancialDetailsWithDocumentDetailsErrorModel(1, "error-2"))
+        setupMockGetFinancialDetails(taxYear + 1, nino)(taxYearFinancialDetails_PlusOneYear)
         val futureResult = TestCreditHistoryService.getCreditsHistory(taxYear, nino)
-        whenReady(futureResult.failed) { failureValue =>
-          failureValue.getMessage shouldBe "CreditHistoryService::ERROR::CutOverCredits"
-        }
-      }
+        futureResult.isCompleted shouldBe false
     }
 
-    "a successful Payment/Credit History response is returned from the connector" should {
-      "return a list of MFA credits only" in {
-        setupGetPayments(taxYear)(Payments(paymentsForTheGivenTaxYear))
-        setupMockGetFinancialDetails(taxYear, nino)(taxYearFinancialDetails)
-        val mfaCreditModels = TestCreditHistoryService.getCreditsHistory(taxYear, nino).futureValue
-        mfaCreditModels shouldBe Right(creditModels)
-        mfaCreditModels.right.foreach { ds =>
-          ds.foreach{ d =>
-            d.creditType shouldBe MfaCreditType
-          }
-        }
-      }
-
-      "return a list of MFA and CutOver credits" in {
-        setupGetPayments(taxYear)(Payments(creditsForTheGivenTaxYear))
-        setupMockGetFinancialDetails(taxYear, nino)(taxYearFinancialDetails)
-        setupGetPaymentAllocationCharges(nino, documentIdA)(cutOverCreditsAsFinancialDocumentA)
-        setupGetPaymentAllocationCharges(nino, documentIdB)(cutOverCreditsAsFinancialDocumentB)
-        val cs = TestCreditHistoryService.getCreditsHistory(taxYear, nino).futureValue
-        cs shouldBe Right(cutOverCreditA ++ cutOverCreditB ++ creditModels)
-        cs.right.foreach { ds =>
-          ds.filter(_.creditType == CutOverCreditType).length shouldBe (cutOverCreditA ++ cutOverCreditB).length
-          ds.filter(_.creditType == MfaCreditType).length shouldBe creditModels.length
-        }
-      }
+//    "a successful Payment/Credit History response is returned from the connector" should {
+//      "return a list of MFA credits only" in {
+//        setupGetPayments(taxYear)(Payments(paymentsForTheGivenTaxYear))
+//        setupMockGetFinancialDetails(taxYear, nino)(taxYearFinancialDetails)
+//        val mfaCreditModels = TestCreditHistoryService.getCreditsHistory(taxYear, nino).futureValue
+//        mfaCreditModels shouldBe Right(creditModels)
+//        mfaCreditModels.right.foreach { ds =>
+//          ds.foreach{ d =>
+//            d.creditType shouldBe MfaCreditType
+//          }
+//        }
+//      }
+//
+//      "return a list of MFA and CutOver credits" in {
+//        setupGetPayments(taxYear)(Payments(creditsForTheGivenTaxYear))
+//        setupMockGetFinancialDetails(taxYear, nino)(taxYearFinancialDetails)
+//        setupGetPaymentAllocationCharges(nino, documentIdA)(cutOverCreditsAsFinancialDocumentA)
+//        setupGetPaymentAllocationCharges(nino, documentIdB)(cutOverCreditsAsFinancialDocumentB)
+//        val cs = TestCreditHistoryService.getCreditsHistory(taxYear, nino).futureValue
+//        cs shouldBe Right(cutOverCreditA ++ cutOverCreditB ++ creditModels)
+//        cs.right.foreach { ds =>
+//          ds.filter(_.creditType == CutOverCreditType).length shouldBe (cutOverCreditA ++ cutOverCreditB).length
+//          ds.filter(_.creditType == MfaCreditType).length shouldBe creditModels.length
+//        }
+//      }
 
     }
 

--- a/test/services/helpers/CreditHistoryDataHelper.scala
+++ b/test/services/helpers/CreditHistoryDataHelper.scala
@@ -16,9 +16,9 @@
 
 package services.helpers
 
-import models.{CreditDetailModel, CutOverCreditType, MfaCreditType}
-import models.financialDetails.{BalanceDetails, DocumentDetail, FinancialDetail, FinancialDetailsModel, Payment, SubItem}
+import models.financialDetails._
 import models.paymentAllocationCharges.FinancialDetailsWithDocumentDetailsModel
+import models.{CreditDetailModel, CutOverCreditType, MfaCreditType}
 
 import java.time.LocalDate
 
@@ -42,12 +42,22 @@ trait CreditHistoryDataHelper {
   val documentIdA: String = "DOCID01"
   val documentIdB: String = "DOCID02"
 
-  val documentDetailsWhichIsCredit = DocumentDetail("testYear2", "testTransactionId1", None, None, Some(100.00), Some(-120.00), LocalDate.of(taxYear, 3, 29))
+  val documentDetailsWhichIsCutOverCredit = DocumentDetail(
+    "testYear2", "testTransactionId1",
+    None,
+    None, Some(100.00), Some(-120.00),
+    LocalDate.of(taxYear, 3, 29)
+  )
+  val documentDetailsWhichIsMfaCredit = DocumentDetail("testYear2",
+    "testTransactionId1",
+    Some("ITSA Overpayment Relief"), None, Some(100.00), None,
+    LocalDate.of(taxYear, 3, 29))
+
   val taxYearFinancialDetails = FinancialDetailsModel(
     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
     codingDetails = None,
     documentDetails = List(
-      documentDetailsWhichIsCredit,
+      documentDetailsWhichIsCutOverCredit,
       DocumentDetail("testYear2", "testTransactionId2", None, None, None, None, LocalDate.of(taxYear, 3, 29))
     ),
     financialDetails = List(
@@ -55,13 +65,15 @@ trait CreditHistoryDataHelper {
       FinancialDetail("testYear2", None, Some("testTransactionId2"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.now.plusDays(5).toString)))))
     )
   )
-  val creditDetailModel = CreditDetailModel(date = LocalDate.parse("2022-08-22"), documentDetail = documentDetailsWhichIsCredit, CutOverCreditType)
+
+  val creditDetailModelasCutOver = CreditDetailModel(date = LocalDate.parse("2022-08-22"), documentDetail = documentDetailsWhichIsCutOverCredit, CutOverCreditType)
+  val creditDetailModelasMfa = CreditDetailModel(date = LocalDate.parse("2022-03-29"), documentDetail = documentDetailsWhichIsMfaCredit, MfaCreditType)
 
   val taxYearFinancialDetails_PlusOneYear = FinancialDetailsModel(
     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
     codingDetails = None,
     documentDetails = List(
-      DocumentDetail("testYear2", "testTransactionId1", None, None, Some(100.00), None, LocalDate.of(taxYear, 3, 29)),
+      documentDetailsWhichIsMfaCredit,
       DocumentDetail("testYear2", "testTransactionId2", None, None, None, None, LocalDate.of(taxYear, 3, 29))
     ),
     financialDetails = List(
@@ -148,9 +160,4 @@ trait CreditHistoryDataHelper {
       financialDetail
     )
   )
-
-  //val cutOverCreditA: List[CreditDetailModel] = cutOverCreditsAsFinancialDocumentA
-  //val cutOverCreditB: List[CreditDetailModel] = cutOverCreditsAsFinancialDocumentB
-
-  //val creditModels: List[CreditDetailModel] = taxYearFinancialDetails
 }

--- a/test/services/helpers/CreditHistoryDataHelper.scala
+++ b/test/services/helpers/CreditHistoryDataHelper.scala
@@ -16,7 +16,7 @@
 
 package services.helpers
 
-import models.CreditDetailModel
+import models.{CreditDetailModel, CutOverCreditType, MfaCreditType}
 import models.financialDetails.{BalanceDetails, DocumentDetail, FinancialDetail, FinancialDetailsModel, Payment, SubItem}
 import models.paymentAllocationCharges.FinancialDetailsWithDocumentDetailsModel
 
@@ -41,11 +41,13 @@ trait CreditHistoryDataHelper {
   val nino: String = "someNino"
   val documentIdA: String = "DOCID01"
   val documentIdB: String = "DOCID02"
+
+  val documentDetailsWhichIsCredit = DocumentDetail("testYear2", "testTransactionId1", None, None, Some(100.00), Some(-120.00), LocalDate.of(taxYear, 3, 29))
   val taxYearFinancialDetails = FinancialDetailsModel(
     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
     codingDetails = None,
     documentDetails = List(
-      DocumentDetail("testYear2", "testTransactionId1", None, None, Some(100.00), None, LocalDate.of(taxYear, 3, 29)),
+      documentDetailsWhichIsCredit,
       DocumentDetail("testYear2", "testTransactionId2", None, None, None, None, LocalDate.of(taxYear, 3, 29))
     ),
     financialDetails = List(
@@ -53,6 +55,7 @@ trait CreditHistoryDataHelper {
       FinancialDetail("testYear2", None, Some("testTransactionId2"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.now.plusDays(5).toString)))))
     )
   )
+  val creditDetailModel = CreditDetailModel(date = LocalDate.parse("2022-08-22"), documentDetail = documentDetailsWhichIsCredit, CutOverCreditType)
 
   val taxYearFinancialDetails_PlusOneYear = FinancialDetailsModel(
     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),

--- a/test/services/helpers/CreditHistoryDataHelper.scala
+++ b/test/services/helpers/CreditHistoryDataHelper.scala
@@ -61,8 +61,8 @@ trait CreditHistoryDataHelper {
       DocumentDetail("testYear2", "testTransactionId2", None, None, None, None, LocalDate.of(taxYear, 3, 29))
     ),
     financialDetails = List(
-      FinancialDetail("testYear2", None, Some("testTransactionId1"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.parse("2022-08-25").toString))))),
-      FinancialDetail("testYear2", None, Some("testTransactionId2"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.parse("2022-08-25").toString)))))
+      FinancialDetail("testYear2", None, Some("testTransactionId1"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.parse("2022-08-25")))))),
+      FinancialDetail("testYear2", None, Some("testTransactionId2"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.parse("2022-08-25"))))))
     )
   )
 

--- a/test/services/helpers/CreditHistoryDataHelper.scala
+++ b/test/services/helpers/CreditHistoryDataHelper.scala
@@ -24,8 +24,6 @@ import java.time.LocalDate
 
 trait CreditHistoryDataHelper {
 
-  import CreditDetailModel._
-
   val paymentsForTheGivenTaxYear: List[Payment] = List(Payment(reference = Some("reference"), amount = Some(100.00),
     outstandingAmount = Some(1.00), method = Some("method"), documentDescription = None, lot = Some("lot"), lotItem = Some("lotItem"),
     dueDate = Some("date"), documentDate = "docDate", Some("DOCID01")))
@@ -44,6 +42,19 @@ trait CreditHistoryDataHelper {
   val documentIdA: String = "DOCID01"
   val documentIdB: String = "DOCID02"
   val taxYearFinancialDetails = FinancialDetailsModel(
+    balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
+    codingDetails = None,
+    documentDetails = List(
+      DocumentDetail("testYear2", "testTransactionId1", None, None, Some(100.00), None, LocalDate.of(taxYear, 3, 29)),
+      DocumentDetail("testYear2", "testTransactionId2", None, None, None, None, LocalDate.of(taxYear, 3, 29))
+    ),
+    financialDetails = List(
+      FinancialDetail("testYear2", None, Some("testTransactionId1"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.now.plusDays(3).toString))))),
+      FinancialDetail("testYear2", None, Some("testTransactionId2"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.now.plusDays(5).toString)))))
+    )
+  )
+
+  val taxYearFinancialDetails_PlusOneYear = FinancialDetailsModel(
     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
     codingDetails = None,
     documentDetails = List(
@@ -135,8 +146,8 @@ trait CreditHistoryDataHelper {
     )
   )
 
-  val cutOverCreditA: List[CreditDetailModel] = cutOverCreditsAsFinancialDocumentA
-  val cutOverCreditB: List[CreditDetailModel] = cutOverCreditsAsFinancialDocumentB
+  //val cutOverCreditA: List[CreditDetailModel] = cutOverCreditsAsFinancialDocumentA
+  //val cutOverCreditB: List[CreditDetailModel] = cutOverCreditsAsFinancialDocumentB
 
-  val creditModels: List[CreditDetailModel] = taxYearFinancialDetails
+  //val creditModels: List[CreditDetailModel] = taxYearFinancialDetails
 }

--- a/test/services/helpers/CreditHistoryDataHelper.scala
+++ b/test/services/helpers/CreditHistoryDataHelper.scala
@@ -61,12 +61,12 @@ trait CreditHistoryDataHelper {
       DocumentDetail("testYear2", "testTransactionId2", None, None, None, None, LocalDate.of(taxYear, 3, 29))
     ),
     financialDetails = List(
-      FinancialDetail("testYear2", None, Some("testTransactionId1"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.now.plusDays(3).toString))))),
-      FinancialDetail("testYear2", None, Some("testTransactionId2"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.now.plusDays(5).toString)))))
+      FinancialDetail("testYear2", None, Some("testTransactionId1"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.parse("2022-08-25").toString))))),
+      FinancialDetail("testYear2", None, Some("testTransactionId2"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.parse("2022-08-25").toString)))))
     )
   )
 
-  val creditDetailModelasCutOver = CreditDetailModel(date = LocalDate.parse("2022-08-22"), documentDetail = documentDetailsWhichIsCutOverCredit, CutOverCreditType)
+  val creditDetailModelasCutOver = CreditDetailModel(date = LocalDate.parse("2022-08-25"), documentDetail = documentDetailsWhichIsCutOverCredit, CutOverCreditType)
   val creditDetailModelasMfa = CreditDetailModel(date = LocalDate.parse("2022-03-29"), documentDetail = documentDetailsWhichIsMfaCredit, MfaCreditType)
 
   val taxYearFinancialDetails_PlusOneYear = FinancialDetailsModel(
@@ -77,8 +77,8 @@ trait CreditHistoryDataHelper {
       DocumentDetail("testYear2", "testTransactionId2", None, None, None, None, LocalDate.of(taxYear, 3, 29))
     ),
     financialDetails = List(
-      FinancialDetail("testYear2", None, Some("testTransactionId1"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.now.plusDays(3).toString))))),
-      FinancialDetail("testYear2", None, Some("testTransactionId2"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.now.plusDays(5).toString)))))
+      FinancialDetail("testYear2", None, Some("testTransactionId1"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.parse("2022-08-25").toString))))),
+      FinancialDetail("testYear2", None, Some("testTransactionId2"), None, None, None, None, None, None, None, None, Some(Seq(SubItem(Some(LocalDate.parse("2022-08-25").toString)))))
     )
   )
 


### PR DESCRIPTION
  * yet another rework for CreditHistoryService;
  * add date to CreditDetailModel
  * extract CreditDetailModel.date for MFA and CutOver credit in a the different way;
  * extract credit for (taxYear + taxYear + 1) than filter by date to get required calendarYear credits;
  * required unit test coverage added