### PR TITLE
MISUV-7256: FS Patch V3 / STAGING only

### DIFF
--- a/app/controllers/ChargeSummaryController.scala
+++ b/app/controllers/ChargeSummaryController.scala
@@ -37,7 +37,7 @@ import play.api.mvc._
 import services.{DateServiceInterface, FinancialDetailsService, IncomeSourceDetailsService}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.language.LanguageUtils
-import utils.FallBackBackLinks
+import utils.{AuthenticatorPredicate, FallBackBackLinks}
 import views.html.ChargeSummary
 import views.html.errorPages.CustomNotFoundError
 
@@ -49,6 +49,7 @@ object ChargeSummaryController {
 }
 
 class ChargeSummaryController @Inject()(val authenticate: AuthenticationPredicate,
+                                        val auth : AuthenticatorPredicate,
                                         val checkSessionTimeout: SessionTimeoutPredicate,
                                         val retrieveNinoWithIncomeSources: IncomeSourceDetailsPredicate,
                                         val financialDetailsService: FinancialDetailsService,
@@ -123,14 +124,11 @@ class ChargeSummaryController @Inject()(val authenticate: AuthenticationPredicat
     }
 
   def showAgent(taxYear: Int, id: String, isLatePaymentCharge: Boolean = false): Action[AnyContent] =
-    Authenticated.async {
-      implicit request =>
-        implicit user =>
-          getMtdItUserWithIncomeSources(incomeSourceDetailsService) flatMap {
-            implicit mtdItUser =>
-              handleRequest(taxYear, id, isLatePaymentCharge, isAgent = true)
-          }
+    auth.authenticatedAction(isAgent = true) {
+      implicit mtdItUser =>
+        handleRequest(taxYear, id, isLatePaymentCharge, isAgent = true)
     }
+
 
   private def doShowChargeSummary(taxYear: Int, id: String, isLatePaymentCharge: Boolean,
                                   chargeDetailsforTaxYear: FinancialDetailsModel, paymentsForAllYears: FinancialDetailsModel,

--- a/app/controllers/NextUpdatesController.scala
+++ b/app/controllers/NextUpdatesController.scala
@@ -101,16 +101,13 @@ class NextUpdatesController @Inject()(NoNextUpdatesView: NoNextUpdates,
         origin)
   }
 
-  def showAgent: Action[AnyContent] = Authenticated.async { implicit request =>
-    implicit user =>
-      getMtdItUserWithIncomeSources(incomeSourceDetailsService).flatMap {
-        mtdItUser =>
-          getNextUpdates(
-            controllers.routes.HomeController.showAgent,
-            isAgent = true,
-            agentItvcErrorHandler,
-            None)(mtdItUser)
-      }
+  def showAgent: Action[AnyContent] = auth.authenticatedAction(isAgent = true) {
+    implicit mtdItUser =>
+      getNextUpdates(
+        controllers.routes.HomeController.showAgent,
+        isAgent = true,
+        agentItvcErrorHandler,
+        None)
   }
 
   private def auditNextUpdates[A](user: MtdItUser[A], isAgent: Boolean, origin: Option[String])(implicit hc: HeaderCarrier, request: Request[_]): Unit =

--- a/test/controllers/ChargeSummaryControllerSpec.scala
+++ b/test/controllers/ChargeSummaryControllerSpec.scala
@@ -37,6 +37,7 @@ import services.{DateService, FinancialDetailsService}
 import testConstants.BaseTestConstants.{testAgentAuthRetrievalSuccess, testTaxYear}
 import testConstants.FinancialDetailsTestConstants._
 import testUtils.TestSupport
+import utils.AuthenticatorPredicate
 
 import scala.concurrent.Future
 
@@ -77,6 +78,7 @@ class ChargeSummaryControllerSpec extends MockAuthenticationPredicate
 
     val controller = new ChargeSummaryController(
       MockAuthenticationPredicate,
+      app.injector.instanceOf[AuthenticatorPredicate],
       app.injector.instanceOf[SessionTimeoutPredicate],
       MockIncomeSourceDetailsPredicate,
       financialDetailsService,

--- a/test/controllers/ChargeSummaryControllerSpec.scala
+++ b/test/controllers/ChargeSummaryControllerSpec.scala
@@ -78,7 +78,7 @@ class ChargeSummaryControllerSpec extends MockAuthenticationPredicate
 
     val controller = new ChargeSummaryController(
       MockAuthenticationPredicate,
-      app.injector.instanceOf[AuthenticatorPredicate],
+      testAuthenticator,
       app.injector.instanceOf[SessionTimeoutPredicate],
       MockIncomeSourceDetailsPredicate,
       financialDetailsService,

--- a/test/controllers/ChargeSummaryControllerTest.scala
+++ b/test/controllers/ChargeSummaryControllerTest.scala
@@ -32,6 +32,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.mvc.MessagesControllerComponents
 import services.{DateServiceInterface, FinancialDetailsService, IncomeSourceDetailsService}
 import uk.gov.hmrc.play.language.LanguageUtils
+import utils.AuthenticatorPredicate
 import views.html.ChargeSummary
 import views.html.errorPages.CustomNotFoundError
 
@@ -54,6 +55,7 @@ class ChargeSummaryControllerTest extends AnyWordSpecLike with Matchers with Bef
   val authorisedFunctions: FrontendAuthorisedFunctions = mock(classOf[FrontendAuthorisedFunctions])
   val customNotFoundErrorView: CustomNotFoundError = mock(classOf[CustomNotFoundError])
   val featureSwitchPredicate: FeatureSwitchPredicate = mock(classOf[FeatureSwitchPredicate])
+  val authenticator: AuthenticatorPredicate = mock(classOf[AuthenticatorPredicate])
 
   implicit val appConfig: FrontendAppConfig = mock(classOf[FrontendAppConfig])
   implicit val dateService: DateServiceInterface = mock(classOf[DateServiceInterface])
@@ -61,7 +63,7 @@ class ChargeSummaryControllerTest extends AnyWordSpecLike with Matchers with Bef
   implicit val  mcc: MessagesControllerComponents = mock(classOf[MessagesControllerComponents])
   implicit val itvcErrorHandlerAgent: AgentItvcErrorHandler = mock(classOf[AgentItvcErrorHandler])
 
-  val controller: ChargeSummaryController = spy(new ChargeSummaryController(authenticate, checkSessionTimeout, retrieveNinoWithIncomeSources,
+  val controller: ChargeSummaryController = spy(new ChargeSummaryController(authenticate, authenticator, checkSessionTimeout, retrieveNinoWithIncomeSources,
     financialDetailsService, auditingService, itvcErrorHandler, financialDetailsConnector, chargeHistoryConnector, chargeSummaryView,
     retrievebtaNavPartial, incomeSourceDetailsService, authorisedFunctions, customNotFoundErrorView, featureSwitchPredicate))
 


### PR DESCRIPTION
  * - change in the next set of controllers / auth for agents to be aligned with the rest of the code =>
 ** - PaymentAllocationsController;
 **  - NextUpdatesController;
 ** - ChargeSummaryController;

There are sill occurrences of old style auth approach in other controller like:
ForecastIncomeSummaryController / but FS load in case of read from mongo is addressed in the different way;

Next story is created to address remaining changes https://jira.tools.tax.service.gov.uk/browse/MISUV-7776