### PR TITLE
MISUV-7766 | Claim to Adjust POA | Update - Option (entry point) for adjusting POAs on WYO page

### DIFF
--- a/app/models/financialDetails/DocumentDetail.scala
+++ b/app/models/financialDetails/DocumentDetail.scala
@@ -160,6 +160,11 @@ case class DocumentDetail(taxYear: Int,
     case _ => false
   }
 
+  val isPOA: Boolean = {
+    val poaDescriptions = Seq("ITSA- POA 1", "ITSA - POA 2")
+    documentDescription.exists(poaDescriptions.contains)
+  }
+
   def isBalancingCharge(codedOutEnabled: Boolean = false): Boolean = getChargeTypeKey(codedOutEnabled) == "balancingCharge.text"
 
   def isBalancingChargeZero(codedOutEnabled: Boolean = false): Boolean = {

--- a/app/models/financialDetails/WhatYouOweChargesList.scala
+++ b/app/models/financialDetails/WhatYouOweChargesList.scala
@@ -36,6 +36,9 @@ case class WhatYouOweChargesList(balanceDetails: BalanceDetails, chargesList: Li
 
   def isChargesListEmpty: Boolean = chargesList.isEmpty && !bcdChargeTypeDefinedAndGreaterThanZero
 
+  def hasUnpaidPOAs: Boolean = chargesList.exists(docDetail =>
+    docDetail.documentDetail.isPOA && docDetail.documentDetail.outstandingAmount > 0.0)
+
   def hasDunningLock: Boolean = chargesList.exists(charge => charge.dunningLock)
 
   def hasLpiWithDunningLock: Boolean =

--- a/app/services/ClaimToAdjustHelper.scala
+++ b/app/services/ClaimToAdjustHelper.scala
@@ -42,13 +42,13 @@ trait ClaimToAdjustHelper {
 
   protected val poaDocumentDescriptions: List[String] = List(POA1, POA2)
 
+  // TODO: Can unpaid be removed? We are now allowing changes to paid POAs
+
   private val isUnpaidPoAOne: DocumentDetail => Boolean = documentDetail =>
-    documentDetail.documentDescription.contains(POA1) &&
-      (documentDetail.outstandingAmount != 0)
+    documentDetail.documentDescription.contains(POA1) && (documentDetail.outstandingAmount != 0)
 
   private val isUnpaidPoATwo: DocumentDetail => Boolean = documentDetail =>
-    documentDetail.documentDescription.contains(POA2) &&
-      (documentDetail.outstandingAmount != 0)
+    documentDetail.documentDescription.contains(POA2) && (documentDetail.outstandingAmount != 0)
 
   private val getTaxReturnDeadline: LocalDate => LocalDate = date =>
     LocalDate.of(date.getYear, Month.JANUARY, LAST_DAY_OF_JANUARY)

--- a/app/views/WhatYouOwe.scala.html
+++ b/app/views/WhatYouOwe.scala.html
@@ -54,7 +54,7 @@
     isAgent: Boolean = false,
     isUserMigrated: Boolean = false,
     creditAndRefundEnabled: Boolean,
-        claimToAdjustViewModel: WYOClaimToAdjustViewModel,
+    claimToAdjustViewModel: WYOClaimToAdjustViewModel,
     origin: Option[String] = None)(implicit request: Request[_], user: MtdItUser[_], messages: Messages)
 
 @import implicitDateFormatter.longDate
@@ -326,12 +326,32 @@
 }
 
 @getClaimToAdjustPoaSection = @{
-    claimToAdjustViewModel.claimToAdjustTaxYear match {
-        case Some(value) =>
-            link(link = WYOClaimToAdjustViewModel.ctaLink(isAgent),
-                messageKey = getMessage("adjust-poa", value.startYear.toString, value.endYear.toString),
-                id = Some("adjust-poa-link"))
-        case None => Html("")
+    if(whatYouOweChargesList.hasUnpaidPOAs) {
+        p(id = Some("adjust-poa-content"))(
+            claimToAdjustViewModel.claimToAdjustTaxYear match {
+                case Some(value) =>
+                    link(
+                        link = WYOClaimToAdjustViewModel.ctaLink(isAgent),
+                        messageKey = getMessage("adjust-poa", value.startYear.toString, value.endYear.toString),
+                        id = Some("adjust-poa-link"))
+                case None => Html("")
+        })
+    } else {
+        claimToAdjustViewModel.claimToAdjustTaxYear match {
+            case Some(value) =>
+                p(id = Some("adjust-paid-poa-content"))(Html(s"""
+                    ${getMessage("adjust-poa.paid-1", value.startYear.toString, value.endYear.toString)}
+                    ${link(
+                        link = WYOClaimToAdjustViewModel.ctaLink(isAgent),
+                        messageKey = getMessage("adjust-poa.paid-2", value.startYear.toString, value.endYear.toString),
+                        id = Some("adjust-poa-link"))}
+                    ${getMessage("adjust-poa.paid-3", value.startYear.toString, value.endYear.toString)}
+                    <span class="govuk-!-font-weight-bold">
+                        ${getMessage("adjust-poa.paid-4", (value.endYear + 1).toString)}
+                    </span>
+                """))
+            case None => Html("")
+        }
     }
 }
 
@@ -345,9 +365,14 @@
     @h1(msg = getHeading, id = Some("page-heading"))
     @if(whatYouOweChargesList.isChargesListEmpty && whatYouOweChargesList.codedOutDocumentDetail.isEmpty) {
         @p(id = Some("no-payments-due"))(Html(getNoPaymentsDueText))
+
+        @getClaimToAdjustPoaSection
+
         @saNoteParagraph
     } else {
+
         <div>
+
             @if(whatYouOweChargesList.chargesList.nonEmpty || whatYouOweChargesList.bcdChargeTypeDefinedAndGreaterThanZero) {
                 <div id="payments-due-table">
                     <table class="govuk-table">

--- a/app/views/WhatYouOwe.scala.html
+++ b/app/views/WhatYouOwe.scala.html
@@ -349,6 +349,7 @@
                     <span class="govuk-!-font-weight-bold">
                         ${getMessage("adjust-poa.paid-4", (value.endYear + 1).toString)}
                     </span>
+                    ${getMessage("adjust-poa.paid-5")}
                 """))
             case None => Html("")
         }

--- a/conf/messages
+++ b/conf/messages
@@ -900,6 +900,7 @@ whatYouOwe.adjust-poa.paid-1                                       = You can
 whatYouOwe.adjust-poa.paid-2                                       = adjust your payments on account for the {0} to {1} tax year
 whatYouOwe.adjust-poa.paid-3                                       = at any point before submitting your tax return for {0} to {1}, and no later than
 whatYouOwe.adjust-poa.paid-4                                       = 31 January {0}.
+whatYouOwe.adjust-poa.paid-5                                       =
 
 ## Charge Summary ##
 chargeSummary.paymentOnAccount1.text							   = Payment on account 1 of 2

--- a/conf/messages
+++ b/conf/messages
@@ -893,6 +893,10 @@ whatYouOwe.moneyOnAccount-3                                        = claim a ref
 whatYouOwe.moneyOnAccount-agent                                    = Money in your client’s account
 whatYouOwe.moneyOnAccount-agent-2                                  = in your client’s account. You can leave the money there to pay their next bill or
 whatYouOwe.adjust-poa                                              = Adjust payments on account for the {0} to {1} tax year
+whatYouOwe.adjust-poa.paid-1                                       = You can
+whatYouOwe.adjust-poa.paid-2                                       = adjust your payments on account for the {0} to {1} tax year
+whatYouOwe.adjust-poa.paid-3                                       = at any point before submitting your tax return for {0} to {1}, and no later than
+whatYouOwe.adjust-poa.paid-4                                       = 31 January {0}.
 
 ## Charge Summary ##
 chargeSummary.paymentOnAccount1.text							   = Payment on account 1 of 2

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -882,6 +882,11 @@ whatYouOwe.balancingCharge.interest.line2.text                  = {0} i {1}
 whatYouOwe.taxYear                                              = Blwyddyn dreth
 whatYouOwe.over-due.interest.line2                              = {0} i {1} ar {2}%
 whatYouOwe.adjust-poa                                           = Addasu taliadau ar gyfrif ar gyfer blwyddyn dreth {0} i {1}
+whatYouOwe.adjust-poa.paid-1                                    = Gallwch
+whatYouOwe.adjust-poa.paid-2                                    = addasu eich taliadau ar gyfrif ar gyfer blwyddyn dreth {0} i {1}
+whatYouOwe.adjust-poa.paid-3                                    = Ffurflen Dreth ar gyfer {0} i {1}, ac erbyn
+whatYouOwe.adjust-poa.paid-4                                    = 31 Ionawr {0}
+whatYouOwe.adjust-poa.paid-5                                    = fan bellaf.
 
 ## Charge Summary ##
 chargeSummary.paymentOnAccount1.text                            = Taliad ar gyfrif 1 o 2

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -884,7 +884,7 @@ whatYouOwe.over-due.interest.line2                              = {0} i {1} ar {
 whatYouOwe.adjust-poa                                           = Addasu taliadau ar gyfrif ar gyfer blwyddyn dreth {0} i {1}
 whatYouOwe.adjust-poa.paid-1                                    = Gallwch
 whatYouOwe.adjust-poa.paid-2                                    = addasu eich taliadau ar gyfrif ar gyfer blwyddyn dreth {0} i {1}
-whatYouOwe.adjust-poa.paid-3                                    = Ffurflen Dreth ar gyfer {0} i {1}, ac erbyn
+whatYouOwe.adjust-poa.paid-3                                    = ar unrhyw adeg cyn cyflwyno’ch Ffurflen Dreth ar gyfer 2023 i 2024, ac erbyn
 whatYouOwe.adjust-poa.paid-4                                    = 31 Ionawr {0}
 whatYouOwe.adjust-poa.paid-5                                    = fan bellaf.
 

--- a/test/testConstants/FinancialDetailsTestConstants.scala
+++ b/test/testConstants/FinancialDetailsTestConstants.scala
@@ -1168,6 +1168,15 @@ object FinancialDetailsTestConstants {
     interestOutstandingAmount = interestOutstandingAmount
   )
 
+  def whatYouOweDataWithPaidPOAs(dunningLocks: List[Option[String]] = noDunningLocks)(implicit dateService: DateService): WhatYouOweChargesList = WhatYouOweChargesList(
+    balanceDetails = BalanceDetails(1.00, 0.00, 1.00, None, None, None, None, None),
+    chargesList = financialDetailsDueIn30Days(dunningLocks)
+      .getAllDocumentDetailsWithDueDates()(dateService)
+      .map(d => d.copy(documentDetail = d.documentDetail.copy(outstandingAmount = 0.0))),
+    outstandingChargesModel = Some(outstandingChargesDueIn30Days)
+  )
+
+
   def whatYouOweDataWithDataDueIn30Days(dunningLocks: List[Option[String]] = noDunningLocks)(implicit dateService: DateService): WhatYouOweChargesList = WhatYouOweChargesList(
     balanceDetails = BalanceDetails(1.00, 0.00, 1.00, None, None, None, None, None),
     chargesList = financialDetailsDueIn30Days(dunningLocks).getAllDocumentDetailsWithDueDates()(dateService),


### PR DESCRIPTION
When both POA 1 and POA 2 are paid i.e. no payments on account due on 'What you owe' (WYO) page, we display the option to adjust POAs with some content.