### PR TITLE
MISUV-5914: avoiding re-compilation when changing read incomeSource override

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -164,4 +164,7 @@ class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, val config
 
   lazy val ivUrl = servicesConfig.getString("identity-verification-frontend.host")
   lazy val relativeIVUpliftParams = servicesConfig.getBoolean("identity-verification-frontend.use-relative-params")
+
+  lazy val incomeSourceOverrides = config.getOptional[Seq[String]]("afterIncomeSourceCreated")
+
 }

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -165,6 +165,6 @@ class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, val config
   lazy val ivUrl = servicesConfig.getString("identity-verification-frontend.host")
   lazy val relativeIVUpliftParams = servicesConfig.getBoolean("identity-verification-frontend.use-relative-params")
 
-  lazy val incomeSourceOverrides = config.getOptional[Seq[String]]("afterIncomeSourceCreated")
+  def incomeSourceOverrides(): Option[Seq[String]] = config.getOptional[Seq[String]]("afterIncomeSourceCreated")
 
 }

--- a/app/connectors/IncomeTaxViewChangeConnector.scala
+++ b/app/connectors/IncomeTaxViewChangeConnector.scala
@@ -163,7 +163,7 @@ trait IncomeTaxViewChangeConnector extends RawResponseReads with FeatureSwitchin
     implicit headerCarrier: HeaderCarrier, mtdItUser: MtdItUserWithNino[_]): Future[IncomeSourceDetailsResponse] = {
 
     //Check and add test headers Gov-Test-Scenario for dynamic stub Income Sources Created Scenarios
-    val hc = checkAndAddTestHeader(mtdItUser.path, headerCarrier, appConfig.incomeSourceOverrides)
+    val hc = checkAndAddTestHeader(mtdItUser.path, headerCarrier, appConfig.incomeSourceOverrides())
 
     val url = getIncomeSourcesUrl(mtdItUser.mtditid)
     Logger("application").debug(s"[IncomeTaxViewChangeConnector][getIncomeSources] - GET $url")

--- a/app/connectors/IncomeTaxViewChangeConnector.scala
+++ b/app/connectors/IncomeTaxViewChangeConnector.scala
@@ -163,7 +163,7 @@ trait IncomeTaxViewChangeConnector extends RawResponseReads with FeatureSwitchin
     implicit headerCarrier: HeaderCarrier, mtdItUser: MtdItUserWithNino[_]): Future[IncomeSourceDetailsResponse] = {
 
     //Check and add test headers Gov-Test-Scenario for dynamic stub Income Sources Created Scenarios
-    val hc = checkAndAddTestHeader(mtdItUser.path, headerCarrier)
+    val hc = checkAndAddTestHeader(mtdItUser.path, headerCarrier, appConfig.incomeSourceOverrides)
 
     val url = getIncomeSourcesUrl(mtdItUser.mtditid)
     Logger("application").debug(s"[IncomeTaxViewChangeConnector][getIncomeSources] - GET $url")

--- a/app/utils/Headers.scala
+++ b/app/utils/Headers.scala
@@ -21,22 +21,19 @@ import uk.gov.hmrc.http.HeaderCarrier
 object Headers {
 
   //Checks and adding the value to the test header
-  def checkAndAddTestHeader(requestPath: String, headerCarrier: HeaderCarrier): HeaderCarrier = {
+  def checkAndAddTestHeader(requestPath: String,
+                            headerCarrier: HeaderCarrier,
+                            configPages: Option[Seq[String]]): HeaderCarrier = {
+    val incomeSourcePage : Map[String, String] = configPages.map(kv =>
+          kv.map(k => (k, "afterIncomeSourceCreated")).toMap
+      ).getOrElse( Map[String, String]())
     val urlPathArray = requestPath.split('/')
     val actionPath = if(urlPathArray.isEmpty) "" else urlPathArray.last
-    val updatedHeader = govUKTestHeaderValuesMap.get(actionPath) match {
+    val updatedHeader = incomeSourcePage.get(actionPath) match {
       case Some(data) => "Gov-Test-Scenario" -> data
       case _ => "Gov-Test-Scenario" -> ""
     }
     headerCarrier.withExtraHeaders(updatedHeader)
-  }
-
-  // Map list of action names with its test header values
-  def govUKTestHeaderValuesMap(): Map[String, String] = {
-    Map(
-      "uk-property-reporting-method" -> "afterIncomeSourceCreated", // UK Property Select reporting method
-      "foreign-property-reporting-method" -> "afterIncomeSourceCreated" // Foreign Property Select reporting method
-    )
   }
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -312,6 +312,10 @@ time-machine {
     add-years = 1
 }
 
+afterIncomeSourceCreated = ["foreign-property-reporting-method",
+    "uk-property-reporting-method",
+    "foreign-property-added"]
+
 bootstrap.http.headersAllowlist = [ "Gov-Test-Scenario", "Location", "X-Request-Timestamp", "X-Session-Id" ]
 internalServiceHostPatterns = [ "localhost" ]
 

--- a/test/connectors/IncomeTaxViewChangeConnectorSpec.scala
+++ b/test/connectors/IncomeTaxViewChangeConnectorSpec.scala
@@ -160,6 +160,10 @@ class IncomeTaxViewChangeConnectorSpec extends TestSupport with MockHttp with Mo
     }
   }
 
+  val incomeSourceOverride = Seq(
+    "uk-property-reporting-method", // UK Property Select reporting method
+    "foreign-property-reporting-method" // Foreign Property Select reporting method
+  )
 
   "getIncomeSources" should {
 
@@ -169,8 +173,10 @@ class IncomeTaxViewChangeConnectorSpec extends TestSupport with MockHttp with Mo
 
     val getIncomeSourcesTestUrl = s"http://localhost:9999/income-tax-view-change/income-sources/$testMtditid"
 
+
     "return an IncomeSourceDetailsModel when successful JSON is received" in new Setup {
       setupMockHttpGet(getIncomeSourcesTestUrl)(successResponse)
+      when(appConfig.incomeSourceOverrides()).thenReturn( Some(incomeSourceOverride) )
 
       val result: Future[IncomeSourceDetailsResponse] = getIncomeSources()
       result.futureValue shouldBe singleBusinessAndPropertyMigrat2019
@@ -180,6 +186,7 @@ class IncomeTaxViewChangeConnectorSpec extends TestSupport with MockHttp with Mo
 
     "return IncomeSourceDetailsError in case of bad/malformed JSON response" in new Setup {
       setupMockHttpGet(getIncomeSourcesTestUrl)(successResponseBadJson)
+      when(appConfig.incomeSourceOverrides()).thenReturn( Some(incomeSourceOverride) )
 
       val result: Future[IncomeSourceDetailsResponse] = getIncomeSources()
       result.futureValue shouldBe IncomeSourceDetailsError(Status.INTERNAL_SERVER_ERROR, "Json Validation Error Parsing Income Source Details response")
@@ -188,6 +195,7 @@ class IncomeTaxViewChangeConnectorSpec extends TestSupport with MockHttp with Mo
 
     "return IncomeSourceDetailsError model in case of failure" in new Setup {
       setupMockHttpGet(getIncomeSourcesTestUrl)(badResponse)
+      when(appConfig.incomeSourceOverrides()).thenReturn( Some(incomeSourceOverride) )
 
       val result: Future[IncomeSourceDetailsResponse] = getIncomeSources()
       result.futureValue shouldBe IncomeSourceDetailsError(Status.BAD_REQUEST, "Error Message")
@@ -196,6 +204,7 @@ class IncomeTaxViewChangeConnectorSpec extends TestSupport with MockHttp with Mo
 
     "return IncomeSourceDetailsError model in case of future failed scenario" in new Setup {
       setupMockFailedHttpGet(getIncomeSourcesTestUrl)
+      when(appConfig.incomeSourceOverrides()).thenReturn( Some(incomeSourceOverride) )
 
       val result: Future[IncomeSourceDetailsResponse] = getIncomeSources()
       result.futureValue shouldBe IncomeSourceDetailsError(Status.INTERNAL_SERVER_ERROR, "Unexpected future failed error, unknown error")

--- a/test/utils/HeadersSpec.scala
+++ b/test/utils/HeadersSpec.scala
@@ -27,7 +27,7 @@ class HeadersSpec extends TestSupport {
 
   "Return updated Gov-Test-Scenario headers" when {
     "the action scenario matches the govUKTestHeaderValuesMap" in {
-        val updatedHeaders = checkAndAddTestHeader(ukSelectReportingMethod, headerCarrier)
+        val updatedHeaders = checkAndAddTestHeader(ukSelectReportingMethod, headerCarrier, appConfig.incomeSourceOverrides())
         val hc = headerCarrier.withExtraHeaders(testHeader -> incomeSourceCreatedJourney)
         updatedHeaders shouldBe hc
     }
@@ -35,7 +35,7 @@ class HeadersSpec extends TestSupport {
 
   "Return empty Gov-Test-Scenario headers" when {
     "the action scenario does not matches the govUKTestHeaderValuesMap" in {
-      val updatedHeaders = checkAndAddTestHeader("otherAction", headerCarrier)
+      val updatedHeaders = checkAndAddTestHeader("otherAction", headerCarrier, appConfig.incomeSourceOverrides())
       val hc = headerCarrier.withExtraHeaders(testHeader -> "")
       updatedHeaders shouldBe hc
     }


### PR DESCRIPTION
  * refactor code to read incomeSource overrides from app~.config; we can change single string in the application.config file without recompilation apply required changes