### PR TITLE
MISUV-4408: tidy up warning during compilation / scala upgrade to 2.13.8 left over 

### DIFF
--- a/app/audit/models/TaxYearSummaryResponseAuditModel.scala
+++ b/app/audit/models/TaxYearSummaryResponseAuditModel.scala
@@ -61,7 +61,7 @@ case class TaxYearSummaryResponseAuditModel(mtdItUser: MtdItUser[_],
   private val calculationDetails = {
     if (R7bTxmEvents) {
       Json.obj() ++
-        unattendedCalcReason ++
+        unattendedCalcReason() ++
         ("income", taxYearSummaryViewModel.map(_.income)) ++
         ("allowancesAndDeductions", taxYearSummaryViewModel.map(_.deductions)) ++
         ("taxableIncome", taxYearSummaryViewModel.map(_.totalTaxableIncome)) ++

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -96,7 +96,7 @@ class HomeController @Inject()(val homeView: views.html.Home,
       for {
         paymentsDue <- dueDates.map(_.sortBy(_.toEpochDay()))
         dunningLockExistsValue <- unpaidCharges.map(_.collectFirst { case fdm: FinancialDetailsModel if fdm.dunningLockExists => true })
-        outstandingChargesModel <- whatYouOweService.getWhatYouOweChargesList.map(_.outstandingChargesModel match {
+        outstandingChargesModel <- whatYouOweService.getWhatYouOweChargesList().map(_.outstandingChargesModel match {
           case Some(OutstandingChargesModel(locm)) => locm.filter(ocm => ocm.relevantDueDate.isDefined && ocm.chargeName == "BCD")
           case _ => Nil
         })

--- a/app/controllers/NextUpdatesController.scala
+++ b/app/controllers/NextUpdatesController.scala
@@ -65,7 +65,7 @@ class NextUpdatesController @Inject()(NoNextUpdatesView: NoNextUpdates,
           if (nextUpdates.obligations.nonEmpty) {
             Ok(view(nextUpdates, backUrl = controllers.routes.HomeController.show(origin).url, isAgent = false, origin = origin)(user))
           } else {
-            itvcErrorHandler.showInternalServerError
+            itvcErrorHandler.showInternalServerError()
           }
         }
       } else {

--- a/app/controllers/SignOutController.scala
+++ b/app/controllers/SignOutController.scala
@@ -35,7 +35,7 @@ class SignOutController @Inject()(config: FrontendAppConfig,
   implicit val ec: ExecutionContext = mcc.executionContext
 
   val signOut: Action[AnyContent] = Action.async { implicit request =>
-    enrolmentsAuthService.authorised.retrieve(Retrievals.affinityGroup) {
+    enrolmentsAuthService.authorised().retrieve(Retrievals.affinityGroup) {
       case Some(AffinityGroup.Agent) => Future.successful(s"${config.contactFormServiceIdentifier}A")
       case _ => Future.successful(config.contactFormServiceIdentifier)
     }

--- a/app/controllers/agent/EnterClientsUTRController.scala
+++ b/app/controllers/agent/EnterClientsUTRController.scala
@@ -67,7 +67,7 @@ class EnterClientsUTRController @Inject()(enterClientsUTR: EnterClientsUTR,
 
   def submit: Action[AnyContent] = Authenticated.asyncWithoutClientAuth() { implicit request =>
     implicit user =>
-      ClientsUTRForm.form.bindFromRequest.fold(
+      ClientsUTRForm.form.bindFromRequest().fold(
         hasErrors => Future.successful(BadRequest(enterClientsUTR(
           clientUTRForm = hasErrors,
           postAction = routes.EnterClientsUTRController.submit

--- a/app/controllers/predicates/AuthenticationPredicate.scala
+++ b/app/controllers/predicates/AuthenticationPredicate.scala
@@ -86,7 +86,7 @@ class AuthenticationPredicate @Inject()(implicit val ec: ExecutionContext,
         Redirect(controllers.routes.SignInController.signIn)
       case s =>
         Logger("application").error(s"[AuthenticationPredicate][async] Unexpected Error Caught. Show ISE.\n$s\n", s)
-        itvcErrorHandler.showInternalServerError
+        itvcErrorHandler.showInternalServerError()
     }
   }
 

--- a/app/controllers/predicates/IncomeSourceDetailsPredicate.scala
+++ b/app/controllers/predicates/IncomeSourceDetailsPredicate.scala
@@ -45,7 +45,7 @@ class IncomeSourceDetailsPredicate @Inject()(val incomeSourceDetailsService: Inc
     incomeSourceDetailsService.getIncomeSourceDetails(Some(cacheKey)) map {
       case sources: IncomeSourceDetailsModel =>
         Right(MtdItUser(request.mtditid, request.nino, request.userName, sources, None, request.saUtr, request.credId, request.userType, request.arn))
-      case _ => Left(itvcErrorHandler.showInternalServerError)
+      case _ => Left(itvcErrorHandler.showInternalServerError())
     }
 
   }

--- a/app/controllers/predicates/IncomeSourceDetailsPredicateNoCache.scala
+++ b/app/controllers/predicates/IncomeSourceDetailsPredicateNoCache.scala
@@ -43,7 +43,7 @@ class IncomeSourceDetailsPredicateNoCache @Inject()(val incomeSourceDetailsServi
     incomeSourceDetailsService.getIncomeSourceDetails(None) map {
       case sources: IncomeSourceDetailsModel =>
         Right(MtdItUser(request.mtditid, request.nino, request.userName, sources, None, request.saUtr, request.credId, request.userType, request.arn))
-      case _ => Left(itvcErrorHandler.showInternalServerError)
+      case _ => Left(itvcErrorHandler.showInternalServerError())
     }
   }
 }

--- a/app/controllers/predicates/NinoPredicate.scala
+++ b/app/controllers/predicates/NinoPredicate.scala
@@ -63,7 +63,7 @@ class NinoPredicate @Inject()(val ninoLookupService: NinoLookupService,
           case error: NinoResponseError =>
             Logger("application").error(s"[NinoPredicate][buildMtdUserWithNino] NINO could not be retrieved from NinoLookupService")
             auditNinoLookupError(error, request.mtditid)
-            Left(itvcErrorHandler.showInternalServerError)
+            Left(itvcErrorHandler.showInternalServerError())
         }
     }
   }

--- a/app/testOnly/controllers/StubDataController.scala
+++ b/app/testOnly/controllers/StubDataController.scala
@@ -49,7 +49,7 @@ class StubDataController @Inject()(stubDataView: StubDataView)
 
   val submit: Action[AnyContent] = Action.async {
     implicit request =>
-      StubDataForm.stubDataForm.bindFromRequest.fold(
+      StubDataForm.stubDataForm.bindFromRequest().fold(
         formWithErrors => Future.successful(BadRequest(view(formWithErrors))),
         schema => {
           dynamicStubConnector.addData(schema).map(

--- a/app/testOnly/controllers/StubSchemaController.scala
+++ b/app/testOnly/controllers/StubSchemaController.scala
@@ -48,7 +48,7 @@ class StubSchemaController @Inject()(stubSchemaView: StubSchemaView)
 
   val submit: Action[AnyContent] = Action.async {
     implicit request =>
-      StubSchemaForm.stubSchemaForm.bindFromRequest.fold(
+      StubSchemaForm.stubSchemaForm.bindFromRequest().fold(
         formWithErrors => Future.successful(BadRequest(view(formWithErrors))),
         schema => {
           dynamicStubConnector.addSchema(schema).map(

--- a/app/views/Home.scala.html
+++ b/app/views/Home.scala.html
@@ -160,7 +160,7 @@
             </div>
         </div>
 
-        @tiles
+        @tiles()
 
     } else {
         <div class="grid-row">
@@ -194,7 +194,7 @@
             </div>
         </div>
 
-        @tiles
+        @tiles()
 
     }
     }

--- a/app/views/partials/taxYearSummaryTabsPartial.scala.html
+++ b/app/views/partials/taxYearSummaryTabsPartial.scala.html
@@ -62,21 +62,21 @@
 @tableTabItems() = @{
     if(showForecastData) {
         Seq(
-            taxCalculationTabItem,
-            forecastTabItem,
-            paymentsTabItem,
-            updatesTabItem
+            taxCalculationTabItem(),
+            forecastTabItem(),
+            paymentsTabItem(),
+            updatesTabItem()
         )
     } else {
         Seq(
-            taxCalculationTabItem,
-            paymentsTabItem,
-            updatesTabItem
+            taxCalculationTabItem(),
+            paymentsTabItem(),
+            updatesTabItem()
         )
     }
 }
 
 @govukTabs(Tabs(
-    items = tableTabItems,
+    items = tableTabItems(),
     classes = "govuk-tabs-upper-padding"
 ))

--- a/build.sbt
+++ b/build.sbt
@@ -96,6 +96,8 @@ lazy val microservice = Project(appName, file("."))
   .settings(scoverageSettings: _*)
   .settings(defaultSettings(): _*)
   .settings(majorVersion := 1)
+  .settings(scalacOptions += "-Wconf:cat=lint-multiarg-infix:silent")
+  //.settings(scalacOptions += "-Xfatal-warnings") => https://jira.tools.tax.service.gov.uk/browse/MISUV-4437
   .settings(
     Keys.fork in Test := true,
     javaOptions in Test += "-Dlogger.resource=logback-test.xml"


### PR DESCRIPTION
  * suppress warning 'multiarg-infix' warning at the moment;
  * fix next warning's => 'Auto-application to `()` is deprecated'

At this moment FE contains just 11 warnings => next sets of stories to resolve these => [enforce compile failure on warning](https://jira.tools.tax.service.gov.uk/browse/MISUV-4437)