### PR TITLE
MISUV-4034 Bug fix for add 'Money in your account' section to 'Credits summary' page

### DIFF
--- a/app/views/CreditsSummary.scala.html
+++ b/app/views/CreditsSummary.scala.html
@@ -86,6 +86,10 @@
     }
 }
 
+@getMoneyInYourAccountSectioName(isAgent: Boolean) = @{
+    if(isAgent) messages("credits.money-in-your-account-section.agent.name") else messages("credits.money-in-your-account-section.name")
+}
+
 @dropDownDetails(isAgent: Boolean) = {
     @h2(msg = "credits.drop-down-list.credit-from-hmrc-adjustment", classes = "govuk-heading-s", optId = Some("h2-credit-from-hmrc-adjustment"))
     @p(id = Some("p-credit-from-hmrc-adjustment")){@messages("credits.drop-down-list.credit-from-hmrc-adjustment.value")}
@@ -111,8 +115,8 @@
 
 @moneyInYourAccount(isAgent: Boolean) = {
     @maybeBalanceDetails.map { balanceDetails =>
-        @balanceDetails.availableCredit.map { availableCredit =>
-            @h2(msg = "credits.money-in-your-account-section.name", classes = "govuk-heading-s", optId = Some("h2-money-in-your-account"))
+        @balanceDetails.availableCredit.filter(_ > 0.00).map { availableCredit =>
+            @h2(msg = getMoneyInYourAccountSectioName(isAgent), classes = "govuk-heading-s", optId = Some("h2-money-in-your-account"))
             @if(isAgent) {
                 @p(id = Some("p-money-in-your-account")) {
                     @messages("credits.money-in-your-account-section.agent.content", availableCredit.toCurrencyString)

--- a/conf/messages
+++ b/conf/messages
@@ -428,6 +428,7 @@ credits.drop-down-list.credit-from-an-earlier-tax-year.agent.sa-note    = This i
 credits.drop-down-list.sa-link                                          = Self Assessment online account
 credits.drop-down-list.sa-link-agent                                    = Self Assessment for Agents account
 credits.money-in-your-account-section.name                              = Money in your account
+credits.money-in-your-account-section.agent.name                        = Money in your client’s account
 credits.money-in-your-account-section.content                           = There is a total of {0} in your account. You can leave the money there to pay your next bill or
 credits.money-in-your-account-section.agent.name                        = Money in your client’s account
 credits.money-in-your-account-section.agent.content                     = There is a total of {0} in your client’s account. You can leave the money there to pay their next bill or

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -510,6 +510,7 @@ credits.drop-down-list.credit-from-an-earlier-tax-year.agent.sa-note    = Dyma a
 credits.drop-down-list.sa-link                                          = cyfrif Hunanasesiad ar-lein blaenorol
 credits.drop-down-list.sa-link-agent                                    = cyfrif Hunanasesiad ar gyfer Asiantau
 credits.money-in-your-account-section.name                              = Arian yn eich cyfrif
+credits.money-in-your-account-section.agent.name                        = Arian yng nghyfrif eich cleient
 credits.money-in-your-account-section.content                           = Mae cyfanswm o {0} yn eich cyfrif. Gallwch adael yr arian yno i dalu’ch bil nesaf neu gallwch
 credits.money-in-your-account-section.agent.name                        = Arian yng nghyfrif eich cleient
 credits.money-in-your-account-section.agent.content                     = Mae cyfanswm o {0} yng nghyfrif eich cleient. Gallwch adael yr arian yno i dalu bil nesaf eich cleient neu gallwch

--- a/test/views/CreditsSummaryViewSpec.scala
+++ b/test/views/CreditsSummaryViewSpec.scala
@@ -44,6 +44,7 @@ class CreditsSummaryViewSpec extends TestSupport with FeatureSwitching with Impl
   val expectedDate: String = "29 Mar 2018"
   val utr: Option[String] = Some(testMtditid)
   val testMaybeBalanceDetails: Option[BalanceDetails] = Some(financialDetailCreditCharge.balanceDetails)
+  val testMaybeBalanceDetailsWithZeroAvailableCredit: Option[BalanceDetails] = Some(financialDetailCreditCharge.balanceDetails.copy(availableCredit = Some(0.00)))
 
   val creditsSummaryHeading: String = messages("credits.heading", s"$testCalendarYear")
   val creditsSummaryTitle: String = messages("titlePattern.serviceName.govUk", creditsSummaryHeading)
@@ -68,6 +69,7 @@ class CreditsSummaryViewSpec extends TestSupport with FeatureSwitching with Impl
   val saNoteMigratedOnlineAccountAgentLink: String = s"https://www.gov.uk/guidance/self-assessment-for-agents-online-service"
   val saNoteMigratedOnlineAccountAgentLinkText: String = s"${messages("credits.drop-down-list.sa-link-agent")}${messages("pagehelp.opensInNewTabText")}"
   val moneyInYourAccountHeading: String = messages("credits.money-in-your-account-section.name")
+  val moneyInYourAccountAgentHeading: String = messages("credits.money-in-your-account-section.agent.name")
   val moneyInYourAccountMoneyClaimARefundLinkText: String = messages("credits.money-in-your-account-section.claim-a-refund-link")
   val moneyInYourAccountContent: String = s"""${messages("credits.money-in-your-account-section.content", s"${financialDetailCreditCharge.balanceDetails.availableCredit.get.toCurrencyString}")} ${moneyInYourAccountMoneyClaimARefundLinkText}."""
   val moneyInYourAccountAgentContent: String = s"""${messages("credits.money-in-your-account-section.agent.content", s"${financialDetailCreditCharge.balanceDetails.availableCredit.get.toCurrencyString}")} ${moneyInYourAccountMoneyClaimARefundLinkText}."""
@@ -187,6 +189,23 @@ class CreditsSummaryViewSpec extends TestSupport with FeatureSwitching with Impl
       document.getElementsByClass("govuk-link").last().text() shouldBe getPageHelpLinkTextBtn
     }
 
+    "a user has a credit and the Status is Partially allocated and availableCredit is 0.00 then Money in your account should not be present" in new Setup(creditCharges = creditAndRefundCreditDetailListPartiallyAllocatedMFA, maybeBalanceDetails = testMaybeBalanceDetailsWithZeroAvailableCredit) {
+      enable(MFACreditsAndDebits)
+
+      document.title() shouldBe creditsSummaryTitle
+      layoutContent.selectHead("h1").text shouldBe creditsSummaryHeading
+      document.select("th:nth-child(1)").first().text() shouldBe creditsTableHeadDateText
+      document.select("td:nth-child(1)").first().text() shouldBe expectedDate
+      document.select("th:nth-child(2)").text() shouldBe creditsTableHeadTypeText
+      document.select("td:nth-child(2)").first().text() shouldBe creditsTableHeadTypeValue
+      document.select("th:nth-child(3)").text() shouldBe creditsTableHeadStatusText
+      document.select("td:nth-child(3)").first().text() shouldBe creditsTableStatusPartiallyAllocatedValue
+      document.select("th:nth-child(4)").text() shouldBe creditsTableHeadAmountText
+      document.select("td:nth-child(4)").first().text() shouldBe "£1,000.00"
+      document.select("#h2-money-in-your-account").isEmpty shouldBe true
+      document.getElementsByClass("govuk-link").last().text() shouldBe getPageHelpLinkTextBtn
+    }
+
   }
 
 
@@ -219,7 +238,7 @@ class CreditsSummaryViewSpec extends TestSupport with FeatureSwitching with Impl
         document.selectById("sa-note-migrated-agent-online-account-link").text() shouldBe saNoteMigratedOnlineAccountAgentLinkText
         document.selectById("sa-note-migrated-agent-online-account-link").attr("href") shouldBe saNoteMigratedOnlineAccountAgentLink
 
-        document.selectById("h2-money-in-your-account").text() shouldBe moneyInYourAccountHeading
+        document.selectById("h2-money-in-your-account").text() shouldBe moneyInYourAccountAgentHeading
         document.selectById("p-money-in-your-account").text() shouldBe moneyInYourAccountAgentContent
         document.selectById("money-in-your-account-claim-a-refund-link").text() shouldBe moneyInYourAccountMoneyClaimARefundLinkText
         document.selectById("money-in-your-account-claim-a-refund-link").attr("href") shouldBe moneyInYourAccountMoneyClaimARefundAgentLink


### PR DESCRIPTION
Fix the issue that the Agent should gave this text Money in your client's account
Fix the issue when availableCredit is £0.00 then Money in your account block should not be rendered.