### PR TITLE
Misuv 4834 - WhatYouOweControllerISpec(s): remove usage of LocalDate.now

### DIFF
--- a/it/controllers/WhatYouOweControllerISpec.scala
+++ b/it/controllers/WhatYouOweControllerISpec.scala
@@ -46,12 +46,13 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
   )(FakeRequest())
 
   val testTaxYear: Int = getCurrentTaxYearEnd.getYear - 1
+  val testDate: LocalDate = LocalDate.parse("2022-01-01")
 
   "Navigating to /report-quarterly/income-and-expenses/view/payments-owed" when {
 
     "Authorised" when {
 
-      "render the payments due totals" in {
+      "render the payments due totals dm" in {
         disable(NavBarFs)
         Given("Display Totals feature is enabled")
 
@@ -62,7 +63,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
 
         And("I wiremock stub a financial details response with coded out documents")
         IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
-          testValidFinancialDetailsModelJsonCodingOut(2000, 2000, (testTaxYear - 1).toString, LocalDate.now().plusYears(1).toString))
+          testValidFinancialDetailsModelJsonCodingOut(2000, 2000, (testTaxYear - 1).toString, testDate.toString))
 
         IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
           "utr", testSaUtr.toLong, (testTaxYear - 1).toString)(OK, validOutStandingChargeResponseJsonWithoutAciAndBcdCharges)
@@ -92,7 +93,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
 
           And("I wiremock stub a multiple financial details and outstanding charges response")
           IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
-            testValidFinancialDetailsModelJson(2000, 2000, (testTaxYear - 1).toString, LocalDate.now().toString))
+            testValidFinancialDetailsModelJson(2000, 2000, (testTaxYear - 1).toString, testDate.toString))
           IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
             "utr", testSaUtr.toLong, (testTaxYear - 1).toString)(OK, validOutStandingChargeResponseJsonWithAciAndBcdCharges)
 
@@ -133,7 +134,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
 
 
           And("I wiremock stub a multiple financial details response")
-          val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, LocalDate.now().minusDays(15).toString)
+          val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, testDate.toString)
           val financialDetailsModel = financialDetailsResponseJson.as[FinancialDetailsModel]
 
           IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
@@ -195,8 +196,8 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
             ),
             "financialDetails" -> Json.arr(
               financialDetailJson((testTaxYear - 1).toString, transactionId = "transId1"),
-              financialDetailJson((testTaxYear - 1).toString, "SA Payment on Account 1", LocalDate.now().plusDays(1).toString, "transId2"),
-              financialDetailJson((testTaxYear - 1).toString, "SA Payment on Account 2", LocalDate.now().minusDays(1).toString, "transId3")
+              financialDetailJson((testTaxYear - 1).toString, "SA Payment on Account 1", testDate.plusDays(1).toString, "transId2"),
+              financialDetailJson((testTaxYear - 1).toString, "SA Payment on Account 2", testDate.minusDays(1).toString, "transId3")
             )
           )
 
@@ -239,7 +240,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
 
 
           And("I wiremock stub a multiple financial details response")
-          val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, LocalDate.now().minusDays(15).toString, dunningLock = noDunningLock)
+          val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, testDate.minusDays(15).toString, dunningLock = noDunningLock)
           val financialDetailsModel = financialDetailsResponseJson.as[FinancialDetailsModel]
 
           IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
@@ -278,7 +279,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
 
 
           And("I wiremock stub a multiple financial details response")
-          val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, LocalDate.now().minusDays(15).toString, dunningLock = oneDunningLock)
+          val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, testDate.minusDays(15).toString, dunningLock = oneDunningLock)
           val financialDetailsModel = financialDetailsResponseJson.as[FinancialDetailsModel]
 
           IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
@@ -317,7 +318,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
 
 
           And("I wiremock stub a multiple financial details response")
-          val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, LocalDate.now().minusDays(15).toString, dunningLock = twoDunningLocks)
+          val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, testDate.minusDays(15).toString, dunningLock = twoDunningLocks)
           val financialDetailsModel = financialDetailsResponseJson.as[FinancialDetailsModel]
 
           IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
@@ -412,7 +413,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
 
           And("I wiremock stub a single financial details response")
           IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
-            testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, LocalDate.now().toString))
+            testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, testDate.toString))
           IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
             "utr", testSaUtr.toLong, (testTaxYear - 1).toString)(INTERNAL_SERVER_ERROR, testOutstandingChargesErrorModelJson)
 
@@ -629,7 +630,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
 
           And("I wiremock stub a mixed financial details response")
           IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
-            testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, LocalDate.now().plusYears(1).toString))
+            testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, testDate.plusYears(1).toString))
 
           IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
             "utr", testSaUtr.toLong, (testTaxYear - 1).toString)(OK, validOutStandingChargeResponseJsonWithoutAciAndBcdCharges)
@@ -677,7 +678,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
           And("I wiremock stub a financial details response with coded out documents")
           IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
             testValidFinancialDetailsModelJsonCodingOut(2000, 2000, testTaxYear.toString,
-              LocalDate.now().toString, 0, (getCurrentTaxYearEnd.getYear - 1).toString, 2000))
+              testDate.toString, 0, (getCurrentTaxYearEnd.getYear - 1).toString, 2000))
 
           IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
             "utr", testSaUtr.toLong, (testTaxYear - 1).toString)(OK, validOutStandingChargeResponseJsonWithoutAciAndBcdCharges)
@@ -763,7 +764,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
 
           And("I wiremock stub a financial details response with coded out documents")
           IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
-            testValidFinancialDetailsModelJsonCodingOut(2000, 2000, testTaxYear.toString, LocalDate.now().plusYears(1).toString))
+            testValidFinancialDetailsModelJsonCodingOut(2000, 2000, testTaxYear.toString, testDate.plusYears(1).toString))
 
           IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
             "utr", testSaUtr.toLong, (testTaxYear - 1).toString)(OK, validOutStandingChargeResponseJsonWithoutAciAndBcdCharges)
@@ -806,7 +807,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
 
             And("I wiremock stub a multiple financial details response")
             IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
-              testValidFinancialDetailsModelMFADebitsJson(2000, 2000, testTaxYear.toString, LocalDate.now().plusYears(1).toString))
+              testValidFinancialDetailsModelMFADebitsJson(2000, 2000, testTaxYear.toString, testDate.plusYears(1).toString))
             IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
               "utr", testSaUtr.toLong, (testTaxYear - 1).toString)(OK, validOutStandingChargeResponseJsonWithoutAciAndBcdCharges)
 
@@ -846,7 +847,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
 
     "API#1171 IncomeSourceDetails Caching" when {
       "caching should be ENABLED" in {
-        testIncomeSourceDetailsCaching(false, 1,
+        testIncomeSourceDetailsCaching(resetCacheAfterFirstCall = false, 1,
           () => IncomeTaxViewChangeFrontend.getPaymentsDue)
       }
     }
@@ -867,8 +868,8 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
         ),
         "financialDetails" -> Json.arr(
           financialDetailJson(testTaxYear.toString, transactionId = "transId1"),
-          financialDetailJson(testTaxYear.toString, "SA Payment on Account 1", LocalDate.now().plusDays(1).toString, "transId2"),
-          financialDetailJson(testTaxYear.toString, "SA Payment on Account 2", LocalDate.now().minusDays(1).toString, "transId3")
+          financialDetailJson(testTaxYear.toString, "SA Payment on Account 1", LocalDate.now().plusDays(1).toString/*testDate.plusDays(1).toString*/, "transId2"),
+          financialDetailJson(testTaxYear.toString, "SA Payment on Account 2", LocalDate.now().minusDays(1).toString/*testDate.minusDays(1).toString*/, "transId3")
         )
       )
 

--- a/it/controllers/WhatYouOweControllerISpec.scala
+++ b/it/controllers/WhatYouOweControllerISpec.scala
@@ -52,7 +52,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
 
     "Authorised" when {
 
-      "render the payments due totals dm" in {
+      "render the payments due totals" in {
         disable(NavBarFs)
         Given("Display Totals feature is enabled")
 
@@ -134,7 +134,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
 
 
           And("I wiremock stub a multiple financial details response")
-          val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, testDate.toString)
+          val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, testDate.minusDays(15).toString)
           val financialDetailsModel = financialDetailsResponseJson.as[FinancialDetailsModel]
 
           IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
@@ -716,7 +716,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
 
           And("I wiremock stub a multiple financial details and outstanding charges response")
           IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
-            testValidFinancialDetailsModelJson(2000, 2000, (testTaxYear - 1).toString, LocalDate.now().toString, isClass2Nic = true))
+            testValidFinancialDetailsModelJson(2000, 2000, (testTaxYear - 1).toString, testDate.toString, isClass2Nic = true))
 
           IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
             "utr", testSaUtr.toLong, (testTaxYear - 1).toString)(OK, validOutStandingChargeResponseJsonWithAciAndBcdCharges)
@@ -868,8 +868,8 @@ class WhatYouOweControllerISpec extends ComponentSpecBase {
         ),
         "financialDetails" -> Json.arr(
           financialDetailJson(testTaxYear.toString, transactionId = "transId1"),
-          financialDetailJson(testTaxYear.toString, "SA Payment on Account 1", LocalDate.now().plusDays(1).toString/*testDate.plusDays(1).toString*/, "transId2"),
-          financialDetailJson(testTaxYear.toString, "SA Payment on Account 2", LocalDate.now().minusDays(1).toString/*testDate.minusDays(1).toString*/, "transId3")
+          financialDetailJson(testTaxYear.toString, "SA Payment on Account 1", testDate.plusDays(1).toString/*testDate.plusDays(1).toString*/, "transId2"),
+          financialDetailJson(testTaxYear.toString, "SA Payment on Account 2", testDate.minusDays(1).toString/*testDate.minusDays(1).toString*/, "transId3")
         )
       )
 

--- a/it/controllers/agent/WhatYouOweControllerISpec.scala
+++ b/it/controllers/agent/WhatYouOweControllerISpec.scala
@@ -26,12 +26,13 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
 
   val testArn: String = "1"
 
+  val testDate: LocalDate = LocalDate.parse("2022-01-01")
   val incomeSourceDetailsModel: IncomeSourceDetailsModel = IncomeSourceDetailsModel(
     mtdbsa = testMtditid,
     yearOfMigration = None,
     businesses = List(BusinessDetailsModel(
       Some("testId"),
-      Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+      Some(AccountingPeriodModel(testDate, testDate.plusYears(1))),
       None,
       Some(getCurrentTaxYearEnd)
     )),
@@ -61,7 +62,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
             yearOfMigration = None,
             businesses = List(BusinessDetailsModel(
               Some("testId"),
-              Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+              Some(AccountingPeriodModel(testDate, testDate.plusYears(1))),
               None,
               Some(getCurrentTaxYearEnd)
             )),
@@ -71,7 +72,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
 
         IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"$currentTaxYearEnd - 1-04-06", s"$currentTaxYearEnd-04-05")(OK,
           testValidFinancialDetailsModelJson(
-            2000, 2000, currentTaxYearEnd.toString, LocalDate.now().toString))
+            2000, 2000, currentTaxYearEnd.toString, testDate.toString))
         IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
           "utr", testSaUtr.toLong, currentTaxYearEnd.toString)(OK, validOutStandingChargeResponseJsonWithAciAndBcdCharges)
 
@@ -136,7 +137,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
       IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(
         OK, propertyOnlyResponseWithMigrationData(previousTaxYearEnd, Some(currentTaxYearEnd.toString)))
 
-      val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, currentTaxYearEnd.toString, LocalDate.now().minusDays(15).toString)
+      val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, currentTaxYearEnd.toString, testDate.minusDays(15).toString)
       val financialDetailsModel = financialDetailsResponseJson.as[FinancialDetailsModel]
 
       IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"$previousTaxYearEnd-04-06", s"$currentTaxYearEnd-04-05"
@@ -196,8 +197,8 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
         ),
         "financialDetails" -> Json.arr(
           financialDetailJson((currentTaxYearEnd - 2).toString, transactionId = "transId1"),
-          financialDetailJson((currentTaxYearEnd - 2).toString, "SA Payment on Account 1", LocalDate.now().plusDays(1).toString, transactionId = "transId2"),
-          financialDetailJson((currentTaxYearEnd - 2).toString, "SA Payment on Account 2", LocalDate.now().minusDays(1).toString, transactionId = "transId3")
+          financialDetailJson((currentTaxYearEnd - 2).toString, "SA Payment on Account 1", testDate.plusDays(1).toString, transactionId = "transId2"),
+          financialDetailJson((currentTaxYearEnd - 2).toString, "SA Payment on Account 2", testDate.minusDays(1).toString, transactionId = "transId3")
         ))
 
       IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"$previousTaxYearEnd-04-06", s"$currentTaxYearEnd-04-05")(
@@ -303,7 +304,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
       IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(
         testNino, s"$previousTaxYearEnd-04-06", s"$currentTaxYearEnd-04-05")(
         OK, testValidFinancialDetailsModelJson(
-          2000, 2000, currentTaxYearEnd.toString, LocalDate.now().toString))
+          2000, 2000, currentTaxYearEnd.toString, testDate.toString))
 
       IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
         "utr", testSaUtr.toLong, (currentTaxYearEnd - 1).toString)(
@@ -332,7 +333,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
 
     And("I wiremock stub a multiple financial details response")
     IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
-      testValidFinancialDetailsModelJsonAccruingInterest(2000, 2000, testTaxYear.toString, LocalDate.now().minusDays(15).toString))
+      testValidFinancialDetailsModelJsonAccruingInterest(2000, 2000, testTaxYear.toString, testDate.minusDays(15).toString))
     IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
       "utr", testSaUtr.toLong, (testTaxYear - 1).toString)(OK, validOutStandingChargeResponseJsonWithoutAciAndBcdCharges)
 
@@ -377,7 +378,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
 
     And("I wiremock stub a multiple financial details response")
     IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
-      testValidFinancialDetailsModelJsonAccruingInterest(2000, 2000, testTaxYear.toString, LocalDate.now().minusDays(15).toString, Some(55.50)))
+      testValidFinancialDetailsModelJsonAccruingInterest(2000, 2000, testTaxYear.toString, testDate.minusDays(15).toString, Some(55.50)))
     IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
       "utr", testSaUtr.toLong, (testTaxYear - 1).toString)(OK, validOutStandingChargeResponseJsonWithoutAciAndBcdCharges)
 
@@ -422,7 +423,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
       IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, propertyOnlyResponseWithMigrationData(testTaxYear - 1, Some(testTaxYear.toString)))
 
       And("I wiremock stub a multiple financial details response")
-      val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, LocalDate.now().minusDays(15).toString, dunningLock = noDunningLock)
+      val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, testDate.minusDays(15).toString, dunningLock = noDunningLock)
       val financialDetailsModel = financialDetailsResponseJson.as[FinancialDetailsModel]
 
       IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
@@ -460,7 +461,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
 
 
       And("I wiremock stub a multiple financial details response with dunning lock present")
-      val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, LocalDate.now().minusDays(15).toString, dunningLock = oneDunningLock)
+      val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, testDate.minusDays(15).toString, dunningLock = oneDunningLock)
       val financialDetailsModel = financialDetailsResponseJson.as[FinancialDetailsModel]
 
       IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
@@ -499,7 +500,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
 
 
       And("I wiremock stub a multiple financial details response with dunning locks present")
-      val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, LocalDate.now().minusDays(15).toString, dunningLock = twoDunningLocks)
+      val financialDetailsResponseJson = testValidFinancialDetailsModelJson(2000, 2000, testTaxYear.toString, testDate.minusDays(15).toString, dunningLock = twoDunningLocks)
       val financialDetailsModel = financialDetailsResponseJson.as[FinancialDetailsModel]
 
       IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
@@ -721,7 +722,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
       }
     }
 
-    "YearOfMigration exists with valid financial details charges and invalid outstanding charges" when {
+    "YearOfMigration exists with valid financial details charges and invalid outstanding charges dm" when {
       "only BCD charge" in {
         stubAuthorisedAgentUser(authorised = true)
 
@@ -730,7 +731,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
 
         IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"$previousTaxYearEnd-04-06", s"$currentTaxYearEnd-04-05"
         )(OK, testValidFinancialDetailsModelJson(
-          2000, 2000, currentTaxYearEnd.toString, LocalDate.now().plusYears(1).toString))
+          2000, 2000, currentTaxYearEnd.toString, testDate.plusYears(1).toString))
 
         IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
           "utr", testSaUtr.toLong, previousTaxYearEnd.toString)(OK, validOutStandingChargeResponseJsonWithoutAciAndBcdCharges)
@@ -774,7 +775,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
 
       And("I wiremock stub a multiple financial details response")
       IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05")(OK,
-        testValidFinancialDetailsModelJsonAccruingInterest(2000, 2000, testTaxYear.toString, LocalDate.now().minusDays(15).toString))
+        testValidFinancialDetailsModelJsonAccruingInterest(2000, 2000, testTaxYear.toString, testDate.minusDays(15).toString))
       IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
         "utr", testSaUtr.toLong, twoPreviousTaxYearEnd.toString)(OK, validOutStandingChargeResponseJsonWithoutAciAndBcdCharges)
 
@@ -806,7 +807,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
         propertyOnlyResponseWithMigrationData(testTaxYear - 1, Some(testTaxYear.toString)))
 
       IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05"
-      )(OK, testValidFinancialDetailsModelJsonCodingOut(2000, 2000, testTaxYear.toString, LocalDate.now().plusYears(1).toString))
+      )(OK, testValidFinancialDetailsModelJsonCodingOut(2000, 2000, testTaxYear.toString, testDate.plusYears(1).toString))
 
       IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
         "utr", testSaUtr.toLong, (testTaxYear - 1).toString)(OK, validOutStandingChargeResponseJsonWithoutAciAndBcdCharges)
@@ -843,7 +844,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
         propertyOnlyResponseWithMigrationData(testTaxYear - 1, Some(testTaxYear.toString)))
 
       IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"${testTaxYear - 1}-04-06", s"$testTaxYear-04-05"
-      )(OK, testValidFinancialDetailsModelJsonCodingOut(2000, 2000, testTaxYear.toString, LocalDate.now().plusYears(1).toString))
+      )(OK, testValidFinancialDetailsModelJsonCodingOut(2000, 2000, testTaxYear.toString, testDate.plusYears(1).toString))
 
       IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
         "utr", testSaUtr.toLong, (testTaxYear - 1).toString)(OK, validOutStandingChargeResponseJsonWithoutAciAndBcdCharges)
@@ -900,8 +901,8 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
       ),
       "financialDetails" -> Json.arr(
         financialDetailJson(currentTaxYearEnd.toString, transactionId = "transId1"),
-        financialDetailJson(currentTaxYearEnd.toString, "SA Payment on Account 1", LocalDate.now().plusDays(1).toString, transactionId = "transId2"),
-        financialDetailJson(currentTaxYearEnd.toString, "SA Payment on Account 2", LocalDate.now().minusDays(1).toString, transactionId = "transId3")
+        financialDetailJson(currentTaxYearEnd.toString, "SA Payment on Account 1", testDate.plusDays(1).toString, transactionId = "transId2"),
+        financialDetailJson(currentTaxYearEnd.toString, "SA Payment on Account 2", testDate.minusDays(1).toString, transactionId = "transId3")
       ))
 
     IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"$previousTaxYearEnd-04-06", s"$currentTaxYearEnd-04-05")(

--- a/it/controllers/agent/WhatYouOweControllerISpec.scala
+++ b/it/controllers/agent/WhatYouOweControllerISpec.scala
@@ -742,7 +742,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
       }
     }
 
-    "YearOfMigration exists with valid financial details charges and invalid outstanding charges dm" when {
+    "YearOfMigration exists with valid financial details charges and invalid outstanding charges" when {
       "only BCD charge" in {
         stubAuthorisedAgentUser(authorised = true)
 

--- a/it/controllers/agent/WhatYouOweControllerISpec.scala
+++ b/it/controllers/agent/WhatYouOweControllerISpec.scala
@@ -27,6 +27,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
   val testArn: String = "1"
 
   val testDate: LocalDate = LocalDate.parse("2022-01-01")
+
   val incomeSourceDetailsModel: IncomeSourceDetailsModel = IncomeSourceDetailsModel(
     mtdbsa = testMtditid,
     yearOfMigration = None,

--- a/it/controllers/agent/WhatYouOweControllerISpec.scala
+++ b/it/controllers/agent/WhatYouOweControllerISpec.scala
@@ -98,7 +98,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
 
       IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"$previousTaxYearEnd-04-06", s"$currentTaxYearEnd-04-05")(OK,
         testValidFinancialDetailsModelJson(
-          2000, 2000, (currentTaxYearEnd - 2).toString, LocalDate.now().toString))
+          2000, 2000, (currentTaxYearEnd - 2).toString, LocalDate.parse("2022-01-01").toString))
 
       IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
         "utr", testSaUtr.toLong, (currentTaxYearEnd - 1).toString)(OK, validOutStandingChargeResponseJsonWithAciAndBcdCharges)

--- a/it/controllers/agent/WhatYouOweControllerISpec.scala
+++ b/it/controllers/agent/WhatYouOweControllerISpec.scala
@@ -10,7 +10,7 @@ import models.core.AccountingPeriodModel
 import models.financialDetails.{BalanceDetails, FinancialDetailsModel, WhatYouOweChargesList}
 import models.incomeSourceDetails.{BusinessDetailsModel, IncomeSourceDetailsModel}
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK, SEE_OTHER}
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import play.api.test.FakeRequest
 import testConstants.BaseIntegrationTestConstants._
 import testConstants.FinancialDetailsIntegrationTestConstants._
@@ -38,6 +38,25 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
     )),
     property = None
   )
+
+  val testValidOutStandingChargeResponseJsonWithAciAndBcdCharges: JsValue = Json.parse(
+    s"""
+       |{
+       |  "outstandingCharges": [{
+       |         "chargeName": "BCD",
+       |         "relevantDueDate": "$testDate",
+       |         "chargeAmount": 123456789012345.67,
+       |         "tieBreaker": 1234
+       |       },
+       |       {
+       |         "chargeName": "ACI",
+       |         "relevantDueDate": "$testDate",
+       |         "chargeAmount": 12.67,
+       |         "tieBreaker": 1234
+       |       }
+       |  ]
+       |}
+       |""".stripMargin)
 
   val currentTaxYearEnd: Int = getCurrentTaxYearEnd.getYear
   val previousTaxYearEnd: Int = currentTaxYearEnd - 1
@@ -206,7 +225,7 @@ class WhatYouOweControllerISpec extends ComponentSpecBase with FeatureSwitching 
 
       IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
         "utr", testSaUtr.toLong, (currentTaxYearEnd - 1).toString)(
-        OK, validOutStandingChargeResponseJsonWithAciAndBcdCharges)
+        OK, testValidOutStandingChargeResponseJsonWithAciAndBcdCharges)
 
       val result = IncomeTaxViewChangeFrontend.getPaymentsDue(clientDetailsWithConfirmation)
 

--- a/it/testConstants/FinancialDetailsIntegrationTestConstants.scala
+++ b/it/testConstants/FinancialDetailsIntegrationTestConstants.scala
@@ -17,7 +17,7 @@
 package testConstants
 
 import java.time.LocalDate
-import BaseIntegrationTestConstants.{testDate, testErrorMessage, testErrorNotFoundStatus, testErrorStatus}
+import BaseIntegrationTestConstants.{testErrorMessage, testErrorNotFoundStatus, testErrorStatus}
 import IncomeSourceIntegrationTestConstants.{id1040000123, noDunningLock, noInterestLock}
 import enums.ChargeType.NIC4_WALES
 import helpers.servicemocks.AuthStub.dateService
@@ -526,13 +526,17 @@ object FinancialDetailsIntegrationTestConstants {
       DocumentDetailWithDueDate(
         DocumentDetail("2021", "1040000123",
           Some("TRM New Charge"), Some("Class 2 National Insurance"), Some(2000), Some(2000), LocalDate.parse("2018-03-29"), Some(80), None, None, Some(LocalDate.parse("2018-03-29")),
-          Some(LocalDate.parse("2018-03-29")), Some(100), None, None, None), Some(LocalDate.parse("2018-03-29")), true, false, false),
+          Some(LocalDate.parse("2018-03-29")), Some(100), None, None, None),
+        Some(LocalDate.parse("2018-03-29")),
+        true,
+        false,
+        false),
       DocumentDetailWithDueDate(
         DocumentDetail("2021", "1040000124", Some("ITSA- POA 1"), None, Some(2000), Some(2000), LocalDate.parse("2018-03-29"),
-        None, None, None, None, None, None, None, None, None), Some(LocalDate.now()), false, false, false),
+        None, None, None, None, None, None, None, None, None), Some(LocalDate.parse("2022-01-01")), false, false, false),
       DocumentDetailWithDueDate(
         DocumentDetail("2021", "1040000125", Some("ITSA - POA 2"), None, Some(2000), Some(2000), LocalDate.parse("2018-03-29"),
-        None, None, None, None, None, None, None, None, None), Some(LocalDate.now()), false, false, false)
+        None, None, None, None, None, None, None, None, None), Some(LocalDate.parse("2022-01-01")), false, false, false)
     )
 
 

--- a/it/testConstants/FinancialDetailsIntegrationTestConstants.scala
+++ b/it/testConstants/FinancialDetailsIntegrationTestConstants.scala
@@ -17,7 +17,7 @@
 package testConstants
 
 import java.time.LocalDate
-import BaseIntegrationTestConstants.{testErrorMessage, testErrorNotFoundStatus, testErrorStatus}
+import BaseIntegrationTestConstants.{testDate, testErrorMessage, testErrorNotFoundStatus, testErrorStatus}
 import IncomeSourceIntegrationTestConstants.{id1040000123, noDunningLock, noInterestLock}
 import enums.ChargeType.NIC4_WALES
 import helpers.servicemocks.AuthStub.dateService
@@ -447,15 +447,76 @@ object FinancialDetailsIntegrationTestConstants {
     )
   )
 
-  def whatYouOweDataWithDataDueIn30Days(implicit dateService: DateService): WhatYouOweChargesList = WhatYouOweChargesList(
-    balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
-    chargesList = List(DocumentDetailWithDueDate(DocumentDetail("2021", "1040000123",
-      Some("TRM New Charge"), None, Some(2000), Some(2000), LocalDate.parse("2018-03-29"), Some(80), None, None, Some(LocalDate.parse("2018-03-29")),
-      Some(LocalDate.parse("2018-03-29")), Some(100), None, None, None), Some(LocalDate.parse("2018-03-29")), true, false, false),
-      DocumentDetailWithDueDate(DocumentDetail("2021", "1040000124", Some("ITSA- POA 1"), None, Some(2000), Some(2000), LocalDate.parse("2018-03-29"),
-        None, None, None, None, None, None, None, None, None), Some(LocalDate.now()), false, false, false),
-      DocumentDetailWithDueDate(DocumentDetail("2021", "1040000125", Some("ITSA - POA 2"), None, Some(2000), Some(2000), LocalDate.parse("2018-03-29"),
-        None, None, None, None, None, None, None, None, None), Some(LocalDate.now()), false, false, false))
+  def whatYouOweDataWithDataDueIn30Days(implicit dateService: DateService): WhatYouOweChargesList =
+    WhatYouOweChargesList(
+      balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
+      chargesList = List(
+        DocumentDetailWithDueDate(
+          DocumentDetail(
+            taxYear = "2021",
+            transactionId = "1040000123",
+            documentDescription = Some("TRM New Charge"),
+            documentText = None,
+            outstandingAmount = Some(2000),
+            originalAmount = Some(2000),
+            documentDate = LocalDate.parse("2018-03-29"),
+            interestOutstandingAmount = Some(80),
+            interestRate = None,
+            latePaymentInterestId = None,
+            interestFromDate = Some(LocalDate.parse("2018-03-29")),
+            interestEndDate = Some(LocalDate.parse("2018-03-29")),
+            latePaymentInterestAmount = Some(100), lpiWithDunningBlock = None, paymentLotItem = None, paymentLot = None),
+          dueDate = Some(LocalDate.parse("2018-03-29")),
+          isLatePaymentInterest = true,
+          dunningLock = false,
+          codingOutEnabled = false
+        ),
+        DocumentDetailWithDueDate(
+          DocumentDetail(
+            taxYear = "2021",
+            transactionId = "1040000124",
+            documentDescription = Some("ITSA- POA 1"),
+            documentText = None,
+            outstandingAmount = Some(2000),
+            originalAmount = Some(2000),
+            documentDate = LocalDate.parse("2018-03-29"),
+            interestOutstandingAmount = None,
+            interestRate = None,
+            latePaymentInterestId = None,
+            interestFromDate = None,
+            interestEndDate = None,
+            latePaymentInterestAmount = None,
+            lpiWithDunningBlock = None,
+            paymentLotItem = None,
+            paymentLot = None),
+          dueDate = Some(LocalDate.parse("2022-01-01")),
+          isLatePaymentInterest = false,
+          dunningLock = false,
+          codingOutEnabled = false),
+      DocumentDetailWithDueDate(
+        DocumentDetail(
+          taxYear = "2021",
+          transactionId = "1040000125",
+          documentDescription = Some("ITSA - POA 2"),
+          documentText = None,
+          outstandingAmount = Some(2000),
+          originalAmount = Some(2000),
+          documentDate = LocalDate.parse("2018-03-29"),
+          interestOutstandingAmount = None,
+          interestRate = None,
+          latePaymentInterestId = None,
+          interestFromDate = None,
+          interestEndDate = None,
+          latePaymentInterestAmount = None,
+          lpiWithDunningBlock = None,
+          paymentLotItem = None,
+          paymentLot = None
+        ),
+        dueDate = Some(LocalDate.parse("2022-01-01")),
+        isLatePaymentInterest = false,
+        dunningLock = false,
+        codingOutEnabled = false)
+      )
     ,
     outstandingChargesModel = Some(outstandingChargesOverdueData)
   )
@@ -530,7 +591,7 @@ object FinancialDetailsIntegrationTestConstants {
     chargesList = List(DocumentDetailWithDueDate(DocumentDetail("2021", "transId1", Some("ITSA- POA 1"), None, Some(1000), Some(3400),
       LocalDate.parse("2018-03-29"), None, None, None, None, None, None, None, None, None), Some(LocalDate.parse("2018-02-14")), false, false, false),
       DocumentDetailWithDueDate(DocumentDetail("2021", "transId2", Some("ITSA- POA 1"), None, Some(100), Some(1000), LocalDate.parse("2018-03-29"),
-        None, None, None, None, None, None, None, None, None), Some(LocalDate.now().plusDays(1)), false, false, false)),
+        None, None, None, None, None, None, None, None, None), Some(LocalDate.parse("2022-01-01").plusDays(1)), false, false, false)),
     outstandingChargesModel = Some(outstandingChargesOverdueData)
   )
 

--- a/it/testConstants/FinancialDetailsIntegrationTestConstants.scala
+++ b/it/testConstants/FinancialDetailsIntegrationTestConstants.scala
@@ -447,76 +447,15 @@ object FinancialDetailsIntegrationTestConstants {
     )
   )
 
-  def whatYouOweDataWithDataDueIn30Days(implicit dateService: DateService): WhatYouOweChargesList =
-    WhatYouOweChargesList(
-      balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
-      chargesList = List(
-        DocumentDetailWithDueDate(
-          DocumentDetail(
-            taxYear = "2021",
-            transactionId = "1040000123",
-            documentDescription = Some("TRM New Charge"),
-            documentText = None,
-            outstandingAmount = Some(2000),
-            originalAmount = Some(2000),
-            documentDate = LocalDate.parse("2018-03-29"),
-            interestOutstandingAmount = Some(80),
-            interestRate = None,
-            latePaymentInterestId = None,
-            interestFromDate = Some(LocalDate.parse("2018-03-29")),
-            interestEndDate = Some(LocalDate.parse("2018-03-29")),
-            latePaymentInterestAmount = Some(100), lpiWithDunningBlock = None, paymentLotItem = None, paymentLot = None),
-          dueDate = Some(LocalDate.parse("2018-03-29")),
-          isLatePaymentInterest = true,
-          dunningLock = false,
-          codingOutEnabled = false
-        ),
-        DocumentDetailWithDueDate(
-          DocumentDetail(
-            taxYear = "2021",
-            transactionId = "1040000124",
-            documentDescription = Some("ITSA- POA 1"),
-            documentText = None,
-            outstandingAmount = Some(2000),
-            originalAmount = Some(2000),
-            documentDate = LocalDate.parse("2018-03-29"),
-            interestOutstandingAmount = None,
-            interestRate = None,
-            latePaymentInterestId = None,
-            interestFromDate = None,
-            interestEndDate = None,
-            latePaymentInterestAmount = None,
-            lpiWithDunningBlock = None,
-            paymentLotItem = None,
-            paymentLot = None),
-          dueDate = Some(LocalDate.parse("2022-01-01")),
-          isLatePaymentInterest = false,
-          dunningLock = false,
-          codingOutEnabled = false),
-      DocumentDetailWithDueDate(
-        DocumentDetail(
-          taxYear = "2021",
-          transactionId = "1040000125",
-          documentDescription = Some("ITSA - POA 2"),
-          documentText = None,
-          outstandingAmount = Some(2000),
-          originalAmount = Some(2000),
-          documentDate = LocalDate.parse("2018-03-29"),
-          interestOutstandingAmount = None,
-          interestRate = None,
-          latePaymentInterestId = None,
-          interestFromDate = None,
-          interestEndDate = None,
-          latePaymentInterestAmount = None,
-          lpiWithDunningBlock = None,
-          paymentLotItem = None,
-          paymentLot = None
-        ),
-        dueDate = Some(LocalDate.parse("2022-01-01")),
-        isLatePaymentInterest = false,
-        dunningLock = false,
-        codingOutEnabled = false)
-      )
+  def whatYouOweDataWithDataDueIn30Days(implicit dateService: DateService): WhatYouOweChargesList = WhatYouOweChargesList(
+    balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
+    chargesList = List(DocumentDetailWithDueDate(DocumentDetail("2021", "1040000123",
+      Some("TRM New Charge"), None, Some(2000), Some(2000), LocalDate.parse("2018-03-29"), Some(80), None, None, Some(LocalDate.parse("2018-03-29")),
+      Some(LocalDate.parse("2018-03-29")), Some(100), None, None, None), Some(LocalDate.parse("2018-03-29")), true, false, false),
+      DocumentDetailWithDueDate(DocumentDetail("2021", "1040000124", Some("ITSA- POA 1"), None, Some(2000), Some(2000), LocalDate.parse("2018-03-29"),
+        None, None, None, None, None, None, None, None, None), Some(LocalDate.parse("2022-01-01")), false, false, false),
+      DocumentDetailWithDueDate(DocumentDetail("2021", "1040000125", Some("ITSA - POA 2"), None, Some(2000), Some(2000), LocalDate.parse("2018-03-29"),
+        None, None, None, None, None, None, None, None, None), Some(LocalDate.parse("2022-01-01")), false, false, false))
     ,
     outstandingChargesModel = Some(outstandingChargesOverdueData)
   )
@@ -526,11 +465,7 @@ object FinancialDetailsIntegrationTestConstants {
       DocumentDetailWithDueDate(
         DocumentDetail("2021", "1040000123",
           Some("TRM New Charge"), Some("Class 2 National Insurance"), Some(2000), Some(2000), LocalDate.parse("2018-03-29"), Some(80), None, None, Some(LocalDate.parse("2018-03-29")),
-          Some(LocalDate.parse("2018-03-29")), Some(100), None, None, None),
-        Some(LocalDate.parse("2018-03-29")),
-        true,
-        false,
-        false),
+          Some(LocalDate.parse("2018-03-29")), Some(100), None, None, None), Some(LocalDate.parse("2018-03-29")), true, false, false),
       DocumentDetailWithDueDate(
         DocumentDetail("2021", "1040000124", Some("ITSA- POA 1"), None, Some(2000), Some(2000), LocalDate.parse("2018-03-29"),
         None, None, None, None, None, None, None, None, None), Some(LocalDate.parse("2022-01-01")), false, false, false),
@@ -590,13 +525,14 @@ object FinancialDetailsIntegrationTestConstants {
     outstandingChargesModel = Some(OutstandingChargesModel(List()))
   )
 
+  val staticDateOutstandingChargesOverdueData: OutstandingChargesModel = outstandingChargesModel(LocalDate.parse("2022-01-01"))
   def whatYouOweWithAZeroOutstandingAmount(implicit dateService: DateService): WhatYouOweChargesList = WhatYouOweChargesList(
     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
     chargesList = List(DocumentDetailWithDueDate(DocumentDetail("2021", "transId1", Some("ITSA- POA 1"), None, Some(1000), Some(3400),
       LocalDate.parse("2018-03-29"), None, None, None, None, None, None, None, None, None), Some(LocalDate.parse("2018-02-14")), false, false, false),
       DocumentDetailWithDueDate(DocumentDetail("2021", "transId2", Some("ITSA- POA 1"), None, Some(100), Some(1000), LocalDate.parse("2018-03-29"),
         None, None, None, None, None, None, None, None, None), Some(LocalDate.parse("2022-01-01").plusDays(1)), false, false, false)),
-    outstandingChargesModel = Some(outstandingChargesOverdueData)
+    outstandingChargesModel = Some(staticDateOutstandingChargesOverdueData)
   )
 
   val whatYouOweOutstandingChargesOnly: WhatYouOweChargesList = WhatYouOweChargesList(balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),


### PR DESCRIPTION
Removed all instances of LocalDate.now from the two WhatYouOweControllerISpecs, replaced with a static date. All changes to FinancialDetailsIntegrationTestConstants.scala only affect constants which are only used by WhatYouOweControllerISpec(s)