### PR TITLE
Misuv 5180: Investigate: FE - remove FS use from the services level

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -84,7 +84,7 @@ class HomeController @Inject()(val homeView: views.html.Home,
 
     nextUpdatesService.getNextDeadlineDueDateAndOverDueObligations().flatMap { latestDeadlineDate =>
 
-      val unpaidCharges: Future[List[FinancialDetailsResponseModel]] = financialDetailsService.getAllUnpaidFinancialDetails
+      val unpaidCharges: Future[List[FinancialDetailsResponseModel]] = financialDetailsService.getAllUnpaidFinancialDetails(isEnabled(CodingOut))
 
       val dueDates: Future[List[LocalDate]] = unpaidCharges.map {
         _.flatMap {
@@ -96,7 +96,7 @@ class HomeController @Inject()(val homeView: views.html.Home,
       for {
         paymentsDue <- dueDates.map(_.sortBy(_.toEpochDay()))
         dunningLockExistsValue <- unpaidCharges.map(_.collectFirst { case fdm: FinancialDetailsModel if fdm.dunningLockExists => true })
-        outstandingChargesModel <- whatYouOweService.getWhatYouOweChargesList(unpaidCharges).map(_.outstandingChargesModel match {
+        outstandingChargesModel <- whatYouOweService.getWhatYouOweChargesList(unpaidCharges, isEnabled(CodingOut), isEnabled(MFACreditsAndDebits)).map(_.outstandingChargesModel match {
           case Some(OutstandingChargesModel(locm)) => locm.filter(ocm => ocm.relevantDueDate.isDefined && ocm.chargeName == "BCD")
           case _ => Nil
         })

--- a/app/controllers/WhatYouOweController.scala
+++ b/app/controllers/WhatYouOweController.scala
@@ -58,7 +58,7 @@ class WhatYouOweController @Inject()(val checkSessionTimeout: SessionTimeoutPred
                     isAgent: Boolean,
                     origin: Option[String] = None)
                    (implicit user: MtdItUser[_], hc: HeaderCarrier, ec: ExecutionContext, messages: Messages): Future[Result] = {
-    whatYouOweService.getWhatYouOweChargesList() flatMap {
+    whatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits)) flatMap {
       whatYouOweChargesList =>
         auditingService.extendedAudit(WhatYouOweResponseAuditModel(user, whatYouOweChargesList, dateService))
 

--- a/app/services/CreditHistoryService.scala
+++ b/app/services/CreditHistoryService.scala
@@ -18,7 +18,6 @@ package services
 
 import auth.MtdItUser
 import config.FrontendAppConfig
-import config.featureswitch.{CutOverCredits, FeatureSwitching, MFACreditsAndDebits}
 import connectors.IncomeTaxViewChangeConnector
 import exceptions.MissingFieldException
 import models.financialDetails.{DocumentDetail, FinancialDetail}
@@ -33,7 +32,7 @@ import scala.util.{Failure, Success, Try}
 
 class CreditHistoryService @Inject()(incomeTaxViewChangeConnector: IncomeTaxViewChangeConnector,
                                      val appConfig: FrontendAppConfig)
-                                    (implicit ec: ExecutionContext) extends FeatureSwitching {
+                                    (implicit ec: ExecutionContext) {
 
   // This logic is based on the findings in => RepaymentHistoryUtils.combinePaymentHistoryData method
   // Problem: we need to get list of credits (MFA + CutOver) and filter it out by calendar year
@@ -73,7 +72,7 @@ class CreditHistoryService @Inject()(incomeTaxViewChangeConnector: IncomeTaxView
       case Failure(_) => throw MissingFieldException("Tax Year field should be a numeric value in a format of YYYY")
     }
 
-  def getCreditsHistory(calendarYear: Int, nino: String)
+  def getCreditsHistory(calendarYear: Int, nino: String, MFACreditsEnabled: Boolean, CutoverCreditsEnabled: Boolean)
                        (implicit hc: HeaderCarrier, user: MtdItUser[_]): Future[Either[CreditHistoryError.type, List[CreditDetailModel]]] = {
 
     for {
@@ -83,22 +82,22 @@ class CreditHistoryService @Inject()(incomeTaxViewChangeConnector: IncomeTaxView
       case (Right(creditModelTY), Right(creditModelTYandOne)) =>
         val creditsForTaxYearAndPlusOne =
           (creditModelTY ++ creditModelTYandOne).filter(creditDetailModel => getTaxYearAsInt(creditDetailModel.documentDetail.taxYear) == calendarYear)
-        Right(filterExcludedCredits(creditsForTaxYearAndPlusOne))
+        Right(filterExcludedCredits(creditsForTaxYearAndPlusOne, MFACreditsEnabled, CutoverCreditsEnabled))
       case (Right(creditModelTY), Left(_)) =>
         val creditsForTaxYear =
           creditModelTY.filter(creditDetailModel => getTaxYearAsInt(creditDetailModel.documentDetail.taxYear) == calendarYear)
-        Right(filterExcludedCredits(creditsForTaxYear))
+        Right(filterExcludedCredits(creditsForTaxYear, MFACreditsEnabled, CutoverCreditsEnabled))
       case (Left(_), Right(creditModelTYandOne)) =>
         val creditsForTaxYearPlusOne =
           creditModelTYandOne.filter(creditDetailModel => getTaxYearAsInt(creditDetailModel.documentDetail.taxYear) == calendarYear)
-        Right(filterExcludedCredits(creditsForTaxYearPlusOne))
+        Right(filterExcludedCredits(creditsForTaxYearPlusOne, MFACreditsEnabled, CutoverCreditsEnabled))
       case (_, _) =>
         Left(CreditHistoryError)
     }
   }
 
-  private def filterExcludedCredits(credits: List[CreditDetailModel]): List[CreditDetailModel] = {
-    (isEnabled(MFACreditsAndDebits), isEnabled(CutOverCredits)) match {
+  private def filterExcludedCredits(credits: List[CreditDetailModel], MFACreditsEnabled: Boolean, CutoverCreditsEnabled: Boolean): List[CreditDetailModel] = {
+    (MFACreditsEnabled, CutoverCreditsEnabled) match {
       case (true, false) => credits.filterNot(_.creditType == CutOverCreditType)
       case (false, true) => credits.filterNot(_.creditType == MfaCreditType)
       case (false, false) => credits.filterNot(c => c.creditType == MfaCreditType || c.creditType == CutOverCreditType)

--- a/app/services/FinancialDetailsService.scala
+++ b/app/services/FinancialDetailsService.scala
@@ -105,20 +105,20 @@ class FinancialDetailsService @Inject()(val incomeTaxViewChangeConnector: Income
     }
   }
 
-  def getAllUnpaidFinancialDetails(implicit user: MtdItUser[_], hc: HeaderCarrier, ec: ExecutionContext): Future[List[FinancialDetailsResponseModel]] = {
+  def getAllUnpaidFinancialDetails(codingOutEnabled: Boolean)(implicit user: MtdItUser[_], hc: HeaderCarrier, ec: ExecutionContext): Future[List[FinancialDetailsResponseModel]] = {
     getAllFinancialDetails.map { chargesWithYears =>
       chargesWithYears.flatMap {
         case (_, errorModel: FinancialDetailsErrorModel) => Some(errorModel)
         case (_, financialDetails: FinancialDetailsModel) =>
-          val unpaidDocDetails: List[DocumentDetail] = unpaidDocumentDetails(financialDetails)
+          val unpaidDocDetails: List[DocumentDetail] = unpaidDocumentDetails(financialDetails, codingOutEnabled)
           if (unpaidDocDetails.nonEmpty) Some(financialDetails.copy(documentDetails = unpaidDocDetails)) else None
       }
     }
   }
 
-  private def unpaidDocumentDetails(financialDetailsModel: FinancialDetailsModel): List[DocumentDetail] = {
+  private def unpaidDocumentDetails(financialDetailsModel: FinancialDetailsModel, codingOutEnabled: Boolean): List[DocumentDetail] = {
     financialDetailsModel.documentDetails.collect {
-      case documentDetail: DocumentDetail if documentDetail.isCodingOutDocumentDetail(isEnabled(CodingOut)) => documentDetail
+      case documentDetail: DocumentDetail if documentDetail.isCodingOutDocumentDetail(codingOutEnabled) => documentDetail
       case documentDetail: DocumentDetail if documentDetail.latePaymentInterestAmount.isDefined && !documentDetail.interestIsPaid => documentDetail
       case documentDetail: DocumentDetail if documentDetail.isNotCodingOutDocumentDetail && !documentDetail.isPaid => documentDetail
     }

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -150,7 +150,7 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
         disableAllSwitches()
         when(NextUpdatesService.getNextDeadlineDueDateAndOverDueObligations()(any(), any(), any())) thenReturn Future.successful(updateDateAndOverdueObligations)
         mockSingleBusinessIncomeSource()
-        when(financialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+        when(financialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
           .thenReturn(Future.successful(List(FinancialDetailsModel(
             balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
             documentDetails = List(DocumentDetail(nextPaymentYear, "testId", Some("ITSA- POA 1"), Some("documentText"), Some(1000.00), None, LocalDate.of(2018, 3, 29))),
@@ -158,7 +158,7 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
               transactionId = Some("testId"),
               items = Some(Seq(SubItem(dueDate = Some(nextPaymentDate.toString))))))
           ))))
-        when(whatYouOweService.getWhatYouOweChargesList(any())(any(), any()))
+        when(whatYouOweService.getWhatYouOweChargesList(any(), any(), any())(any(), any()))
           .thenReturn(Future.successful(emptyWhatYouOweChargesListIndividual))
 
         val result: Future[Result] = controller.show()(fakeRequestWithActiveSession)
@@ -173,9 +173,9 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
         disableAllSwitches()
         when(NextUpdatesService.getNextDeadlineDueDateAndOverDueObligations()(any(), any(), any())) thenReturn Future.successful(updateDateAndOverdueObligations)
         mockSingleBusinessIncomeSource()
-        when(financialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+        when(financialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
           .thenReturn(Future.successful(List(FinancialDetailsErrorModel(1, "testString"))))
-        when(whatYouOweService.getWhatYouOweChargesList(any())(any(), any()))
+        when(whatYouOweService.getWhatYouOweChargesList(any(), any(), any())(any(), any()))
           .thenReturn(Future.successful(oneOverdueBCDPaymentInWhatYouOweChargesListIndividual))
 
         val result: Future[Result] = controller.show()(fakeRequestWithActiveSession)
@@ -191,7 +191,7 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
         when(NextUpdatesService.getNextDeadlineDueDateAndOverDueObligations()(any(), any(), any())) thenReturn Future.successful(updateDateAndOverdueObligations)
         mockSingleBusinessIncomeSource()
 
-        when(financialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+        when(financialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
           .thenReturn(Future.successful(List(
             FinancialDetailsModel(
               balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
@@ -210,7 +210,7 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
                 transactionId = Some("testId3"),
                 items = Some(Seq(SubItem(dueDate = Some(nextPaymentDate.toString)))))))
           )))
-        when(whatYouOweService.getWhatYouOweChargesList(any())(any(), any()))
+        when(whatYouOweService.getWhatYouOweChargesList(any(), any(), any())(any(), any()))
           .thenReturn(Future.successful(emptyWhatYouOweChargesListIndividual))
 
         val result: Future[Result] = controller.show()(fakeRequestWithActiveSession)
@@ -226,7 +226,7 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
         when(NextUpdatesService.getNextDeadlineDueDateAndOverDueObligations()(any(), any(), any())) thenReturn Future.successful(updateDateAndOverdueObligations)
         mockSingleBusinessIncomeSource()
 
-        when(financialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+        when(financialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
           .thenReturn(Future.successful(List(
             FinancialDetailsModel(
               balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
@@ -252,7 +252,7 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
                 transactionId = Some("testId3"),
                 items = Some(Seq(SubItem(dueDate = Some(nextPaymentDate.toString)))))))
           )))
-        when(whatYouOweService.getWhatYouOweChargesList(any())(any(), any()))
+        when(whatYouOweService.getWhatYouOweChargesList(any(), any(), any())(any(), any()))
           .thenReturn(Future.successful(emptyWhatYouOweChargesListIndividual))
 
         val result: Future[Result] = controller.show()(fakeRequestWithActiveSession)
@@ -268,9 +268,9 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
         "there is a problem getting financial details" in new Setup {
           when(NextUpdatesService.getNextDeadlineDueDateAndOverDueObligations()(any(), any(), any())) thenReturn Future.successful(updateDateAndOverdueObligations)
           mockSingleBusinessIncomeSource()
-          when(financialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(financialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(FinancialDetailsErrorModel(1, "testString"))))
-          when(whatYouOweService.getWhatYouOweChargesList(any())(any(), any()))
+          when(whatYouOweService.getWhatYouOweChargesList(any(), any(), any())(any(), any()))
             .thenReturn(Future.successful(emptyWhatYouOweChargesListIndividual))
 
           val result: Future[Result] = controller.show()(fakeRequestWithActiveSession)
@@ -285,9 +285,9 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
         "There are no financial detail" in new Setup {
           when(NextUpdatesService.getNextDeadlineDueDateAndOverDueObligations()(any(), any(), any())) thenReturn Future.successful(updateDateAndOverdueObligations)
           mockSingleBusinessIncomeSource()
-          when(financialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(financialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(FinancialDetailsModel(BalanceDetails(1.00, 2.00, 3.00, None, None, None, None), List(), List()))))
-          when(whatYouOweService.getWhatYouOweChargesList(any())(any(), any()))
+          when(whatYouOweService.getWhatYouOweChargesList(any(), any(), any())(any(), any()))
             .thenReturn(Future.successful(emptyWhatYouOweChargesListIndividual))
 
           val result: Future[Result] = controller.show()(fakeRequestWithActiveSession)
@@ -302,14 +302,14 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
         "All financial detail bill are paid" in new Setup {
           when(NextUpdatesService.getNextDeadlineDueDateAndOverDueObligations()(any(), any(), any())) thenReturn Future.successful(updateDateAndOverdueObligations)
           mockSingleBusinessIncomeSource()
-          when(financialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(financialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(FinancialDetailsModel(
               balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
               documentDetails = List(DocumentDetail(nextPaymentYear, "testId", None, None, Some(0), None, LocalDate.of(2018, 3, 29))),
               financialDetails = List(FinancialDetail(nextPaymentYear, transactionId = Some("testId"),
                 items = Some(Seq(SubItem(dueDate = Some(nextPaymentDate.toString))))))
             ))))
-          when(whatYouOweService.getWhatYouOweChargesList(any())(any(), any()))
+          when(whatYouOweService.getWhatYouOweChargesList(any(), any(), any())(any(), any()))
             .thenReturn(Future.successful(emptyWhatYouOweChargesListIndividual))
 
           val result: Future[Result] = controller.show()(fakeRequestWithActiveSession)
@@ -326,14 +326,14 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
       "there is a update date to display" in new Setup {
         when(NextUpdatesService.getNextDeadlineDueDateAndOverDueObligations()(any(), any(), any())) thenReturn Future.successful(updateDateAndOverdueObligations)
         mockSingleBusinessIncomeSource()
-        when(financialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+        when(financialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
           .thenReturn(Future.successful(List(FinancialDetailsModel(
             balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
             documentDetails = List(DocumentDetail(nextPaymentYear, "testId", None, None, Some(1000.00), None, LocalDate.of(2018, 3, 29))),
             financialDetails = List(FinancialDetail(nextPaymentYear, transactionId = Some("testId"),
               items = Some(Seq(SubItem(dueDate = Some(nextPaymentDate.toString))))))
           ))))
-        when(whatYouOweService.getWhatYouOweChargesList(any())(any(), any()))
+        when(whatYouOweService.getWhatYouOweChargesList(any(), any(), any())(any(), any()))
           .thenReturn(Future.successful(emptyWhatYouOweChargesListIndividual))
 
         val result: Future[Result] = controller.show()(fakeRequestWithActiveSession)
@@ -418,7 +418,7 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
             when(mockDateService.getCurrentDate).thenReturn(LocalDate.now())
             mockSingleBusinessIncomeSource()
             mockNextDeadlineDueDateAndOverDueObligations()(updateDateAndOverdueObligationsLPI)
-            when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any())) thenReturn Future.failed(new InternalServerException("obligation test exception"))
+            when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any())) thenReturn Future.failed(new InternalServerException("obligation test exception"))
             setupMockGetWhatYouOweChargesListEmpty()
 
             val result: Future[Result] = TestHomeController.showAgent()(fakeRequestConfirmedClient())
@@ -433,7 +433,7 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
             mockSingleBusinessIncomeSource()
             when(mockDateService.getCurrentDate).thenReturn(LocalDate.now())
             mockNextDeadlineDueDateAndOverDueObligations()(updateDateAndOverdueObligationsLPI)
-            when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+            when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
               .thenReturn(Future.successful(List(financialDetailsModel(dueDateValue = Some(LocalDate.of(2021, 5, 15).toString)))))
             setupMockGetWhatYouOweChargesListEmptyFromFinancialDetails()
 
@@ -452,7 +452,7 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
             mockSingleBusinessIncomeSource()
             when(mockDateService.getCurrentDate).thenReturn(LocalDate.now())
             mockNextDeadlineDueDateAndOverDueObligations()(updateDateAndOverdueObligationsLPI)
-            when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+            when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
               .thenReturn(Future.successful(List(financialDetailsModel(testTaxYear, dueDateValue = None))))
             setupMockGetWhatYouOweChargesListWithOneFromFinancialDetails()
 
@@ -470,7 +470,7 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
             when(mockDateService.getCurrentDate).thenReturn(LocalDate.now())
             mockSingleBusinessIncomeSource()
             mockNextDeadlineDueDateAndOverDueObligations()(updateDateAndOverdueObligationsLPI)
-            when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+            when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
               .thenReturn(Future.successful(List(financialDetailsModel(testTaxYear, dunningLock = Some("Stand over order")))))
             setupMockGetWhatYouOweChargesListWithOneFromFinancialDetails()
 
@@ -489,7 +489,7 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
             when(mockDateService.getCurrentDate).thenReturn(LocalDate.now())
             mockSingleBusinessIncomeSource()
             mockNextDeadlineDueDateAndOverDueObligations()(updateDateAndOverdueObligationsLPI)
-            when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+            when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
               .thenReturn(Future.successful(List(financialDetailsModel(testTaxYear, dunningLock = Some("Stand over order")),
                 financialDetailsModel(testTaxYear))))
             setupMockGetWhatYouOweChargesListWithOneFromFinancialDetails()
@@ -509,7 +509,7 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
             when(mockDateService.getCurrentDate).thenReturn(LocalDate.now())
             mockSingleBusinessIncomeSource()
             mockNextDeadlineDueDateAndOverDueObligations()(updateDateAndOverdueObligationsLPI)
-            when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+            when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
               .thenReturn(Future.successful(List(financialDetailsModel(testTaxYear, dunningLock = Some("Stand over order"), dueDateValue = None))))
             setupMockGetWhatYouOweChargesListWithOneFromFinancialDetails()
 
@@ -528,7 +528,7 @@ class HomeControllerSpec extends TestSupport with MockIncomeSourceDetailsService
             when(mockDateService.getCurrentDate).thenReturn(LocalDate.now())
             mockSingleBusinessIncomeSource()
             mockNextDeadlineDueDateAndOverDueObligations()(updateDateAndOverdueObligationsLPI)
-            when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+            when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
               .thenReturn(Future.successful(List(financialDetailsModel(testTaxYear, dunningLock = None, dueDateValue = None))))
             setupMockGetWhatYouOweChargesListWithOneFromFinancialDetails()
 

--- a/test/controllers/WhatYouOweControllerSpec.scala
+++ b/test/controllers/WhatYouOweControllerSpec.scala
@@ -94,7 +94,7 @@ class WhatYouOweControllerSpec extends MockAuthenticationPredicate with MockInco
         setupMockAgentAuthRetrievalSuccess(testAgentAuthRetrievalSuccess)
         setupMockAuthRetrievalSuccess(BaseTestConstants.testIndividualAuthSuccessWithSaUtrResponse())
 
-        when(whatYouOweService.getWhatYouOweChargesList()(any(), any()))
+        when(whatYouOweService.getWhatYouOweChargesList(any(),any())(any(), any()))
           .thenReturn(Future.successful(whatYouOweChargesListFull))
 
         when(whatYouOweService.getCreditCharges()(any(), any()))
@@ -115,7 +115,7 @@ class WhatYouOweControllerSpec extends MockAuthenticationPredicate with MockInco
         setupMockAgentAuthRetrievalSuccess(testAgentAuthRetrievalSuccess)
         setupMockAuthRetrievalSuccess(BaseTestConstants.testIndividualAuthSuccessWithSaUtrResponse())
 
-        when(whatYouOweService.getWhatYouOweChargesList()(any(), any()))
+        when(whatYouOweService.getWhatYouOweChargesList(any(),any())(any(), any()))
           .thenReturn(Future.successful(whatYouOweChargesListEmpty))
 
         when(whatYouOweService.getCreditCharges()(any(), any()))
@@ -136,7 +136,7 @@ class WhatYouOweControllerSpec extends MockAuthenticationPredicate with MockInco
         setupMockAgentAuthRetrievalSuccess(testAgentAuthRetrievalSuccess)
         setupMockAuthRetrievalSuccess(BaseTestConstants.testIndividualAuthSuccessWithSaUtrResponse())
 
-        when(whatYouOweService.getWhatYouOweChargesList()(any(), any()))
+        when(whatYouOweService.getWhatYouOweChargesList(any(),any())(any(), any()))
           .thenReturn(Future.failed(new Exception("failed to retrieve data")))
 
         val result: Future[Result] = controller.show()(fakeRequestWithActiveSession)
@@ -164,7 +164,7 @@ class WhatYouOweControllerSpec extends MockAuthenticationPredicate with MockInco
         setupMockAuthRetrievalSuccess(BaseTestConstants.testIndividualAuthSuccessWithSaUtrResponse())
 
 
-        when(whatYouOweService.getWhatYouOweChargesList()(any(), any()))
+        when(whatYouOweService.getWhatYouOweChargesList(any(),any())(any(), any()))
           .thenReturn(Future.successful(whatYouOweWithAvailableCredits))
 
         when(whatYouOweService.getCreditCharges()(any(), any()))
@@ -194,7 +194,7 @@ class WhatYouOweControllerSpec extends MockAuthenticationPredicate with MockInco
         setupMockAgentAuthRetrievalSuccess(testAgentAuthRetrievalSuccess)
         setupMockAuthRetrievalSuccess(BaseTestConstants.testIndividualAuthSuccessWithSaUtrResponse())
 
-        when(whatYouOweService.getWhatYouOweChargesList()(any(), any()))
+        when(whatYouOweService.getWhatYouOweChargesList(any(),any())(any(), any()))
           .thenReturn(Future.successful(whatYouOweWithZeroAvailableCredits))
 
         when(whatYouOweService.getCreditCharges()(any(), any()))

--- a/test/mocks/services/MockCreditHistoryService.scala
+++ b/test/mocks/services/MockCreditHistoryService.scala
@@ -38,12 +38,12 @@ trait MockCreditHistoryService extends UnitSpec with BeforeAndAfterEach {
   }
 
   def mockCreditHistoryService(creditDetailsModel: List[CreditDetailModel]): Unit = {
-    when(mockCreditHistoryService.getCreditsHistory(any(), any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
+    when(mockCreditHistoryService.getCreditsHistory(any(), any(), any(), any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
       .thenReturn(Future.successful(Right(creditDetailsModel)))
   }
 
   def mockCreditHistoryFailed(): Unit = {
-    when(mockCreditHistoryService.getCreditsHistory(any(), any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
+    when(mockCreditHistoryService.getCreditsHistory(any(), any(), any(), any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
       .thenReturn(Future.successful(Left(CreditHistoryError)))
   }
 

--- a/test/mocks/services/MockWhatYouOweService.scala
+++ b/test/mocks/services/MockWhatYouOweService.scala
@@ -45,18 +45,18 @@ trait MockWhatYouOweService extends UnitSpec with BeforeAndAfterEach {
   }
 
   def setupMockGetWhatYouOweChargesListEmpty(): Unit =
-    when(mockWhatYouOweService.getWhatYouOweChargesList()(any(), any()))
+    when(mockWhatYouOweService.getWhatYouOweChargesList(any(),any())(any(), any()))
       .thenReturn(Future.successful(emptyWhatYouOweChargesList))
 
   def setupMockGetWhatYouOweChargesListEmptyFromFinancialDetails(): Unit =
-    when(mockWhatYouOweService.getWhatYouOweChargesList(any())(any(), any()))
+    when(mockWhatYouOweService.getWhatYouOweChargesList(any(), any(),any())(any(), any()))
       .thenReturn(Future.successful(emptyWhatYouOweChargesList))
 
   def setupMockGetWhatYouOweChargesListWithOne(): Unit =
-    when(mockWhatYouOweService.getWhatYouOweChargesList()(any(), any()))
+    when(mockWhatYouOweService.getWhatYouOweChargesList(any(),any())(any(), any()))
       .thenReturn(Future.successful(oneOverdueBCDPaymentInWhatYouOweChargesList))
   def setupMockGetWhatYouOweChargesListWithOneFromFinancialDetails(): Unit =
-    when(mockWhatYouOweService.getWhatYouOweChargesList(any())(any(), any()))
+    when(mockWhatYouOweService.getWhatYouOweChargesList(any(), any(),any())(any(), any()))
       .thenReturn(Future.successful(oneOverdueBCDPaymentInWhatYouOweChargesList))
 
 }

--- a/test/services/CreditHistoryServiceSpec.scala
+++ b/test/services/CreditHistoryServiceSpec.scala
@@ -56,7 +56,7 @@ class CreditHistoryServiceSpec extends TestSupport with MockIncomeTaxViewChangeC
       "return a credit history error (~getFinancialDetails failed)" in {
         setupMockGetFinancialDetails(taxYear, nino)(FinancialDetailsErrorModel(500, "ERROR"))
         setupMockGetFinancialDetails(taxYear + 1, nino)(FinancialDetailsErrorModel(500, "ERROR"))
-        TestCreditHistoryService.getCreditsHistory(taxYear, nino).futureValue shouldBe Left(CreditHistoryError)
+        TestCreditHistoryService.getCreditsHistory(taxYear, nino, false, false).futureValue shouldBe Left(CreditHistoryError)
       }
     }
 
@@ -67,7 +67,7 @@ class CreditHistoryServiceSpec extends TestSupport with MockIncomeTaxViewChangeC
           enable(CutOverCredits)
           setupMockGetFinancialDetails(taxYear, nino)(taxYearFinancialDetails)
           setupMockGetFinancialDetails(taxYear + 1, nino)(taxYearFinancialDetails_PlusOneYear)
-          val futureResult = TestCreditHistoryService.getCreditsHistory(taxYear, nino)
+          val futureResult = TestCreditHistoryService.getCreditsHistory(taxYear, nino, true, true)
           whenReady(futureResult) { result =>
             result shouldBe Right(List(creditDetailModelasCutOver, creditDetailModelasMfa, creditDetailModelasBCC))
           }
@@ -79,7 +79,7 @@ class CreditHistoryServiceSpec extends TestSupport with MockIncomeTaxViewChangeC
           disable(CutOverCredits)
           setupMockGetFinancialDetails(taxYear, nino)(taxYearFinancialDetails)
           setupMockGetFinancialDetails(taxYear + 1, nino)(taxYearFinancialDetails_PlusOneYear)
-          val futureResult = TestCreditHistoryService.getCreditsHistory(taxYear, nino)
+          val futureResult = TestCreditHistoryService.getCreditsHistory(taxYear, nino, true, false)
           whenReady(futureResult) { result =>
             result shouldBe Right(List(creditDetailModelasMfa, creditDetailModelasBCC))
           }
@@ -91,7 +91,7 @@ class CreditHistoryServiceSpec extends TestSupport with MockIncomeTaxViewChangeC
           enable(CutOverCredits)
           setupMockGetFinancialDetails(taxYear, nino)(taxYearFinancialDetails)
           setupMockGetFinancialDetails(taxYear + 1, nino)(taxYearFinancialDetails_PlusOneYear)
-          val futureResult = TestCreditHistoryService.getCreditsHistory(taxYear, nino)
+          val futureResult = TestCreditHistoryService.getCreditsHistory(taxYear, nino, false, true)
           whenReady(futureResult) { result =>
             result shouldBe Right(List(creditDetailModelasCutOver, creditDetailModelasBCC))
           }
@@ -103,7 +103,7 @@ class CreditHistoryServiceSpec extends TestSupport with MockIncomeTaxViewChangeC
           disable(CutOverCredits)
           setupMockGetFinancialDetails(taxYear, nino)(taxYearFinancialDetails)
           setupMockGetFinancialDetails(taxYear + 1, nino)(taxYearFinancialDetails_PlusOneYear)
-          val futureResult = TestCreditHistoryService.getCreditsHistory(taxYear, nino)
+          val futureResult = TestCreditHistoryService.getCreditsHistory(taxYear, nino, false, false)
           whenReady(futureResult) { result =>
             result shouldBe Right(List(creditDetailModelasBCC))
           }

--- a/test/services/FinancialDetailsServiceSpec.scala
+++ b/test/services/FinancialDetailsServiceSpec.scala
@@ -411,7 +411,7 @@ class FinancialDetailsServiceSpec extends TestSupport with MockIncomeTaxViewChan
         setupMockGetFinancialDetails(getTaxEndYear(LocalDate.now.minusYears(1)), testNino)(financialDetailLastYear)
         setupMockGetFinancialDetails(getTaxEndYear(LocalDate.now), testNino)(financialDetail)
 
-        val result = TestFinancialDetailsService.getAllUnpaidFinancialDetails(mtdUser(2), headerCarrier, ec)
+        val result = TestFinancialDetailsService.getAllUnpaidFinancialDetails(isEnabled(CodingOut))(mtdUser(2), headerCarrier, ec)
 
         result.futureValue shouldBe expectedResult
       }
@@ -463,7 +463,7 @@ class FinancialDetailsServiceSpec extends TestSupport with MockIncomeTaxViewChan
           )
         ))
 
-        val result = TestFinancialDetailsService.getAllUnpaidFinancialDetails(mtdUser(2), headerCarrier, ec)
+        val result = TestFinancialDetailsService.getAllUnpaidFinancialDetails(isEnabled(CodingOut))(mtdUser(2), headerCarrier, ec)
 
         result.futureValue shouldBe expectedResult
       }
@@ -492,7 +492,7 @@ class FinancialDetailsServiceSpec extends TestSupport with MockIncomeTaxViewChan
           )
         ))
 
-        val result = TestFinancialDetailsService.getAllUnpaidFinancialDetails(mtdUser(2), headerCarrier, ec)
+        val result = TestFinancialDetailsService.getAllUnpaidFinancialDetails(isEnabled(CodingOut))(mtdUser(2), headerCarrier, ec)
 
         result.futureValue shouldBe List.empty[FinancialDetailsResponseModel]
       }
@@ -524,7 +524,7 @@ class FinancialDetailsServiceSpec extends TestSupport with MockIncomeTaxViewChan
         ))
         setupMockGetFinancialDetails(getTaxEndYear(LocalDate.now), testNino)(financialDetailError)
 
-        val result = TestFinancialDetailsService.getAllUnpaidFinancialDetails(mtdUser(2), headerCarrier, ec)
+        val result = TestFinancialDetailsService.getAllUnpaidFinancialDetails(isEnabled(CodingOut))(mtdUser(2), headerCarrier, ec)
 
         result.futureValue shouldBe expectedResult
       }
@@ -562,7 +562,7 @@ class FinancialDetailsServiceSpec extends TestSupport with MockIncomeTaxViewChan
         setupMockGetFinancialDetails(getTaxEndYear(LocalDate.now.minusYears(1)), testNino)(financialDetailCodingOut)
         setupMockGetFinancialDetails(getTaxEndYear(LocalDate.now), testNino)(financialDetail)
 
-        val result = TestFinancialDetailsService.getAllUnpaidFinancialDetails(mtdUser(2), headerCarrier, ec)
+        val result = TestFinancialDetailsService.getAllUnpaidFinancialDetails(isEnabled(CodingOut))(mtdUser(2), headerCarrier, ec)
 
         result.futureValue shouldBe List(
           financialDetailCodingOut,
@@ -608,7 +608,7 @@ class FinancialDetailsServiceSpec extends TestSupport with MockIncomeTaxViewChan
           setupMockGetFinancialDetails(getTaxEndYear(LocalDate.now.minusYears(1)), testNino)(financialDetailCodingOut)
           setupMockGetFinancialDetails(getTaxEndYear(LocalDate.now), testNino)(financialDetail)
 
-          val result = TestFinancialDetailsService.getAllUnpaidFinancialDetails(mtdUser(2), headerCarrier, ec)
+          val result = TestFinancialDetailsService.getAllUnpaidFinancialDetails(isEnabled(CodingOut))(mtdUser(2), headerCarrier, ec)
 
           result.futureValue shouldBe List(
             financialDetail

--- a/test/services/WhatYouOweServiceSpec.scala
+++ b/test/services/WhatYouOweServiceSpec.scala
@@ -77,59 +77,59 @@ class WhatYouOweServiceSpec extends TestSupport with FeatureSwitching {
       "return a success response back" in {
         when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
           .thenReturn(Future.successful(outstandingChargesDueInMoreThan30Days))
-        when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+        when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(isEnabled(CodingOut))(any(), any(), any()))
           .thenReturn(Future.successful(List(financialDetailsDueInMoreThan30Days())))
 
-        TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser).futureValue shouldBe whatYouOweDataWithDataDueInMoreThan30Days()
+        TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser).futureValue shouldBe whatYouOweDataWithDataDueInMoreThan30Days()
       }
     }
     "when both financial details and outstanding charges return success response and valid data of due in 30 days" should {
       "return a success response back" in {
         when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
           .thenReturn(Future.successful(outstandingChargesDueIn30Days))
-        when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+        when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
           .thenReturn(Future.successful(List(financialDetailsDueIn30Days())))
 
-        TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser).futureValue shouldBe whatYouOweDataWithDataDueIn30Days()
+        TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser).futureValue shouldBe whatYouOweDataWithDataDueIn30Days()
       }
       "when both financial details and outstanding charges return success response and valid data of overdue" should {
         "return a success response back" in {
           when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
             .thenReturn(Future.successful(outstandingChargesOverdueData))
-          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(financialDetailsOverdueData())))
 
-          TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser).futureValue shouldBe whatYouOweDataWithOverdueData()
+          TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser).futureValue shouldBe whatYouOweDataWithOverdueData()
         }
       }
       "when both financial details and outstanding charges return success response and valid data of mixed due dates of overdue and in future payments" should {
         "return a success response back" in {
           when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
             .thenReturn(Future.successful(OutstandingChargesModel(List())))
-          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(financialDetailsWithMixedData1)))
 
-          TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser).futureValue shouldBe whatYouOweDataWithMixedData1
+          TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser).futureValue shouldBe whatYouOweDataWithMixedData1
         }
       }
       "when both financial details and outstanding charges return success response and valid data of mixed due dates of overdue and dueInThirtyDays" should {
         "return a success response back" in {
           when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
             .thenReturn(Future.successful(OutstandingChargesModel(List())))
-          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(financialDetailsWithMixedData2)))
 
-          TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser).futureValue shouldBe whatYouOweDataWithMixedData2
+          TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser).futureValue shouldBe whatYouOweDataWithMixedData2
         }
       }
       "when both financial details return success and outstanding charges return 500" should {
         "return a success response back" in {
           when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
             .thenReturn(Future.successful(OutstandingChargesErrorModel(500, "test message")))
-          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(financialDetailsDueInMoreThan30Days())))
 
-          val res = TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser)
+          val res = TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser)
 
           val ex = res.failed.futureValue
           ex shouldBe an[Exception]
@@ -140,10 +140,10 @@ class WhatYouOweServiceSpec extends TestSupport with FeatureSwitching {
         "return a success response back" in {
           when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
             .thenReturn(Future.successful(outstandingChargesOverdueData))
-          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(financialDetailsDueInMoreThan30Days(), FinancialDetailsErrorModel(500, "test message"))))
 
-          val res = TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser)
+          val res = TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser)
 
           val ex = res.failed.futureValue
           ex shouldBe an[Exception]
@@ -154,10 +154,10 @@ class WhatYouOweServiceSpec extends TestSupport with FeatureSwitching {
         "return a success response back" in {
           when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
             .thenReturn(Future.successful(OutstandingChargesErrorModel(404, "NOT_FOUND")))
-          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(financialDetailsDueInMoreThan30Days())))
 
-          TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser).futureValue shouldBe WhatYouOweChargesList(
+          TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser).futureValue shouldBe WhatYouOweChargesList(
             balanceDetails = BalanceDetails(0.00, 2.00, 2.00, None, None, None, Some(100)),
             chargesList = financialDetailsDueInMoreThan30Days().getAllDocumentDetailsWithDueDates()
           )
@@ -168,10 +168,10 @@ class WhatYouOweServiceSpec extends TestSupport with FeatureSwitching {
         "return a success response back" in {
           when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
             .thenReturn(Future.successful(OutstandingChargesErrorModel(404, "NOT_FOUND")))
-          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(financialDetailsBalancingCharges)))
 
-          TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser).futureValue shouldBe WhatYouOweChargesList(
+          TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser).futureValue shouldBe WhatYouOweChargesList(
             balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
             chargesList = financialDetailsBalancingCharges.getAllDocumentDetailsWithDueDates()
           )
@@ -182,32 +182,32 @@ class WhatYouOweServiceSpec extends TestSupport with FeatureSwitching {
         "return a success empty response back with both outstanding amount zero and no late payment interest" in {
           when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
             .thenReturn(Future.successful(OutstandingChargesErrorModel(404, "NOT_FOUND")))
-          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(financialDetailsWithOutstandingChargesAndLpi(outstandingAmount = List(Some(0), Some(0))))))
 
-          TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser).futureValue shouldBe WhatYouOweChargesList(
+          TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser).futureValue shouldBe WhatYouOweChargesList(
             balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None)
           )
         }
         "return a success empty response with outstanding amount zero and late payment interest amount zero" in {
           when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
             .thenReturn(Future.successful(OutstandingChargesErrorModel(404, "NOT_FOUND")))
-          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(financialDetailsWithOutstandingChargesAndLpi(outstandingAmount = List(Some(0), Some(0)),
               latePaymentInterestAmount = List(Some(0), Some(0)), interestOutstandingAmount = List(Some(0), Some(0))))))
 
-          TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser).futureValue shouldBe WhatYouOweChargesList(
+          TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser).futureValue shouldBe WhatYouOweChargesList(
             balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None)
           )
         }
         "return a success POA2 only response with outstanding amount zero and late payment interest amount non-zero" in {
           when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
             .thenReturn(Future.successful(OutstandingChargesErrorModel(404, "NOT_FOUND")))
-          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(financialDetailsWithOutstandingChargesAndLpi(outstandingAmount = List(Some(0), Some(0)),
               latePaymentInterestAmount = List(Some(0), Some(10)), interestOutstandingAmount = List(Some(0), Some(10))))))
 
-          TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser).futureValue shouldBe WhatYouOweChargesList(
+          TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser).futureValue shouldBe WhatYouOweChargesList(
             balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
             chargesList = List(DocumentDetailWithDueDate(
               DocumentDetail(currentYear, "1040000124", Some("ITSA - POA 2"), Some("documentText"), Some(0), Some(12.34), LocalDate.of(2018, 3, 29), Some(10), Some(100),
@@ -235,7 +235,7 @@ class WhatYouOweServiceSpec extends TestSupport with FeatureSwitching {
           val dd3 = dd1.copy(transactionId = id1040000126, documentText = Some(CODING_OUT_ACCEPTED), amountCodedOut = Some(2500.00))
           when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
             .thenReturn(Future.successful(OutstandingChargesErrorModel(404, "NOT_FOUND")))
-          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(FinancialDetailsModel(
               balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
               documentDetails = List(dd1, dd2, dd3),
@@ -248,7 +248,7 @@ class WhatYouOweServiceSpec extends TestSupport with FeatureSwitching {
                   Some(100), Some(100), Some(NIC4_WALES), Some(100), Some(Seq(SubItem(dueDate = Some(LocalDate.parse("2021-08-25")), dunningLock = Some("Coding out")))))
               )
             ))))
-          TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser).futureValue shouldBe WhatYouOweChargesList(
+          TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser).futureValue shouldBe WhatYouOweChargesList(
             balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
             chargesList = List(DocumentDetailWithDueDate(documentDetail = dd1, dueDate = Some(LocalDate.parse("2021-08-24")), codingOutEnabled = true),
               DocumentDetailWithDueDate(documentDetail = dd2, dueDate = Some(LocalDate.parse("2021-08-25")), codingOutEnabled = true)),
@@ -276,7 +276,7 @@ class WhatYouOweServiceSpec extends TestSupport with FeatureSwitching {
           val dd3 = dd1.copy(transactionId = id1040000126, documentText = Some(CODING_OUT_ACCEPTED))
           when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
             .thenReturn(Future.successful(OutstandingChargesErrorModel(404, "NOT_FOUND")))
-          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+          when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
             .thenReturn(Future.successful(List(FinancialDetailsModel(
               balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
               documentDetails = List(dd1, dd2, dd3),
@@ -290,7 +290,7 @@ class WhatYouOweServiceSpec extends TestSupport with FeatureSwitching {
               )
             ))))
 
-          TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser).futureValue shouldBe WhatYouOweChargesList(
+          TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser).futureValue shouldBe WhatYouOweChargesList(
             balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None),
             chargesList = List(DocumentDetailWithDueDate(documentDetail = dd1, dueDate = Some(LocalDate.parse("2021-08-24"))),
               DocumentDetailWithDueDate(documentDetail = dd2, dueDate = Some(LocalDate.parse("2021-08-25")))),
@@ -305,9 +305,9 @@ class WhatYouOweServiceSpec extends TestSupport with FeatureSwitching {
         if (MFADebitsEnabled) enable(MFACreditsAndDebits) else disable(MFACreditsAndDebits)
         when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
           .thenReturn(Future.successful(OutstandingChargesModel(List())))
-        when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any(), any(), any()))
+        when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
           .thenReturn(Future.successful(List(financialDetails)))
-        TestWhatYouOweService.getWhatYouOweChargesList()(headerCarrier, mtdItUser).futureValue shouldBe expectedResult
+        TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser).futureValue shouldBe expectedResult
       }
 
       "return MFA Debits and non-MFA debits with FS ENABLED" in {

--- a/test/services/WhatYouOweServiceSpec.scala
+++ b/test/services/WhatYouOweServiceSpec.scala
@@ -77,7 +77,7 @@ class WhatYouOweServiceSpec extends TestSupport with FeatureSwitching {
       "return a success response back" in {
         when(mockIncomeTaxViewChangeConnector.getOutstandingCharges(any(), any(), any())(any()))
           .thenReturn(Future.successful(outstandingChargesDueInMoreThan30Days))
-        when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(isEnabled(CodingOut))(any(), any(), any()))
+        when(mockFinancialDetailsService.getAllUnpaidFinancialDetails(any())(any(), any(), any()))
           .thenReturn(Future.successful(List(financialDetailsDueInMoreThan30Days())))
 
         TestWhatYouOweService.getWhatYouOweChargesList(isEnabled(CodingOut), isEnabled(MFACreditsAndDebits))(headerCarrier, mtdItUser).futureValue shouldBe whatYouOweDataWithDataDueInMoreThan30Days()


### PR DESCRIPTION
Removed FS from 3 out of 4 services using it. FS checks are now executed in Controllers/Tests and the variable passed as a parameter into the service. Removing TimeMachine check from DateService was not possible