### PR TITLE
MISUV-5370: Incorrect date format getting displayed on coding out summary page

### DIFF
--- a/app/views/ChargeSummary.scala.html
+++ b/app/views/ChargeSummary.scala.html
@@ -96,7 +96,7 @@
         @messages("chargeSummary.check-paye-tax-code-1")
         <a class="govuk-link" id="paye-tax-code-link" href="https://www.tax.service.gov.uk/check-income-tax/tax-codes/@currentTaxYearEnd">
             @messages("chargeSummary.check-paye-tax-code-2")</a>
-        @messages("chargeSummary.check-paye-tax-code-3", taxYearFrom, taxYearTo)
+        @messages("chargeSummary.check-paye-tax-code-3", taxYearFrom.toString, taxYearTo.toString)
     }
 }
 
@@ -125,7 +125,7 @@
 
 @codingOutMessage = {
     @p(id=Some("coding-out-message")){
-        @messages("chargeSummary.codingOutMessage", taxYearFrom, taxYearTo)
+        @messages("chargeSummary.codingOutMessage", taxYearFrom.toString, taxYearTo.toString)
     }
 }
 

--- a/it/controllers/ChargeSummaryControllerISpec.scala
+++ b/it/controllers/ChargeSummaryControllerISpec.scala
@@ -335,7 +335,7 @@ class ChargeSummaryControllerISpec extends ComponentSpecBase {
         httpStatus(OK),
         pageTitleIndividual("tax-year-summary.payments.codingOut.text"),
         elementTextBySelector("#coding-out-notice")(codingOutInsetPara),
-        elementTextBySelector("#coding-out-message")(codingOutMessage(2017, 2018))
+        elementTextBySelector("#coding-out-message")(codingOutMessageWithStringMessagesArgument(2017, 2018))
       )
     }
 

--- a/it/controllers/agent/ChargeSummaryControllerISpec.scala
+++ b/it/controllers/agent/ChargeSummaryControllerISpec.scala
@@ -34,13 +34,13 @@ import testConstants.BaseIntegrationTestConstants._
 import testConstants.FinancialDetailsIntegrationTestConstants.financialDetailModelPartial
 import testConstants.IncomeSourceIntegrationTestConstants._
 import testConstants.messages.ChargeSummaryMessages
-import testConstants.messages.ChargeSummaryMessages.{codingOutInsetPara, codingOutMessage, notCurrentlyChargingInterest, paymentBreakdownHeading, underReview}
+import testConstants.messages.ChargeSummaryMessages.{codingOutInsetPara, codingOutMessage, codingOutMessageWithStringMessagesArgument, notCurrentlyChargingInterest, paymentBreakdownHeading, underReview}
 import uk.gov.hmrc.auth.core.AffinityGroup.Agent
 
 import java.time.LocalDate
 
 
-class ChargeSummaryControllerISpec extends ComponentSpecBase with FeatureSwitching {
+class ITChargeSummaryControllerISpec extends ComponentSpecBase with FeatureSwitching {
 
 
   val paymentAllocation: List[PaymentsWithChargeType] = List(
@@ -242,7 +242,7 @@ class ChargeSummaryControllerISpec extends ComponentSpecBase with FeatureSwitchi
         httpStatus(OK),
         pageTitleAgent("tax-year-summary.payments.codingOut.text"),
         elementTextBySelector("#coding-out-notice")(codingOutInsetPara),
-        elementTextBySelector("#coding-out-message")(codingOutMessage(getCurrentTaxYearEnd.getYear - 1, getCurrentTaxYearEnd.getYear))
+        elementTextBySelector("#coding-out-message")(codingOutMessageWithStringMessagesArgument(getCurrentTaxYearEnd.getYear - 1, getCurrentTaxYearEnd.getYear))
       )
     }
 

--- a/it/controllers/agent/ChargeSummaryControllerISpec.scala
+++ b/it/controllers/agent/ChargeSummaryControllerISpec.scala
@@ -40,7 +40,7 @@ import uk.gov.hmrc.auth.core.AffinityGroup.Agent
 import java.time.LocalDate
 
 
-class ITChargeSummaryControllerISpec extends ComponentSpecBase with FeatureSwitching {
+class ChargeSummaryControllerISpec extends ComponentSpecBase with FeatureSwitching {
 
 
   val paymentAllocation: List[PaymentsWithChargeType] = List(

--- a/it/testConstants/messages/ChargeSummaryMessages.scala
+++ b/it/testConstants/messages/ChargeSummaryMessages.scala
@@ -29,6 +29,7 @@ object ChargeSummaryMessages {
   val codingOutInsetPara: String = s"${messagesAPI("chargeSummary.codingOutInset-1")} ${messagesAPI("chargeSummary.codingOutInset-2")}" +
     s"${messagesAPI("pagehelp.opensInNewTabText")} ${messagesAPI("chargeSummary.codingOutInset-3")}"
   def codingOutMessage(from: Int, to: Int): String = messagesAPI("chargeSummary.codingOutMessage", from, to)
+  def codingOutMessageWithStringMessagesArgument(from: Int, to: Int): String = messagesAPI("chargeSummary.codingOutMessage", from.toString, to.toString)
 
   val paymentprocessingbullet1: String = s"${messagesAPI("chargeSummary.payments-bullet1-1")} ${messagesAPI("chargeSummary.payments-bullet1-2")}${messagesAPI("pagehelp.opensInNewTabText")} ${messagesAPI("chargeSummary.payments-bullet2")}"
   val paymentprocessingbullet1Agent: String = s"${messagesAPI("chargeSummary.payments-bullet1-1")} ${messagesAPI("chargeSummary.payments-bullet1-2-agent")}${messagesAPI("pagehelp.opensInNewTabText")} ${messagesAPI("chargeSummary.payments-bullet2-agent")}"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.9.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.9.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 

--- a/test/views/ChargeSummaryViewSpec.scala
+++ b/test/views/ChargeSummaryViewSpec.scala
@@ -145,7 +145,6 @@ class ChargeSummaryViewSpec extends ViewSpec with FeatureSwitching{
     def payeTaxCodeText(year: Int) = s"${messages("chargeSummary.check-paye-tax-code-1")} ${messages("chargeSummary.check-paye-tax-code-2")} ${messages("chargeSummary.check-paye-tax-code-3", year - 1, year)}"
     def payeTaxCodeTextWithStringMessage(year: Int) = s"${messages("chargeSummary.check-paye-tax-code-1")} ${messages("chargeSummary.check-paye-tax-code-2")} ${messages("chargeSummary.check-paye-tax-code-3", (year - 1).toString, year.toString)}"
 
-
     val payeTaxCodeLink = s"https://www.tax.service.gov.uk/check-income-tax/tax-codes/${getCurrentTaxYearEnd.getYear}"
     val cancelledPayeTaxCodeInsetText = s"${messages("chargeSummary.cancelledPayeInset-1")} ${messages("chargeSummary.cancelledPayeInset-2")}${messages("pagehelp.opensInNewTabText")}. ${messages("chargeSummary.cancelledPayeInset-3")}"
     val cancellledPayeTaxCodeInsetLink = "https://www.gov.uk/pay-self-assessment-tax-bill/through-your-tax-code"

--- a/test/views/ChargeSummaryViewSpec.scala
+++ b/test/views/ChargeSummaryViewSpec.scala
@@ -94,7 +94,7 @@ class ChargeSummaryViewSpec extends ViewSpec with FeatureSwitching{
     val taxYearHeading: String = messages("taxYears.table.taxYear.heading")
     val balancingCharge: String = messages("chargeSummary.balancingCharge.text")
     val paymentBreakdownNic2: String = messages("chargeSummary.paymentBreakdown.nic2")
-    val codingOutMessage2017To2018: String = messages("chargeSummary.codingOutMessage", 2017, 2018)
+    val codingOutMessage2017To2018: String = messages("chargeSummary.codingOutMessage", "2017", "2018")
     val chargeSummaryCodingOutHeading2017To2018: String = s"$taxYearHeading 6 April 2017 to 5 April 2018 ${messages("chargeSummary.codingOut.text")}"
     val insetPara: String = s"${messages("chargeSummary.codingOutInset-1")} ${messages("chargeSummary.codingOutInset-2")}${messages("pagehelp.opensInNewTabText")} ${messages("chargeSummary.codingOutInset-3")}"
     val paymentBreakdownInterestLocksCharging: String = messages("chargeSummary.paymentBreakdown.interestLocks.charging")
@@ -141,7 +141,7 @@ class ChargeSummaryViewSpec extends ViewSpec with FeatureSwitching{
     val class2NicChargeCreated: String = messages("chargeSummary.chargeHistory.created.class2Nic.text")
     val cancelledSaPayeCreated: String = messages("chargeSummary.chargeHistory.created.cancelledPayeSelfAssessment.text")
 
-    def payeTaxCodeText(year: Int) = s"${messages("chargeSummary.check-paye-tax-code-1")} ${messages("chargeSummary.check-paye-tax-code-2")} ${messages("chargeSummary.check-paye-tax-code-3", year - 1, year)}"
+    def payeTaxCodeText(year: Int) = s"${messages("chargeSummary.check-paye-tax-code-1")} ${messages("chargeSummary.check-paye-tax-code-2")} ${messages("chargeSummary.check-paye-tax-code-3", (year - 1).toString, year.toString)}"
 
     val payeTaxCodeLink = s"https://www.tax.service.gov.uk/check-income-tax/tax-codes/${getCurrentTaxYearEnd.getYear}"
     val cancelledPayeTaxCodeInsetText = s"${messages("chargeSummary.cancelledPayeInset-1")} ${messages("chargeSummary.cancelledPayeInset-2")}${messages("pagehelp.opensInNewTabText")}. ${messages("chargeSummary.cancelledPayeInset-3")}"

--- a/test/views/ChargeSummaryViewSpec.scala
+++ b/test/views/ChargeSummaryViewSpec.scala
@@ -94,7 +94,8 @@ class ChargeSummaryViewSpec extends ViewSpec with FeatureSwitching{
     val taxYearHeading: String = messages("taxYears.table.taxYear.heading")
     val balancingCharge: String = messages("chargeSummary.balancingCharge.text")
     val paymentBreakdownNic2: String = messages("chargeSummary.paymentBreakdown.nic2")
-    val codingOutMessage2017To2018: String = messages("chargeSummary.codingOutMessage", "2017", "2018")
+    val codingOutMessage2017To2018: String = messages("chargeSummary.codingOutMessage", 2017, 2018)
+    val codingOutMessage2017To2018WithStringMessagesArgument: String = messages("chargeSummary.codingOutMessage", "2017", "2018")
     val chargeSummaryCodingOutHeading2017To2018: String = s"$taxYearHeading 6 April 2017 to 5 April 2018 ${messages("chargeSummary.codingOut.text")}"
     val insetPara: String = s"${messages("chargeSummary.codingOutInset-1")} ${messages("chargeSummary.codingOutInset-2")}${messages("pagehelp.opensInNewTabText")} ${messages("chargeSummary.codingOutInset-3")}"
     val paymentBreakdownInterestLocksCharging: String = messages("chargeSummary.paymentBreakdown.interestLocks.charging")
@@ -141,7 +142,9 @@ class ChargeSummaryViewSpec extends ViewSpec with FeatureSwitching{
     val class2NicChargeCreated: String = messages("chargeSummary.chargeHistory.created.class2Nic.text")
     val cancelledSaPayeCreated: String = messages("chargeSummary.chargeHistory.created.cancelledPayeSelfAssessment.text")
 
-    def payeTaxCodeText(year: Int) = s"${messages("chargeSummary.check-paye-tax-code-1")} ${messages("chargeSummary.check-paye-tax-code-2")} ${messages("chargeSummary.check-paye-tax-code-3", (year - 1).toString, year.toString)}"
+    def payeTaxCodeText(year: Int) = s"${messages("chargeSummary.check-paye-tax-code-1")} ${messages("chargeSummary.check-paye-tax-code-2")} ${messages("chargeSummary.check-paye-tax-code-3", year - 1, year)}"
+    def payeTaxCodeTextWithStringMessage(year: Int) = s"${messages("chargeSummary.check-paye-tax-code-1")} ${messages("chargeSummary.check-paye-tax-code-2")} ${messages("chargeSummary.check-paye-tax-code-3", (year - 1).toString, year.toString)}"
+
 
     val payeTaxCodeLink = s"https://www.tax.service.gov.uk/check-income-tax/tax-codes/${getCurrentTaxYearEnd.getYear}"
     val cancelledPayeTaxCodeInsetText = s"${messages("chargeSummary.cancelledPayeInset-1")} ${messages("chargeSummary.cancelledPayeInset-2")}${messages("pagehelp.opensInNewTabText")}. ${messages("chargeSummary.cancelledPayeInset-3")}"
@@ -276,7 +279,7 @@ class ChargeSummaryViewSpec extends ViewSpec with FeatureSwitching{
 
       "have a paragraphs explaining Cancelled PAYE self assessment" in new Setup(documentDetailModel(documentDescription = Some("TRM New Charge"),
         documentText = Some(messages("whatYouOwe.cancelled-paye-sa.heading")), lpiWithDunningBlock = None), codingOutEnabled = true) {
-        document.select("#check-paye-para").text() shouldBe payeTaxCodeText(2018)
+        document.select("#check-paye-para").text() shouldBe payeTaxCodeTextWithStringMessage(2018)
         document.select("#paye-tax-code-link").attr("href") shouldBe payeTaxCodeLink
         document.select("#cancelled-coding-out-notice").text() shouldBe cancelledPayeTaxCodeInsetText
         document.select("#cancelled-coding-out-notice a").attr("href") shouldBe cancellledPayeTaxCodeInsetLink
@@ -660,10 +663,10 @@ class ChargeSummaryViewSpec extends ViewSpec with FeatureSwitching{
 
         "Coding Out is Enabled" in new Setup(documentDetailCodingOut, codingOutEnabled = true) {
           document.select("h1").text() shouldBe chargeSummaryCodingOutHeading2017To2018
-          document.select("#check-paye-para").text() shouldBe payeTaxCodeText(2018)
+          document.select("#check-paye-para").text() shouldBe payeTaxCodeTextWithStringMessage(2018)
           document.select("#paye-tax-code-link").attr("href") shouldBe payeTaxCodeLink
           document.select("#coding-out-notice").text() shouldBe insetPara
-          document.select("#coding-out-message").text() shouldBe codingOutMessage2017To2018
+          document.select("#coding-out-message").text() shouldBe codingOutMessage2017To2018WithStringMessagesArgument
           document.select("#coding-out-notice-link").attr("href") shouldBe cancellledPayeTaxCodeInsetLink
           document.select("a.govuk-button").size() shouldBe 0
           document.select(".govuk-table tbody tr").size() shouldBe 1
@@ -679,7 +682,7 @@ class ChargeSummaryViewSpec extends ViewSpec with FeatureSwitching{
         "Coding Out is Enabled" in new Setup(documentDetailCodingOut, codingOutEnabled = true) {
           document.select("h1").text() shouldBe chargeSummaryCodingOutHeading2017To2018
           document.select("#coding-out-notice").text() shouldBe insetPara
-          document.select("#coding-out-message").text() shouldBe codingOutMessage2017To2018
+          document.select("#coding-out-message").text() shouldBe codingOutMessage2017To2018WithStringMessagesArgument
           document.select("#coding-out-notice-link").attr("href") shouldBe cancellledPayeTaxCodeInsetLink
           document.selectById("paymentAmount").text() shouldBe "Payment amount £2,500.00"
           document.selectById("codingOutRemainingToPay").text() shouldBe messages("chargeSummary.codingOutRemainingToPay", "2019", "2020")


### PR DESCRIPTION
added .toString so that the ints aren't formatted incorrectly