### PR TITLE
Misuv 7945 remove use of mongo in 1 year opt out

### DIFF
--- a/app/services/optout/OptOutService.scala
+++ b/app/services/optout/OptOutService.scala
@@ -165,8 +165,8 @@ class OptOutService @Inject()(itsaStatusUpdateConnector: ITSAStatusUpdateConnect
 
     val result = for {
       intentTaxYear <- OptionT(intentFuture)
-      yearsToUpdate <- OptionT(Future.successful(Option(optOutProposition.optOutYearsToUpdate(intentTaxYear))))
-      responsesSeqOfFutures  <- OptionT(Future.successful(Option(makeUpdateCalls(yearsToUpdate))))
+      yearsToUpdate = optOutProposition.optOutYearsToUpdate(intentTaxYear)
+      responsesSeqOfFutures = makeUpdateCalls(yearsToUpdate)
       responsesSeq <- OptionT(Future.sequence(responsesSeqOfFutures).map(v => Option(v)))
     } yield findAnyFailOrFirstSuccess(responsesSeq)
 

--- a/app/services/optout/OptOutService.scala
+++ b/app/services/optout/OptOutService.scala
@@ -168,8 +168,7 @@ class OptOutService @Inject()(itsaStatusUpdateConnector: ITSAStatusUpdateConnect
       yearsToUpdate <- OptionT(Future.successful(Option(optOutProposition.optOutYearsToUpdate(intentTaxYear))))
       responsesSeqOfFutures  <- OptionT(Future.successful(Option(makeUpdateCalls(yearsToUpdate))))
       responsesSeq <- OptionT(Future.sequence(responsesSeqOfFutures).map(v => Option(v)))
-      finalResponse <- OptionT(Future.successful(Option(findAnyFailOrFirstSuccess(responsesSeq))))
-    } yield finalResponse
+    } yield findAnyFailOrFirstSuccess(responsesSeq)
 
     result.getOrElse(OptOutUpdateResponseFailure.defaultFailure())
   }

--- a/app/services/optout/OptOutService.scala
+++ b/app/services/optout/OptOutService.scala
@@ -114,9 +114,8 @@ class OptOutService @Inject()(itsaStatusUpdateConnector: ITSAStatusUpdateConnect
     fetchOptOutProposition().flatMap { proposition =>
       proposition.optOutPropositionType.map {
         case _: OneYearOptOutProposition =>
-          saveIntent(intent = proposition.availableTaxYearsForOptOut.head)
-          makeOptOutUpdateRequest(proposition)
-        case _: MultiYearOptOutProposition => makeOptOutUpdateRequest(proposition)
+          makeOptOutUpdateRequest(proposition, Future.successful(proposition.availableTaxYearsForOptOut.headOption))
+        case _: MultiYearOptOutProposition => makeOptOutUpdateRequest(proposition, fetchSavedIntent())
       } getOrElse Future.successful(OptOutUpdateResponseFailure.defaultFailure())
     }
   }
@@ -150,7 +149,7 @@ class OptOutService @Inject()(itsaStatusUpdateConnector: ITSAStatusUpdateConnect
     repository.set(data)
   }
 
-  def makeOptOutUpdateRequest(optOutProposition: OptOutProposition)
+  def makeOptOutUpdateRequest(optOutProposition: OptOutProposition, intentFuture: Future[Option[TaxYear]])
                              (implicit user: MtdItUser[_], hc: HeaderCarrier, ec: ExecutionContext): Future[OptOutUpdateResponse] = {
 
     def makeUpdateCalls(optOutYearsToUpdate: Seq[TaxYear]): Seq[Future[OptOutUpdateResponse]] = {
@@ -165,7 +164,7 @@ class OptOutService @Inject()(itsaStatusUpdateConnector: ITSAStatusUpdateConnect
     }
 
     val result = for {
-      intentTaxYear <- OptionT(fetchSavedIntent())
+      intentTaxYear <- OptionT(intentFuture)
       yearsToUpdate <- OptionT(Future.successful(Option(optOutProposition.optOutYearsToUpdate(intentTaxYear))))
       responsesSeqOfFutures  <- OptionT(Future.successful(Option(makeUpdateCalls(yearsToUpdate))))
       responsesSeq <- OptionT(Future.sequence(responsesSeqOfFutures).map(v => Option(v)))

--- a/test/services/optout/OptOutServiceSpec.scala
+++ b/test/services/optout/OptOutServiceSpec.scala
@@ -222,12 +222,8 @@ class OptOutServiceSpec extends UnitSpec
         val proposition = buildOneYearOptOutPropositionForPreviousYear(currentYear)
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         val intent = optOutTaxYear
-        val sessionData: Option[OptOutSessionData] = Some(OptOutSessionData(Some(intent.toString)))
-        val journeyData: UIJourneySessionData = UIJourneySessionData(sessionIdValue, OptOutJourney.Name, optOutSessionData = sessionData)
-        when(repository.get(any[String], any[String])).thenReturn(Future.successful(Option(journeyData)))
-        when(repository.set(any())).thenReturn(Future.successful(true))
 
-        val result = service.makeOptOutUpdateRequest(proposition)
+        val result = service.makeOptOutUpdateRequest(proposition, Future.successful(Some(intent)))
         result.futureValue shouldBe OptOutUpdateResponseSuccess(correlationId, NO_CONTENT)
       }
     }
@@ -249,12 +245,8 @@ class OptOutServiceSpec extends UnitSpec
 
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         val intent = optOutTaxYear
-        val sessionData: Option[OptOutSessionData] = Some(OptOutSessionData(Some(intent.toString)))
-        val journeyData: UIJourneySessionData = UIJourneySessionData(sessionIdValue, OptOutJourney.Name, optOutSessionData = sessionData)
-        when(repository.get(any[String], any[String])).thenReturn(Future.successful(Option(journeyData)))
-        when(repository.set(any())).thenReturn(Future.successful(true))
 
-        val result = service.makeOptOutUpdateRequest(proposition)
+        val result = service.makeOptOutUpdateRequest(proposition, Future.successful(Some(intent)))
         result.futureValue shouldBe OptOutUpdateResponseSuccess(correlationId, NO_CONTENT)
       }
     }
@@ -276,12 +268,8 @@ class OptOutServiceSpec extends UnitSpec
 
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         val intent = optOutTaxYear
-        val sessionData: Option[OptOutSessionData] = Some(OptOutSessionData(Some(intent.toString)))
-        val journeyData: UIJourneySessionData = UIJourneySessionData(sessionIdValue, OptOutJourney.Name, optOutSessionData = sessionData)
-        when(repository.get(any[String], any[String])).thenReturn(Future.successful(Option(journeyData)))
-        when(repository.set(any())).thenReturn(Future.successful(true))
 
-        service.makeOptOutUpdateRequest(proposition)
+        service.makeOptOutUpdateRequest(proposition, Future.successful(Some(intent)))
       }
     }
 
@@ -303,12 +291,8 @@ class OptOutServiceSpec extends UnitSpec
 
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         val intent = currentTaxYear
-        val sessionData: Option[OptOutSessionData] = Some(OptOutSessionData(Some(intent.toString)))
-        val journeyData: UIJourneySessionData = UIJourneySessionData(sessionIdValue, OptOutJourney.Name, optOutSessionData = sessionData)
-        when(repository.get(any[String], any[String])).thenReturn(Future.successful(Option(journeyData)))
-        when(repository.set(any())).thenReturn(Future.successful(true))
 
-        val result = service.makeOptOutUpdateRequest(proposition)
+        val result = service.makeOptOutUpdateRequest(proposition, Future.successful(Some(intent)))
 
         result.futureValue shouldBe OptOutUpdateResponseSuccess(correlationId, NO_CONTENT)
       }
@@ -333,12 +317,8 @@ class OptOutServiceSpec extends UnitSpec
 
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         val intent = currentTaxYear
-        val sessionData: Option[OptOutSessionData] = Some(OptOutSessionData(Some(intent.toString)))
-        val journeyData: UIJourneySessionData = UIJourneySessionData(sessionIdValue, OptOutJourney.Name, optOutSessionData = sessionData)
-        when(repository.get(any[String], any[String])).thenReturn(Future.successful(Option(journeyData)))
-        when(repository.set(any())).thenReturn(Future.successful(true))
 
-        val result = service.makeOptOutUpdateRequest(proposition)
+        val result = service.makeOptOutUpdateRequest(proposition, Future.successful(Some(intent)))
 
         result.futureValue shouldBe OptOutUpdateResponseFailure(correlationId, BAD_REQUEST, errorItems)
       }


### PR DESCRIPTION
This PR removes the need, within the handling of the submit action from the Opt Out Confirmation Page, to persist the tax year to opt-out for in mongo, just to pull it back again in the next function.

This simplification should make it easier to persist the 3 ITSA statuses and the Crystallised status to mongo, giving a consistent context in which to generate all the pages in the journey and to address the recent issues we've seen in E2E testing.

Moreover, I think the original code could have had a race condition in it in that the write to the DB was implemented async, yet not waited for before reading it back. Thought I've not reproduce the race condition, I think we're safer without this possibility.

I would have liked to go further and transform the `makeOptOutUpdateRequest()` function not take a `Future`, but instead the `Option[Boolean]` and use it in a `flatMap()` at it's call site, but I've not been able to wrap my head around how to do this because of the complexity of the for comprehension inside that function (though I have simplified it a little). This may be possible with a future PR, but I didn't want to block this PR trying to resolve this as we have more pressing matters at hand.