### PR TITLE
MISUV-6871: LocalDate.now removal from unit tests and it:Tests

### DIFF
--- a/it/test/controllers/CreditAndRefundControllerISpec.scala
+++ b/it/test/controllers/CreditAndRefundControllerISpec.scala
@@ -33,6 +33,8 @@ import java.time.LocalDate
 
 class CreditAndRefundControllerISpec extends ComponentSpecBase {
 
+  lazy val fixedDate : LocalDate = LocalDate.of(2020, 11, 29)
+
   "Navigating to /report-quarterly/income-and-expenses/view/credit-and-refunds" should {
 
     val testTaxYear: Int = getCurrentTaxYearEnd.getYear
@@ -50,7 +52,7 @@ class CreditAndRefundControllerISpec extends ComponentSpecBase {
 
         And("I wiremock stub a successful Financial Details response with credits and refunds")
         IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"$testPreviousTaxYear-04-06", s"$testTaxYear-04-05")(OK,
-          testValidFinancialDetailsModelCreditAndRefundsJson(-2000, -2000, testPreviousTaxYear.toString, LocalDate.now().plusYears(1).toString))
+          testValidFinancialDetailsModelCreditAndRefundsJson(-2000, -2000, testPreviousTaxYear.toString, fixedDate.plusYears(1).toString))
 
         val res = IncomeTaxViewChangeFrontend.getCreditAndRefunds()
 
@@ -111,7 +113,7 @@ class CreditAndRefundControllerISpec extends ComponentSpecBase {
           propertyOnlyResponseWithMigrationData(testPreviousTaxYear, Some(testTaxYear.toString)))
 
         IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"$testPreviousTaxYear-04-06", s"$testTaxYear-04-05")(OK,
-          testValidFinancialDetailsModelCreditAndRefundsJson(-2000, -2000, testTaxYear.toString, LocalDate.now().plusYears(1).toString))
+          testValidFinancialDetailsModelCreditAndRefundsJson(-2000, -2000, testTaxYear.toString, fixedDate.plusYears(1).toString))
 
         val res = IncomeTaxViewChangeFrontend.getCreditAndRefunds()
 

--- a/it/test/controllers/agent/CalculationPollingControllerISpec.scala
+++ b/it/test/controllers/agent/CalculationPollingControllerISpec.scala
@@ -35,6 +35,7 @@ import java.time.LocalDate
 class CalculationPollingControllerISpec extends ComponentSpecBase {
   val (taxYear, month, dayOfMonth) = (2018, 5, 6)
   val (hour, minute) = (12, 0)
+  lazy val fixedDate : LocalDate = LocalDate.of(2023, 12, 15)
 
   val urlFinalCalcFalse: String = s"http://localhost:$port" + controllers.routes.CalculationPollingController
     .calculationPollerAgent(taxYear, isFinalCalc = false).url
@@ -65,7 +66,7 @@ class CalculationPollingControllerISpec extends ComponentSpecBase {
     businesses = List(BusinessDetailsModel(
       "testId",
       incomeSource = Some(testIncomeSource),
-      Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+      Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
       Some("Test Trading Name"),
       Some(LocalDate.of(2018,1,1)),
       Some(b2TradingStart),
@@ -77,7 +78,7 @@ class CalculationPollingControllerISpec extends ComponentSpecBase {
     properties = List(
       PropertyDetailsModel(
         "testId2",
-        Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+        Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
         Some(LocalDate.of(2018,1,1)),
         propertyIncomeType,
         propertyTradingStartDate,

--- a/it/test/controllers/agent/CreditAndRefundControllerISpec.scala
+++ b/it/test/controllers/agent/CreditAndRefundControllerISpec.scala
@@ -37,6 +37,8 @@ import java.time.LocalDate
 
 class CreditAndRefundControllerISpec extends ComponentSpecBase {
 
+  lazy val fixedDate : LocalDate = LocalDate.of(2020, 11, 29)
+
   "Navigating to /report-quarterly/income-and-expenses/view/agents/credit-and-refunds" should {
 
     val testTaxYear: Int = getCurrentTaxYearEnd.getYear
@@ -55,7 +57,7 @@ class CreditAndRefundControllerISpec extends ComponentSpecBase {
 
         And("I wiremock stub a successful Financial Details response with credits and refunds")
         IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"$testPreviousTaxYear-04-06", s"$testTaxYear-04-05")(OK,
-          testValidFinancialDetailsModelCreditAndRefundsJson(-2000, -2000, testPreviousTaxYear.toString, LocalDate.now().plusYears(1).toString))
+          testValidFinancialDetailsModelCreditAndRefundsJson(-2000, -2000, testPreviousTaxYear.toString, fixedDate.plusYears(1).toString))
 
         val res = IncomeTaxViewChangeFrontend.getCreditAndRefunds(clientDetailsWithConfirmation)
 
@@ -116,7 +118,7 @@ class CreditAndRefundControllerISpec extends ComponentSpecBase {
           propertyOnlyResponseWithMigrationData(testPreviousTaxYear, Some(testTaxYear.toString)))
 
         IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"$testPreviousTaxYear-04-06", s"$testTaxYear-04-05")(OK,
-          testValidFinancialDetailsModelCreditAndRefundsJson(-2000, -2000, testTaxYear.toString, LocalDate.now().plusYears(1).toString))
+          testValidFinancialDetailsModelCreditAndRefundsJson(-2000, -2000, testTaxYear.toString, fixedDate.plusYears(1).toString))
 
 
         val res = IncomeTaxViewChangeFrontend.getCreditAndRefunds(clientDetailsWithConfirmation)
@@ -147,7 +149,7 @@ class CreditAndRefundControllerISpec extends ComponentSpecBase {
             businesses = List(BusinessDetailsModel(
               "testId",
               incomeSource = Some(testIncomeSource),
-              Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+              Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
               None,
               None,
               Some(getCurrentTaxYearEnd),
@@ -161,7 +163,7 @@ class CreditAndRefundControllerISpec extends ComponentSpecBase {
 
         IncomeTaxViewChangeStub.stubGetFinancialDetailsByDateRange(testNino, s"$testPreviousTaxYear-04-06", s"$testTaxYear-04-05")(OK,
           testValidFinancialDetailsModelJson(
-            -2000, -2000, testTaxYear.toString, LocalDate.now().toString))
+            -2000, -2000, testTaxYear.toString, fixedDate.toString))
         IncomeTaxViewChangeStub.stubGetOutstandingChargesResponse(
           "utr", testSaUtr.toLong, testTaxYear.toString)(OK, validOutStandingChargeResponseJsonWithAciAndBcdCharges)
 

--- a/it/test/controllers/agent/DeductionsSummaryControllerISpec.scala
+++ b/it/test/controllers/agent/DeductionsSummaryControllerISpec.scala
@@ -41,6 +41,7 @@ class DeductionsSummaryControllerISpec extends ComponentSpecBase with FeatureSwi
     testMtditid, testNino, Some(Name(Some("Test"), Some("User"))), incomeSource,
     None, Some("1234567890"), credId = None, Some(testUserTypeAgent), arn = Some("1")
   )(FakeRequest())
+  lazy val fixedDate : LocalDate = LocalDate.of(2024, 6, 5)
 
   lazy val incomeSource: IncomeSourceDetailsModel = IncomeSourceDetailsModel(
     testNino,
@@ -49,7 +50,7 @@ class DeductionsSummaryControllerISpec extends ComponentSpecBase with FeatureSwi
     businesses = List(BusinessDetailsModel(
       "testId",
       incomeSource = Some(testIncomeSource),
-      Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+      Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
       None,
       None,
       Some(getCurrentTaxYearEnd),

--- a/it/test/controllers/agent/FinalTaxCalculationControllerISpec.scala
+++ b/it/test/controllers/agent/FinalTaxCalculationControllerISpec.scala
@@ -40,6 +40,7 @@ class FinalTaxCalculationControllerISpec extends ComponentSpecBase with SessionC
   val (taxYear, month, dayOfMonth) = (2018, 5, 6)
   val (hour, minute) = (12, 0)
   val url: String = s"http://localhost:$port" + controllers.routes.FinalTaxCalculationController.showAgent(taxYear).url
+  lazy val fixedDate : LocalDate = LocalDate.of(2024, 6, 5)
 
   implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
   lazy val mcc: MessagesControllerComponents = app.injector.instanceOf[MessagesControllerComponents]
@@ -148,7 +149,7 @@ class FinalTaxCalculationControllerISpec extends ComponentSpecBase with SessionC
     businesses = List(BusinessDetailsModel(
       "testId",
       incomeSource = Some(testIncomeSource),
-      Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+      Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
       Some("Test Trading Name"),
       None,
       Some(LocalDate.of(2018, 1, 1)),
@@ -159,7 +160,7 @@ class FinalTaxCalculationControllerISpec extends ComponentSpecBase with SessionC
     properties = List(
       PropertyDetailsModel(
         "testId2",
-        Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+        Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
         None,
         None,
         Some(LocalDate.of(2018, 1, 1)),

--- a/it/test/controllers/agent/ForecastIncomeSummaryControllerISpec.scala
+++ b/it/test/controllers/agent/ForecastIncomeSummaryControllerISpec.scala
@@ -95,8 +95,10 @@ class ForecastIncomeSummaryControllerISpec extends ComponentSpecBase with Featur
     SessionKeys.confirmedClient -> "true"
   )
 
+  lazy val fixedDate : LocalDate = LocalDate.of(2023, 12, 15)
+
   val getCurrentTaxYearEnd: LocalDate = {
-    val currentDate: LocalDate = LocalDate.now
+    val currentDate: LocalDate = fixedDate
     if (currentDate.isBefore(LocalDate.of(currentDate.getYear, 4, 6))) LocalDate.of(currentDate.getYear, 4, 5)
     else LocalDate.of(currentDate.getYear + 1, 4, 5)
   }
@@ -111,7 +113,7 @@ class ForecastIncomeSummaryControllerISpec extends ComponentSpecBase with Featur
     businesses = List(BusinessDetailsModel(
       "testId",
       incomeSource = Some(testIncomeSource),
-      Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+      Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
       Some("Test Trading Name"),
       None,
       Some(getCurrentTaxYearEnd),
@@ -122,7 +124,7 @@ class ForecastIncomeSummaryControllerISpec extends ComponentSpecBase with Featur
     properties = List(
       PropertyDetailsModel(
         "testId2",
-        Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+        Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
         None,
         None,
         Some(getCurrentTaxYearEnd),

--- a/it/test/controllers/agent/ForecastTaxCalcSummaryControllerISpec.scala
+++ b/it/test/controllers/agent/ForecastTaxCalcSummaryControllerISpec.scala
@@ -90,6 +90,7 @@ object ForecastTaxSummaryAgentControllerTestConstants {
 
 class ForecastTaxCalcSummaryControllerISpec extends ComponentSpecBase {
 
+  lazy val fixedDate : LocalDate = LocalDate.of(2023, 12, 15)
   val incomeSourceDetailsSuccess: IncomeSourceDetailsModel = IncomeSourceDetailsModel(
     nino = testNino,
     mtdbsa = testMtditid,
@@ -97,7 +98,7 @@ class ForecastTaxCalcSummaryControllerISpec extends ComponentSpecBase {
     businesses = List(BusinessDetailsModel(
       "testId",
       incomeSource = Some(testIncomeSource),
-      Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+      Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
       Some("Test Trading Name"),
       None,
       Some(getCurrentTaxYearEnd),
@@ -108,7 +109,7 @@ class ForecastTaxCalcSummaryControllerISpec extends ComponentSpecBase {
     properties = List(
       PropertyDetailsModel(
         "testId2",
-        Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+        Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
         None,
         None,
         Some(getCurrentTaxYearEnd),

--- a/it/test/controllers/agent/IncomeSummaryControllerISpec.scala
+++ b/it/test/controllers/agent/IncomeSummaryControllerISpec.scala
@@ -39,6 +39,7 @@ class IncomeSummaryControllerISpec extends ComponentSpecBase with FeatureSwitchi
 
   val implicitDateFormatter: ImplicitDateFormatter = app.injector.instanceOf[ImplicitDateFormatterImpl]
   implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
+  lazy val fixedDate : LocalDate = LocalDate.of(2023, 12, 15)
 
   val incomeSourceDetailsSuccess: IncomeSourceDetailsModel = IncomeSourceDetailsModel(
     nino = testNino,
@@ -47,7 +48,7 @@ class IncomeSummaryControllerISpec extends ComponentSpecBase with FeatureSwitchi
     businesses = List(BusinessDetailsModel(
       "testId",
       incomeSource = Some(testIncomeSource),
-      Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+      Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
       Some("Test Trading Name"),
       Some(getCurrentTaxYearEnd),
       Some(b2TradingStart),
@@ -58,7 +59,7 @@ class IncomeSummaryControllerISpec extends ComponentSpecBase with FeatureSwitchi
     properties = List(
       PropertyDetailsModel(
         "testId2",
-        Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+        Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
         Some(getCurrentTaxYearEnd),
         propertyIncomeType,
         propertyTradingStartDate,

--- a/it/test/controllers/agent/NextUpdatesControllerISpec.scala
+++ b/it/test/controllers/agent/NextUpdatesControllerISpec.scala
@@ -38,6 +38,8 @@ import java.time.LocalDate
 
 class NextUpdatesControllerISpec extends ComponentSpecBase with FeatureSwitching {
 
+  lazy val fixedDate : LocalDate = LocalDate.of(2024, 6, 5)
+
   val incomeSourceDetails: IncomeSourceDetailsModel = IncomeSourceDetailsModel(
     nino = testNino,
     mtdbsa = testMtditid,
@@ -45,7 +47,7 @@ class NextUpdatesControllerISpec extends ComponentSpecBase with FeatureSwitching
     businesses = List(BusinessDetailsModel(
       "testId",
       incomeSource = Some(testIncomeSource),
-      Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+      Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
       None,
       None,
       Some(getCurrentTaxYearEnd),
@@ -101,7 +103,7 @@ class NextUpdatesControllerISpec extends ComponentSpecBase with FeatureSwitching
         NextUpdatesModel(
           identification = "testId",
           obligations = List(
-            NextUpdateModel(LocalDate.now, LocalDate.now.plusDays(1), LocalDate.now.minusDays(1), "Quarterly", None, "testPeriodKey")
+            NextUpdateModel(fixedDate, fixedDate.plusDays(1), fixedDate.minusDays(1), "Quarterly", None, "testPeriodKey")
           ))
       ))
 

--- a/it/test/controllers/agent/PaymentAllocationsControllerISpec.scala
+++ b/it/test/controllers/agent/PaymentAllocationsControllerISpec.scala
@@ -57,6 +57,8 @@ class PaymentAllocationsControllerISpec extends ComponentSpecBase with FeatureSw
     None, Some("1234567890"), None, Some(Agent), Some("1")
   )(FakeRequest())
 
+  lazy val fixedDate : LocalDate = LocalDate.of(2020, 11, 29)
+
 
   val incomeSourceDetailsSuccess: IncomeSourceDetailsModel = IncomeSourceDetailsModel(
     nino = testNino,
@@ -65,7 +67,7 @@ class PaymentAllocationsControllerISpec extends ComponentSpecBase with FeatureSw
     businesses = List(BusinessDetailsModel(
       "testId",
       incomeSource = Some(testIncomeSource),
-      Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+      Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
       Some("Test Trading Name"),
       None,
       Some(getCurrentTaxYearEnd),
@@ -76,7 +78,7 @@ class PaymentAllocationsControllerISpec extends ComponentSpecBase with FeatureSw
     properties = List(
       PropertyDetailsModel(
         "testId2",
-        Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+        Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
         None,
         None,
         Some(getCurrentTaxYearEnd),

--- a/it/test/controllers/agent/PaymentControllerISpec.scala
+++ b/it/test/controllers/agent/PaymentControllerISpec.scala
@@ -30,6 +30,7 @@ import java.time.LocalDate
 class PaymentControllerISpec extends ComponentSpecBase {
 
   val url: String = "/pay-api/mtd-income-tax/sa/journey/start"
+  lazy val fixedDate : LocalDate = LocalDate.of(2023, 12, 15)
 
 
   val submissionJson: JsValue = Json.parse(
@@ -59,7 +60,7 @@ class PaymentControllerISpec extends ComponentSpecBase {
             businesses = List(BusinessDetailsModel(
               "testId",
               incomeSource = Some(testIncomeSource),
-              Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+              Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
               None,
               None,
               Some(getCurrentTaxYearEnd),
@@ -95,7 +96,7 @@ class PaymentControllerISpec extends ComponentSpecBase {
             businesses = List(BusinessDetailsModel(
               "testId",
               incomeSource = Some(testIncomeSource),
-              Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+              Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
               None,
               None,
               Some(getCurrentTaxYearEnd),

--- a/it/test/controllers/agent/PaymentHistoryControllerISpec.scala
+++ b/it/test/controllers/agent/PaymentHistoryControllerISpec.scala
@@ -66,6 +66,7 @@ class PaymentHistoryControllerISpec extends ComponentSpecBase {
   val currentTaxYearEnd: Int = getCurrentTaxYearEnd.getYear
   val previousTaxYearEnd: Int = currentTaxYearEnd - 1
   val twoPreviousTaxYearEnd: Int = currentTaxYearEnd - 2
+  lazy val fixedDate : LocalDate = LocalDate.of(2024, 6, 5)
 
   val incomeSourceDetailsModel: IncomeSourceDetailsModel = IncomeSourceDetailsModel(
     nino = testNino,
@@ -74,7 +75,7 @@ class PaymentHistoryControllerISpec extends ComponentSpecBase {
     businesses = List(BusinessDetailsModel(
       "testId",
       incomeSource = Some(testIncomeSource),
-      Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+      Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
       None,
       None,
       Some(getCurrentTaxYearEnd),

--- a/it/test/controllers/agent/TaxDueSummaryControllerISpec.scala
+++ b/it/test/controllers/agent/TaxDueSummaryControllerISpec.scala
@@ -46,6 +46,7 @@ class TaxDueSummaryControllerISpec extends ComponentSpecBase with FeatureSwitchi
     testMtditid, testNino, None, multipleBusinessesAndPropertyResponse,
     None, Some("1234567890"), None, Some(Agent), Some("1")
   )(FakeRequest())
+  lazy val fixedDate : LocalDate = LocalDate.of(2020, 11, 29)
 
   val implicitDateFormatter: ImplicitDateFormatter = app.injector.instanceOf[ImplicitDateFormatterImpl]
 
@@ -56,7 +57,7 @@ class TaxDueSummaryControllerISpec extends ComponentSpecBase with FeatureSwitchi
     businesses = List(BusinessDetailsModel(
       "testId",
       incomeSource = Some(testIncomeSource),
-      Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+      Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
       Some("Test Trading Name"),
       None,
       Some(getCurrentTaxYearEnd),
@@ -67,7 +68,7 @@ class TaxDueSummaryControllerISpec extends ComponentSpecBase with FeatureSwitchi
     properties = List(
       PropertyDetailsModel(
         "testId2",
-        Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+        Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
         None,
         None,
         Some(getCurrentTaxYearEnd),

--- a/it/test/controllers/agent/TaxYearSummaryControllerISpec.scala
+++ b/it/test/controllers/agent/TaxYearSummaryControllerISpec.scala
@@ -46,6 +46,7 @@ import java.time.LocalDate
 
 class TaxYearSummaryControllerISpec extends ComponentSpecBase with FeatureSwitching {
 
+  lazy val fixedDate : LocalDate = LocalDate.of(2023, 11, 29)
   val implicitDateFormatter: ImplicitDateFormatter = app.injector.instanceOf[ImplicitDateFormatterImpl]
   val incomeSourceDetailsSuccess: IncomeSourceDetailsModel = IncomeSourceDetailsModel(
     nino = testNino,
@@ -54,7 +55,7 @@ class TaxYearSummaryControllerISpec extends ComponentSpecBase with FeatureSwitch
     businesses = List(BusinessDetailsModel(
       "testId",
       incomeSource = Some(testIncomeSource),
-      Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+      Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
       Some("Test Trading Name"),
       None,
       Some(getCurrentTaxYearEnd),
@@ -65,7 +66,7 @@ class TaxYearSummaryControllerISpec extends ComponentSpecBase with FeatureSwitch
     properties = List(
       PropertyDetailsModel(
         "testId2",
-        Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+        Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
         None,
         None,
         Some(getCurrentTaxYearEnd),
@@ -101,7 +102,7 @@ class TaxYearSummaryControllerISpec extends ComponentSpecBase with FeatureSwitch
         taxYear = getCurrentTaxYearEnd.getYear.toString,
         mainType = Some("SA Payment on Account 1"),
         transactionId = Some("testTransactionId"),
-        items = Some(Seq(SubItem(Some(LocalDate.now))))
+        items = Some(Seq(SubItem(Some(fixedDate))))
       )
     )
   )
@@ -119,8 +120,8 @@ class TaxYearSummaryControllerISpec extends ComponentSpecBase with FeatureSwitch
         interestOutstandingAmount = Some(0.00),
         interestEndDate = Some(LocalDate.of(2021, 6, 24)),
         latePaymentInterestAmount = Some(100.00),
-        effectiveDateOfPayment = Some(LocalDate.now()),
-        documentDueDate = Some(LocalDate.now())
+        effectiveDateOfPayment = Some(fixedDate),
+        documentDueDate = Some(fixedDate)
       ),
       DocumentDetail(
         taxYear = getCurrentTaxYearEnd.getYear,
@@ -132,21 +133,21 @@ class TaxYearSummaryControllerISpec extends ComponentSpecBase with FeatureSwitch
         outstandingAmount = Some(500.00),
         interestOutstandingAmount = Some(0.00),
         interestEndDate = Some(LocalDate.of(2021, 6, 24)),
-        effectiveDateOfPayment = Some(LocalDate.now().plusDays(2)),
-        documentDueDate = Some(LocalDate.now().plusDays(2))
+        effectiveDateOfPayment = Some(fixedDate.plusDays(2)),
+        documentDueDate = Some(fixedDate.plusDays(2))
       )),
     List(
       FinancialDetail(
         taxYear = getCurrentTaxYearEnd.getYear.toString,
         transactionId = Some("testDunningTransactionId"),
         mainType = Some("SA Payment on Account 1"),
-        items = Some(Seq(SubItem(Some(LocalDate.now), amount = Some(12), dunningLock = Some("Stand over order"), transactionId = Some("testDunningTransactionId"))))
+        items = Some(Seq(SubItem(Some(fixedDate), amount = Some(12), dunningLock = Some("Stand over order"), transactionId = Some("testDunningTransactionId"))))
       ),
       FinancialDetail(
         taxYear = getCurrentTaxYearEnd.getYear.toString,
         transactionId = Some("testDunningTransactionId2"),
         mainType = Some("SA Payment on Account 2"),
-        items = Some(Seq(SubItem(Some(LocalDate.now), amount = Some(12), dunningLock = Some("Dunning Lock"), transactionId = Some("testDunningTransactionId2"))))
+        items = Some(Seq(SubItem(Some(fixedDate), amount = Some(12), dunningLock = Some("Dunning Lock"), transactionId = Some("testDunningTransactionId2"))))
       )
     )
   )
@@ -403,7 +404,7 @@ class TaxYearSummaryControllerISpec extends ComponentSpecBase with FeatureSwitch
           elementTextBySelectorList("#payments", "tbody", "tr:nth-of-type(1)", "td:nth-of-type(1)")("24 Jun 2021"),
           elementTextBySelectorList("#payments", "tbody", "tr:nth-of-type(1)", "td:nth-of-type(2)")("£100.00"),
           elementTextBySelectorList("#payments", "tbody", "tr:nth-of-type(2)", "th")(s"$poa1 $underReview"),
-          elementTextBySelectorList("#payments", "tbody", "tr:nth-of-type(2)", "td:nth-of-type(1)")(LocalDate.now.toLongDateShort),
+            elementTextBySelectorList("#payments", "tbody", "tr:nth-of-type(2)", "td:nth-of-type(1)")(fixedDate.toLongDateShort),
           elementTextBySelectorList("#payments", "tbody", "tr:nth-of-type(2)", "td:nth-of-type(2)")("£1,000.00"),
           elementTextBySelectorList("#updates", "div", "h3")(updateTabDue(getCurrentTaxYearEnd.toLongDate)),
           elementTextBySelectorList("#updates", "div", "table", "caption")(

--- a/it/test/controllers/agent/TaxYearsControllerISpec.scala
+++ b/it/test/controllers/agent/TaxYearsControllerISpec.scala
@@ -40,6 +40,7 @@ class TaxYearsControllerISpec extends ComponentSpecBase with FeatureSwitching {
   }
 
   implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
+  lazy val fixedDate : LocalDate = LocalDate.of(2024, 6, 5)
 
   val incomeSourceDetailsSuccess: IncomeSourceDetailsModel = IncomeSourceDetailsModel(
     nino = testNino,
@@ -48,7 +49,7 @@ class TaxYearsControllerISpec extends ComponentSpecBase with FeatureSwitching {
     businesses = List(BusinessDetailsModel(
       "testId",
       incomeSource = Some(testIncomeSource),
-      Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+      Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
       Some("Test Trading Name"),
       Some(getCurrentTaxYearEnd),
       None,
@@ -59,7 +60,7 @@ class TaxYearsControllerISpec extends ComponentSpecBase with FeatureSwitching {
     properties = List(
       PropertyDetailsModel(
         "testId2",
-        Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+        Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
         None,
         None,
         Some(getCurrentTaxYearEnd),
@@ -76,7 +77,7 @@ class TaxYearsControllerISpec extends ComponentSpecBase with FeatureSwitching {
     businesses = List(BusinessDetailsModel(
       "testId",
       incomeSource = Some(testIncomeSource),
-      Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+      Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
       Some("Test Trading Name"),
       None,
       None,
@@ -87,7 +88,7 @@ class TaxYearsControllerISpec extends ComponentSpecBase with FeatureSwitching {
     properties = List(
       PropertyDetailsModel(
         "testId2",
-        Some(AccountingPeriodModel(LocalDate.now, LocalDate.now.plusYears(1))),
+        Some(AccountingPeriodModel(fixedDate, fixedDate.plusYears(1))),
         None,
         None,
         None,


### PR DESCRIPTION
replace LocalDate.now() with fixedDate in it/test