### PR TITLE
MISUV-4336 Bug fix for the payment type

### DIFF
--- a/app/utils/CreditAndRefundUtils.scala
+++ b/app/utils/CreditAndRefundUtils.scala
@@ -33,8 +33,8 @@ object CreditAndRefundUtils {
         case (List((_, financialDetails)), Some(BalanceDetails(_, _, _, Some(availableCredit), _, _, Some(_))), 1)
           if availableCredit != 0 && (validMFACreditType(financialDetails.mainType) || financialDetails.validCutoverCreditType()) =>
           Some(UnallocatedCreditFromSingleCreditItem)
-        case (List((_, financialDetails)), Some(BalanceDetails(_, _, _, Some(availableCredit), _, _, Some(_))), 1)
-          if availableCredit != 0 && financialDetails.mainType.filter(_.contains("Payment on Account")).isDefined =>
+        case (List((documentDetailWithDueDate, _)), Some(BalanceDetails(_, _, _, Some(availableCredit), _, _, Some(_))), 1)
+          if availableCredit != 0 && documentDetailWithDueDate.documentDetail.paymentLot.isDefined && documentDetailWithDueDate.documentDetail.paymentLotItem.isDefined =>
           Some(UnallocatedCreditFromOnePayment)
         case _ => None
       }

--- a/test/testConstants/FinancialDetailsTestConstants.scala
+++ b/test/testConstants/FinancialDetailsTestConstants.scala
@@ -1172,12 +1172,16 @@ object CreditAndRefundConstants {
   )
 
   def documentDetailWithDueDateFinancialDetailListModel(outstandingAmount: Option[BigDecimal] = Some(-1400.0),
-                                                        dueDate: Option[LocalDate] = Some(LocalDate.of(2019, 5, 15)),
+                                                        dueDate: Option[LocalDate] = Some(LocalDate.of(2019,5,15)),
                                                         originalAmount: Option[BigDecimal] = Some(1400.00),
-                                                        mainType: String = "SA Payment on Account 1"):
+                                                        mainType: String = "SA Payment on Account 1",
+                                                        paymentLot: Option[String] = None,
+                                                        paymentLotItem: Option[String] = None,
+                                                       ):
   (DocumentDetailWithDueDate, FinancialDetail) = {
     (documentDetailWithDueDateModel(
-      paymentLot = None,
+      paymentLot = paymentLot,
+      paymentLotItem = paymentLotItem,
       outstandingAmount = outstandingAmount,
       dueDate = dueDate,
       originalAmount = originalAmount),

--- a/test/utils/CreditAndRefundUtilsSpec.scala
+++ b/test/utils/CreditAndRefundUtilsSpec.scala
@@ -53,7 +53,7 @@ class CreditAndRefundUtilsSpec extends TestSupport {
     "maybeUnallocatedCreditType method called with proper values for unallocated credit from one payment" should {
       "return Option[UnallocatedCreditFromOnePayment]" in {
         val unallocatedCreditType = maybeUnallocatedCreditType(
-          List(documentDetailWithDueDateFinancialDetailListModel()),
+          List(documentDetailWithDueDateFinancialDetailListModel(paymentLot = Some("paymentLot"), paymentLotItem = Some("paymentLot"))),
           Some(balanceDetailsModel(
             firstPendingAmountRequested = None,
             secondPendingAmountRequested = None,


### PR DESCRIPTION
Fix the bug for identifying a payment we need to check the existence of **paymentLot** and **paymentLotItem** fields on the **documentDetail**. And not the **mainType** contains "Payment on Account"