### PR TITLE
Fix compilation issue in IntelliJ by using absolute imports

### DIFF
--- a/it/connectors/NavBarEnumFsConnectorISpec.scala
+++ b/it/connectors/NavBarEnumFsConnectorISpec.scala
@@ -1,9 +1,9 @@
 
 package connectors
 
-import helpers.ComponentSpecBase
-import helpers.servicemocks.BtaNavBarPartialConnectorStub
-import helpers.servicemocks.BtaNavBarPartialConnectorStub.testNavLinkJson
+import _root_.helpers.ComponentSpecBase
+import _root_.helpers.servicemocks.BtaNavBarPartialConnectorStub
+import _root_.helpers.servicemocks.BtaNavBarPartialConnectorStub.testNavLinkJson
 import models.btaNavBar.{NavContent, NavLinks}
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.test.Helpers.{await, defaultAwaitTimeout}


### PR DESCRIPTION
When built in IntelliJ, both the UTs and ATs are built to the same directory (test-classes) and the import for the helpers package picks up a local package from the UT erroneously. By using an absolute import, this problem is avoided.