### PR TITLE
MISUV-6526:: enhance incomeSourceId hashing 

### DIFF
--- a/app/models/core/IncomeSourceIdHash.scala
+++ b/app/models/core/IncomeSourceIdHash.scala
@@ -33,8 +33,9 @@ class IncomeSourceIdHash private(val hash: String) extends AnyVal {
 
 object IncomeSourceIdHash {
   def mkIncomeSourceIdHash(id: IncomeSourceId): IncomeSourceIdHash = {
-    val hash = id.value.hashCode().abs.toString
-    new IncomeSourceIdHash(hash)
+    val hashA = id.value.hashCode().abs.toString
+    val hashB = id.value.reverse.hashCode().abs.toString
+    new IncomeSourceIdHash(s"${hashB}${hashA}")
   }
 
   def mkFromQueryString(hashCodeAsString: String): Either[Throwable, IncomeSourceIdHash] = Try {

--- a/test/models/incomeSourceDetails/IncomeSourceIdHashSpec.scala
+++ b/test/models/incomeSourceDetails/IncomeSourceIdHashSpec.scala
@@ -17,14 +17,14 @@
 package models.incomeSourceDetails
 
 import models.core.IncomeSourceId.mkIncomeSourceId
-import models.core.IncomeSourceIdHash.mkIncomeSourceIdHash
+import models.core.IncomeSourceIdHash.{mkFromQueryString, mkIncomeSourceIdHash}
 import models.core.{IncomeSourceId, IncomeSourceIdHash}
 import testConstants.BaseTestConstants.{testSelfEmploymentId, testSelfEmploymentId2, testSelfEmploymentIdValidation}
 import testUtils.UnitSpec
 
 class IncomeSourceIdHashSpec extends UnitSpec {
 
-  val hashValue: String = "1487316523"
+  val hashValue: String = "4154473711487316523"
 
   "IncomeSourceIdHash class" should {
 
@@ -43,7 +43,7 @@ class IncomeSourceIdHashSpec extends UnitSpec {
       "supplied with an incomeSourceId object" in {
         val incomeSourceId: IncomeSourceId = mkIncomeSourceId(testSelfEmploymentId)
         val hashObjectHash: IncomeSourceIdHash = incomeSourceId.toHash
-        val hashOfString = testSelfEmploymentId.hashCode().abs.toString
+        val hashOfString = "4154473711487316523"
 
         hashObjectHash.hash shouldBe hashOfString
       }
@@ -80,6 +80,14 @@ class IncomeSourceIdHashSpec extends UnitSpec {
         val incomeSourceIdMatchingList: Option[IncomeSourceId] = mkIncomeSourceId(testSelfEmploymentIdValidation).toHash.oneOf(incomeSourceIdList)
 
         incomeSourceIdMatchingList shouldBe None
+      }
+    }
+
+    "return true" when {
+      "automated testing findings: two ids returning same hash" in {
+        val idA = mkIncomeSourceId("458G97M2iCklmno")
+        val idB = mkIncomeSourceId("47829VOJ5Tklmn6")
+        idA.toHash.hash should not be idB.toHash.hash
       }
     }
   }

--- a/test/models/incomeSourceDetails/IncomeSourceIdHashSpecification.scala
+++ b/test/models/incomeSourceDetails/IncomeSourceIdHashSpecification.scala
@@ -26,7 +26,7 @@ object IncomeSourceIdHashSpecification extends Properties("IncomeSourceId") {
 
   val range : Seq[Char] = ( 'a' to'z').toList ++ ( 'A' to'Z') ++ ('0' to '9').toList
 
-  val incomeSourceIdGen = Gen.listOfN(1000, Gen.pick(15, range) )
+  val incomeSourceIdGen = Gen.listOfN(7000, Gen.pick(15, range) )
 
   property("make sure hash is unique") = forAll(incomeSourceIdGen) { ids =>
     val hashSet: List[String] = ids.distinct.map { i =>

--- a/test/models/incomeSourceDetails/IncomeSourceIdHashSpecification.scala
+++ b/test/models/incomeSourceDetails/IncomeSourceIdHashSpecification.scala
@@ -40,3 +40,6 @@ object IncomeSourceIdHashSpecification extends Properties("IncomeSourceId") {
   }
 
 }
+
+// 458G97M2iCklmno
+// 47829VOJ5Tklmn6

--- a/test/models/incomeSourceDetails/IncomeSourceIdHashSpecification.scala
+++ b/test/models/incomeSourceDetails/IncomeSourceIdHashSpecification.scala
@@ -40,6 +40,3 @@ object IncomeSourceIdHashSpecification extends Properties("IncomeSourceId") {
   }
 
 }
-
-// 458G97M2iCklmno
-// 47829VOJ5Tklmn6


### PR DESCRIPTION
  * reduce chances of hashCode duplication

For local run N times:

```
for value in {1..100}
do
  sbt "testOnly models.incomeSourceDetails.IncomeSourceIdHashSpecification"
done
```