### PR TITLE
MISUV-6988: it:tests / remove not used imports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,10 @@ lazy val it = project
   )
   .settings(scalaVersion := currentScalaVersion)
   .settings(majorVersion := 1)
+  .settings(scalacOptions += "-Xfatal-warnings")
+//  .settings(semanticdbEnabled := true) // enable SemanticDB
+//  .settings(semanticdbVersion := scalafixSemanticdb.revision)
+//  .settings(scalafixOnCompile := true)
   .settings(
     testForkedParallel := true
   )

--- a/build.sbt
+++ b/build.sbt
@@ -128,9 +128,6 @@ lazy val it = project
   .settings(scalaVersion := currentScalaVersion)
   .settings(majorVersion := 1)
   .settings(scalacOptions += "-Xfatal-warnings")
-//  .settings(semanticdbEnabled := true) // enable SemanticDB
-//  .settings(semanticdbVersion := scalafixSemanticdb.revision)
-//  .settings(scalafixOnCompile := true)
   .settings(
     testForkedParallel := true
   )

--- a/it/test/connectors/NavBarEnumFsConnectorISpec.scala
+++ b/it/test/connectors/NavBarEnumFsConnectorISpec.scala
@@ -25,7 +25,6 @@ import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
 
 import play.api.test.Injecting
-import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.duration._
 import scala.concurrent.Future

--- a/it/test/controllers/CalculationPollingControllerISpec.scala
+++ b/it/test/controllers/CalculationPollingControllerISpec.scala
@@ -24,7 +24,6 @@ import play.api.http.Status._
 import testConstants.BaseIntegrationTestConstants._
 import testConstants.NewCalcBreakdownItTestConstants._
 
-import scala.concurrent.ExecutionContext
 
 class CalculationPollingControllerISpec extends ComponentSpecBase {
 

--- a/it/test/controllers/CreditsSummaryControllerISpec.scala
+++ b/it/test/controllers/CreditsSummaryControllerISpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import audit.models.CreditSummaryAuditing.{CreditsSummaryModel, toCreditSummaryDetailsSeq}
 import audit.models.IncomeSourceDetailsResponseAuditModel
-import auth.{MtdItUserOptionNino, MtdItUserWithNino}
+import auth.MtdItUserOptionNino
 import config.featureswitch.{CutOverCredits, MFACreditsAndDebits}
 import helpers.servicemocks.{AuditStub, IncomeTaxViewChangeStub}
 import helpers.{ComponentSpecBase, CreditsSummaryDataHelper}

--- a/it/test/controllers/HomeControllerISpec.scala
+++ b/it/test/controllers/HomeControllerISpec.scala
@@ -18,10 +18,10 @@ package controllers
 
 import audit.models.{HomeAudit, NextUpdatesResponseAuditModel}
 import auth.MtdItUser
-import config.featureswitch.{IvUplift, NavBarFs}
+import config.featureswitch.NavBarFs
 import helpers.ComponentSpecBase
 import helpers.servicemocks.AuditStub.verifyAuditContainsDetail
-import helpers.servicemocks.{AuthStub, IncomeTaxViewChangeStub}
+import helpers.servicemocks.IncomeTaxViewChangeStub
 import models.nextUpdates.ObligationsModel
 import play.api.http.Status._
 import play.api.test.FakeRequest

--- a/it/test/controllers/PaymentHistoryControllerISpec.scala
+++ b/it/test/controllers/PaymentHistoryControllerISpec.scala
@@ -19,7 +19,7 @@ package controllers
 import audit.models.PaymentHistoryResponseAuditModel
 import auth.MtdItUser
 import config.featureswitch.{CutOverCredits, MFACreditsAndDebits, PaymentHistoryRefunds}
-import helpers.{ComponentSpecBase, servicemocks}
+import helpers.ComponentSpecBase
 import helpers.servicemocks.AuditStub.verifyAuditContainsDetail
 import helpers.servicemocks.IncomeTaxViewChangeStub
 import models.financialDetails.Payment
@@ -28,7 +28,7 @@ import play.api.libs.ws.WSResponse
 import play.api.test.FakeRequest
 import testConstants.BaseIntegrationTestConstants._
 import testConstants.IncomeSourceIntegrationTestConstants._
-import testConstants.messages.{TaxYearSummaryMessages, paymentAndRefundHistoryHeading}
+import testConstants.messages.paymentAndRefundHistoryHeading
 import uk.gov.hmrc.auth.core.AffinityGroup.Individual
 
 import java.time.LocalDate

--- a/it/test/controllers/TaxDueSummaryControllerISpec.scala
+++ b/it/test/controllers/TaxDueSummaryControllerISpec.scala
@@ -30,7 +30,6 @@ import testConstants.IncomeSourceIntegrationTestConstants._
 import testConstants.NewCalcBreakdownItTestConstants.liabilityCalculationModelSuccessful
 import testConstants.NewCalcDataIntegrationTestConstants._
 import testConstants.messages.TaxDueSummaryMessages.{additionCharges, nonVoluntaryClass2Nics, postgraduatePlan, studentPlan, voluntaryClass2Nics}
-import testConstants.messages.{TaxDueSummaryMessages => messages}
 import uk.gov.hmrc.auth.core.AffinityGroup.Individual
 
 

--- a/it/test/controllers/agent/CalculationPollingControllerISpec.scala
+++ b/it/test/controllers/agent/CalculationPollingControllerISpec.scala
@@ -31,7 +31,6 @@ import testConstants.NewCalcBreakdownItTestConstants._
 import testConstants.PropertyDetailsIntegrationTestConstants.{propertyIncomeType, propertyTradingStartDate}
 
 import java.time.LocalDate
-import scala.concurrent.ExecutionContext
 
 class CalculationPollingControllerISpec extends ComponentSpecBase {
   val (taxYear, month, dayOfMonth) = (2018, 5, 6)

--- a/it/test/controllers/agent/TaxDueSummaryControllerISpec.scala
+++ b/it/test/controllers/agent/TaxDueSummaryControllerISpec.scala
@@ -28,7 +28,6 @@ import models.core.AccountingPeriodModel
 import models.incomeSourceDetails.{BusinessDetailsModel, IncomeSourceDetailsModel, PropertyDetailsModel}
 import models.liabilitycalculation.viewmodels.TaxDueSummaryViewModel
 import play.api.http.Status._
-import play.api.i18n.{Messages, MessagesApi}
 import play.api.libs.ws.WSResponse
 import play.api.test.FakeRequest
 import testConstants.BaseIntegrationTestConstants._

--- a/it/test/controllers/agent/UTRErrorControllerISpec.scala
+++ b/it/test/controllers/agent/UTRErrorControllerISpec.scala
@@ -17,9 +17,8 @@
 package controllers.agent
 
 import config.featureswitch.FeatureSwitching
-import controllers.agent.utils.SessionKeys
 import helpers.agent.ComponentSpecBase
-import helpers.servicemocks.AuthStub.{titleInternalServer, titleThereIsAProblem}
+import helpers.servicemocks.AuthStub.titleInternalServer
 import play.api.http.Status._
 import play.api.libs.ws.WSResponse
 

--- a/it/test/controllers/agent/incomeSources/add/AddIncomeSourceStartDateControllerISpec.scala
+++ b/it/test/controllers/agent/incomeSources/add/AddIncomeSourceStartDateControllerISpec.scala
@@ -28,10 +28,8 @@ import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import services.SessionService
 import testConstants.BaseIntegrationTestConstants.{clientDetailsWithConfirmation, testMtditid, testSessionId}
 import testConstants.IncomeSourceIntegrationTestConstants.{businessOnlyResponse, noPropertyOrBusinessResponse}
-import uk.gov.hmrc.http.{HeaderCarrier, SessionId}
 
 import java.time.LocalDate
-import scala.concurrent.ExecutionContext
 
 class AddIncomeSourceStartDateControllerISpec extends ComponentSpecBase {
 

--- a/it/test/controllers/agent/incomeSources/add/IncomeSourceReportingMethodControllerISpec.scala
+++ b/it/test/controllers/agent/incomeSources/add/IncomeSourceReportingMethodControllerISpec.scala
@@ -40,7 +40,7 @@ import testConstants.IncomeSourceIntegrationTestConstants._
 import uk.gov.hmrc.auth.core.AffinityGroup.Agent
 
 import java.time.LocalDate
-import java.time.Month.{APRIL, SEPTEMBER}
+import java.time.Month.APRIL
 
 sealed trait ReportingMethodScenario {
   def isLegacy: Boolean

--- a/it/test/controllers/agent/incomeSources/add/IncomeSourceReportingMethodNotSavedControllerISpec.scala
+++ b/it/test/controllers/agent/incomeSources/add/IncomeSourceReportingMethodNotSavedControllerISpec.scala
@@ -21,7 +21,7 @@ import enums.IncomeSourceJourney.{ForeignProperty, SelfEmployment, UkProperty}
 import helpers.agent.ComponentSpecBase
 import helpers.servicemocks.IncomeTaxViewChangeStub
 import play.api.http.Status.OK
-import testConstants.BaseIntegrationTestConstants.{clientDetailsWithConfirmation, testMtditid, testSelfEmploymentId}
+import testConstants.BaseIntegrationTestConstants.{clientDetailsWithConfirmation, testMtditid}
 import testConstants.IncomeSourceIntegrationTestConstants.{businessOnlyResponse, foreignPropertyOnlyResponse, ukPropertyOnlyResponse}
 
 class IncomeSourceReportingMethodNotSavedControllerISpec extends ComponentSpecBase {

--- a/it/test/controllers/agent/incomeSources/cease/IncomeSourceCeasedBackErrorControllerISpec.scala
+++ b/it/test/controllers/agent/incomeSources/cease/IncomeSourceCeasedBackErrorControllerISpec.scala
@@ -27,7 +27,7 @@ import play.api.libs.ws.WSResponse
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import services.SessionService
 import testConstants.BaseIntegrationTestConstants.testMtditid
-import testConstants.IncomeSourceIntegrationTestConstants.{businessOnlyResponse, completedUIJourneySessionData, foreignPropertyOnlyResponse, ukPropertyOnlyResponse}
+import testConstants.IncomeSourceIntegrationTestConstants.{businessOnlyResponse, completedUIJourneySessionData}
 
 class IncomeSourceCeasedBackErrorControllerISpec extends ComponentSpecBase {
 

--- a/it/test/controllers/agent/incomeSources/manage/ManageObligationsControllerISpec.scala
+++ b/it/test/controllers/agent/incomeSources/manage/ManageObligationsControllerISpec.scala
@@ -16,25 +16,20 @@
 
 package controllers.agent.incomeSources.manage
 
-import auth.MtdItUser
 import config.featureswitch.IncomeSources
-import enums.IncomeSourceJourney.{SelfEmployment, UkProperty}
+import enums.IncomeSourceJourney.UkProperty
 import helpers.agent.ComponentSpecBase
-import helpers.servicemocks.{AuditStub, IncomeTaxViewChangeStub}
-import models.incomeSourceDetails.viewmodels.{DatesModel, ObligationsViewModel}
-import models.incomeSourceDetails.{IncomeSourceDetailsModel, ManageIncomeSourceData, TaxYear, UIJourneySessionData}
+import helpers.servicemocks.IncomeTaxViewChangeStub
+import models.incomeSourceDetails.viewmodels.ObligationsViewModel
+import models.incomeSourceDetails.{ManageIncomeSourceData, UIJourneySessionData}
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK, SEE_OTHER}
-import play.api.test.FakeRequest
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import services.SessionService
-import testConstants.BaseIntegrationTestConstants.{clientDetailsWithConfirmation, testMtditid, testNino, testSaUtr, testSessionId}
-import testConstants.BusinessDetailsIntegrationTestConstants.{business1, business2, business3}
+import testConstants.BaseIntegrationTestConstants.{clientDetailsWithConfirmation, testMtditid, testSessionId}
+import testConstants.BusinessDetailsIntegrationTestConstants.business1
 import testConstants.IncomeSourceIntegrationTestConstants._
 import testConstants.IncomeSourcesObligationsIntegrationTestConstants.{testObligationsModel, testQuarterlyObligationDates}
-import testConstants.PropertyDetailsIntegrationTestConstants.{foreignProperty, ukProperty}
-import uk.gov.hmrc.auth.core.AffinityGroup.Agent
 
-import java.time.LocalDate
 
 class ManageObligationsControllerISpec extends ComponentSpecBase {
 

--- a/it/test/controllers/agent/incomeSources/manage/ReportingMethodErrorControllerISpec.scala
+++ b/it/test/controllers/agent/incomeSources/manage/ReportingMethodErrorControllerISpec.scala
@@ -16,22 +16,17 @@
 
 package controllers.agent.incomeSources.manage
 
-import auth.MtdItUser
 import config.featureswitch.IncomeSources
 import enums.IncomeSourceJourney.{ForeignProperty, SelfEmployment, UkProperty}
 import helpers.agent.ComponentSpecBase
-import helpers.servicemocks.{AuditStub, IncomeTaxViewChangeStub}
-import models.incomeSourceDetails.{IncomeSourceDetailsModel, ManageIncomeSourceData, UIJourneySessionData}
+import helpers.servicemocks.IncomeTaxViewChangeStub
+import models.incomeSourceDetails.{ManageIncomeSourceData, UIJourneySessionData}
 import play.api.http.Status
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK, SEE_OTHER}
-import play.api.test.FakeRequest
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import services.SessionService
 import testConstants.BaseIntegrationTestConstants._
-import testConstants.BusinessDetailsIntegrationTestConstants.{business1, business2, business3}
 import testConstants.IncomeSourceIntegrationTestConstants.{businessOnlyResponse, foreignPropertyOnlyResponse, noPropertyOrBusinessResponse, ukPropertyOnlyResponse}
-import testConstants.PropertyDetailsIntegrationTestConstants.{foreignProperty, ukProperty}
-import uk.gov.hmrc.auth.core.AffinityGroup.Agent
 
 
 class ReportingMethodErrorControllerISpec extends ComponentSpecBase {

--- a/it/test/controllers/incomeSources/add/IncomeSourceReportingMethodControllerISpec.scala
+++ b/it/test/controllers/incomeSources/add/IncomeSourceReportingMethodControllerISpec.scala
@@ -32,7 +32,6 @@ import play.api.libs.json.Json
 import play.api.libs.ws.WSResponse
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
-import repositories.UIJourneySessionDataRepository
 import services.{DateService, SessionService}
 import testConstants.BaseIntegrationTestConstants._
 import testConstants.BusinessDetailsIntegrationTestConstants.b1TradingName
@@ -41,7 +40,7 @@ import testConstants.IncomeSourceIntegrationTestConstants._
 import uk.gov.hmrc.auth.core.AffinityGroup.Individual
 
 import java.time.LocalDate
-import java.time.Month.{APRIL, SEPTEMBER}
+import java.time.Month.APRIL
 
 sealed trait ReportingMethodScenario {
   def isLegacy: Boolean

--- a/it/test/controllers/incomeSources/manage/ManageObligationsControllerISpec.scala
+++ b/it/test/controllers/incomeSources/manage/ManageObligationsControllerISpec.scala
@@ -20,7 +20,7 @@ import config.featureswitch.IncomeSources
 import enums.IncomeSourceJourney.UkProperty
 import helpers.ComponentSpecBase
 import helpers.servicemocks.IncomeTaxViewChangeStub
-import models.incomeSourceDetails.viewmodels.{DatesModel, ObligationsViewModel}
+import models.incomeSourceDetails.viewmodels.ObligationsViewModel
 import models.incomeSourceDetails.{ManageIncomeSourceData, UIJourneySessionData}
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK, SEE_OTHER}
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
@@ -30,7 +30,6 @@ import testConstants.BusinessDetailsIntegrationTestConstants.business1
 import testConstants.IncomeSourceIntegrationTestConstants._
 import testConstants.IncomeSourcesObligationsIntegrationTestConstants.{testObligationsModel, testQuarterlyObligationDates}
 
-import java.time.LocalDate
 
 class ManageObligationsControllerISpec extends ComponentSpecBase {
 

--- a/it/test/controllers/incomeSources/manage/ReportingMethodErrorControllerISpec.scala
+++ b/it/test/controllers/incomeSources/manage/ReportingMethodErrorControllerISpec.scala
@@ -16,22 +16,17 @@
 
 package controllers.incomeSources.manage
 
-import auth.MtdItUser
 import config.featureswitch.IncomeSources
 import enums.IncomeSourceJourney.{ForeignProperty, SelfEmployment, UkProperty}
 import helpers.ComponentSpecBase
-import helpers.servicemocks.{AuditStub, IncomeTaxViewChangeStub}
-import models.incomeSourceDetails.{IncomeSourceDetailsModel, ManageIncomeSourceData, UIJourneySessionData}
+import helpers.servicemocks.IncomeTaxViewChangeStub
+import models.incomeSourceDetails.{ManageIncomeSourceData, UIJourneySessionData}
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK, SEE_OTHER}
-import play.api.test.FakeRequest
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import play.mvc.Http.Status
 import services.SessionService
 import testConstants.BaseIntegrationTestConstants._
-import testConstants.BusinessDetailsIntegrationTestConstants.{business1, business2, business3}
 import testConstants.IncomeSourceIntegrationTestConstants.{businessOnlyResponse, foreignPropertyOnlyResponse, noPropertyOrBusinessResponse, ukPropertyOnlyResponse}
-import testConstants.PropertyDetailsIntegrationTestConstants.{foreignProperty, ukProperty}
-import uk.gov.hmrc.auth.core.AffinityGroup.Individual
 
 class ReportingMethodErrorControllerISpec extends ComponentSpecBase {
 

--- a/it/test/helpers/CustomMatchers.scala
+++ b/it/test/helpers/CustomMatchers.scala
@@ -21,11 +21,8 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.scalatest._
 import org.scalatest.matchers._
-import play.api.i18n.Messages.implicitMessagesProviderToMessages
-import play.api.i18n.{Messages, MessagesApi}
 import play.api.libs.json.Reads
 import play.api.libs.ws.WSResponse
-import play.api.test.FakeRequest
 
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters._

--- a/it/test/helpers/agent/SessionCookieCrumbler.scala
+++ b/it/test/helpers/agent/SessionCookieCrumbler.scala
@@ -18,7 +18,7 @@ package helpers.agent
 
 import play.api.libs.crypto.DefaultCookieSigner
 import play.api.libs.ws.{WSCookie, WSResponse}
-import uk.gov.hmrc.crypto.{CompositeSymmetricCrypto, Crypted, SymmetricCryptoFactory}
+import uk.gov.hmrc.crypto.{Crypted, SymmetricCryptoFactory}
 
 trait SessionCookieCrumbler {
 

--- a/it/test/helpers/servicemocks/BtaNavBarPartialConnectorStub.scala
+++ b/it/test/helpers/servicemocks/BtaNavBarPartialConnectorStub.scala
@@ -18,10 +18,7 @@ package helpers.servicemocks
 
 import com.github.tomakehurst.wiremock.client.WireMock._
 import helpers.WiremockHelper
-import models.btaNavBar.NavContent
-import play.api.http.Status
-import play.api.libs.json.{JsValue, Json}
-import testConstants.BaseIntegrationTestConstants.testNavLinks
+import play.api.libs.json.JsValue
 
 object BtaNavBarPartialConnectorStub {
 

--- a/it/test/repositories/UIJourneySessionDataISpec.scala
+++ b/it/test/repositories/UIJourneySessionDataISpec.scala
@@ -21,7 +21,6 @@ import helpers.ComponentSpecBase
 import models.incomeSourceDetails.{AddIncomeSourceData, UIJourneySessionData}
 import org.mongodb.scala.bson.BsonDocument
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
-import java.time.Instant
 
 class UIJourneySessionDataISpec extends ComponentSpecBase {
   private val repository = app.injector.instanceOf[UIJourneySessionDataRepository]

--- a/it/test/testConstants/PaymentHistoryTestConstraints.scala
+++ b/it/test/testConstants/PaymentHistoryTestConstraints.scala
@@ -18,7 +18,7 @@ package testConstants
 
 import java.time.LocalDate
 import BaseIntegrationTestConstants.{getCurrentTaxYearEnd, otherTestSelfEmploymentId, testSelfEmploymentId}
-import models.core.{AccountingPeriodModel, AddressModel, CessationModel}
+import models.core.AccountingPeriodModel
 import models.incomeSourceDetails.BusinessDetailsModel
 import testConstants.BusinessDetailsIntegrationTestConstants.address
 


### PR DESCRIPTION
Next scalaFix rules applied across it project:
RemoveUnused.imports = true
RemoveUnused.privates = true
RemoveUnused.locals = true
RemoveUnused.patternvars = true
RemoveUnused.params = true