### PR TITLE
MISUV 7885 reduce opt out api calls in next updates controller

### DIFF
--- a/app/controllers/NextUpdatesController.scala
+++ b/app/controllers/NextUpdatesController.scala
@@ -78,8 +78,7 @@ class NextUpdatesController @Inject()(NoNextUpdatesView: NoNextUpdates,
 
             val optOutSetup = {
               for {
-                checks <- optOutService.getNextUpdatesQuarterlyReportingContentChecks
-                optOutOneYearViewModel <- optOutService.nextUpdatesPageOptOutViewModel()
+                (checks, optOutOneYearViewModel) <- optOutService.nextUpdatesPageOptOutViewModels()
               } yield Ok(nextUpdatesOptOutView(viewModel, optOutOneYearViewModel, checks, backUrl.url, isAgent, origin))
             }.recoverWith {
               case ex =>

--- a/app/services/CalculationListService.scala
+++ b/app/services/CalculationListService.scala
@@ -62,7 +62,7 @@ class CalculationListService @Inject()(calculationListConnector: CalculationList
     }
   }
 
-  def isTaxYearCrystallised(taxYear: TaxYear)(implicit user: MtdItUser[_], hc: HeaderCarrier, ec: ExecutionContext): Future[Boolean] = {
+  def isTaxYearCrystallised(taxYear: TaxYear)(implicit user: MtdItUser[_], hc: HeaderCarrier): Future[Boolean] = {
     isTaxYearCrystallised(taxYear.endYear)
   }
 

--- a/app/services/optout/OptOutService.scala
+++ b/app/services/optout/OptOutService.scala
@@ -113,15 +113,6 @@ class OptOutService @Inject()(itsaStatusUpdateConnector: ITSAStatusUpdateConnect
     OptOutProposition(previousYearOptOut, currentYearOptOut, nextYearOptOut)
   }
 
-  private def nextUpdatesQuarterlyReportingContentChecks(oop: OptOutProposition) = {
-    val currentYearStatus = oop.currentTaxYear.status
-    val previousYearStatus = oop.previousTaxYear.status
-    NextUpdatesQuarterlyReportingContentChecks(
-      currentYearStatus == Mandated || currentYearStatus == Voluntary,
-      previousYearStatus == Mandated || previousYearStatus == Voluntary,
-      oop.previousTaxYear.crystallised)
-  }
-
   private def getITSAStatusesFrom(previousYear: TaxYear)(implicit user: MtdItUser[_],
                                                          hc: HeaderCarrier,
                                                          ec: ExecutionContext): Future[Map[TaxYear, ITSAStatus]] =
@@ -220,6 +211,15 @@ class OptOutService @Inject()(itsaStatusUpdateConnector: ITSAStatusUpdateConnect
     }).map { proposition =>
       (nextUpdatesQuarterlyReportingContentChecks(proposition), nextUpdatesOptOutViewModel(proposition))
     }
+  }
+
+  private def nextUpdatesQuarterlyReportingContentChecks(oop: OptOutProposition) = {
+    val currentYearStatus = oop.currentTaxYear.status
+    val previousYearStatus = oop.previousTaxYear.status
+    NextUpdatesQuarterlyReportingContentChecks(
+      currentYearStatus == Mandated || currentYearStatus == Voluntary,
+      previousYearStatus == Mandated || previousYearStatus == Voluntary,
+      oop.previousTaxYear.crystallised)
   }
 
   private def nextUpdatesOptOutViewModel(proposition: OptOutProposition): Option[OptOutViewModel] = {

--- a/app/services/optout/OptOutService.scala
+++ b/app/services/optout/OptOutService.scala
@@ -113,13 +113,6 @@ class OptOutService @Inject()(itsaStatusUpdateConnector: ITSAStatusUpdateConnect
     OptOutProposition(previousYearOptOut, currentYearOptOut, nextYearOptOut)
   }
 
-  def getNextUpdatesQuarterlyReportingContentChecks(implicit user: MtdItUser[_],
-                                                    hc: HeaderCarrier,
-                                                    ec: ExecutionContext): Future[NextUpdatesQuarterlyReportingContentChecks] = {
-    fetchOptOutProposition()
-      .map(oop => nextUpdatesQuarterlyReportingContentChecks(oop))
-  }
-
   private def nextUpdatesQuarterlyReportingContentChecks(oop: OptOutProposition) = {
     val currentYearStatus = oop.currentTaxYear.status
     val previousYearStatus = oop.previousTaxYear.status
@@ -217,13 +210,15 @@ class OptOutService @Inject()(itsaStatusUpdateConnector: ITSAStatusUpdateConnect
     result.getOrElse(OptOutUpdateResponseFailure.defaultFailure())
   }
 
-  def nextUpdatesPageOptOutViewModel()(implicit user: MtdItUser[_], hc: HeaderCarrier, ec: ExecutionContext): Future[Option[OptOutViewModel]] = {
+  def nextUpdatesPageOptOutViewModels()(implicit user: MtdItUser[_],
+                                        hc: HeaderCarrier,
+                                        ec: ExecutionContext): Future[(NextUpdatesQuarterlyReportingContentChecks, Option[OptOutViewModel])] = {
     // Should we fetch the opt out initial state here? It would simplify initialising the journey.
     fetchOptOutProposition().flatMap(oop => {
       // Is there a better way to manage failure of initialiseOptOutJourney()...? handle the boolean?
       initialiseOptOutJourney(oop).map(_ => oop)
     }).map { proposition =>
-      nextUpdatesOptOutViewModel(proposition)
+      (nextUpdatesQuarterlyReportingContentChecks(proposition), nextUpdatesOptOutViewModel(proposition))
     }
   }
 

--- a/app/services/optout/OptOutService.scala
+++ b/app/services/optout/OptOutService.scala
@@ -228,17 +228,17 @@ class OptOutService @Inject()(itsaStatusUpdateConnector: ITSAStatusUpdateConnect
   }
 
   private def nextUpdatesOptOutViewModel(proposition: OptOutProposition): Option[OptOutViewModel] = {
-    proposition.optOutPropositionType.flatMap {
-      case p: OneYearOptOutProposition => Some(OptOutOneYearViewModel(oneYearOptOutTaxYear = p.intent.taxYear, state = p.state()))
-      case _: MultiYearOptOutProposition => Some(OptOutMultiYearViewModel())
+    proposition.optOutPropositionType.map {
+      case p: OneYearOptOutProposition => OptOutOneYearViewModel(oneYearOptOutTaxYear = p.intent.taxYear, state = p.state())
+      case _: MultiYearOptOutProposition => OptOutMultiYearViewModel()
     }
   }
 
   def recallNextUpdatesPageOptOutViewModel()(implicit user: MtdItUser[_], hc: HeaderCarrier, ec: ExecutionContext): Future[Option[OptOutViewModel]] = {
     recallOptOutProposition().map { proposition =>
-      proposition.optOutPropositionType.flatMap {
-        case p: OneYearOptOutProposition => Some(OptOutOneYearViewModel(oneYearOptOutTaxYear = p.intent.taxYear, state = p.state()))
-        case _: MultiYearOptOutProposition => Some(OptOutMultiYearViewModel())
+      proposition.optOutPropositionType.map {
+        case p: OneYearOptOutProposition => OptOutOneYearViewModel(oneYearOptOutTaxYear = p.intent.taxYear, state = p.state())
+        case _: MultiYearOptOutProposition => OptOutMultiYearViewModel()
       }
     }
   }

--- a/test/controllers/NextUpdatesControllerSpec.scala
+++ b/test/controllers/NextUpdatesControllerSpec.scala
@@ -352,7 +352,7 @@ class NextUpdatesControllerSpec extends MockAuthenticationPredicate with MockInc
         setupMockAuthRetrievalSuccess(testIndividualAuthSuccessWithSaUtrResponse())
         mockSingleBusinessIncomeSourceError()
         mockSingleBusinessIncomeSourceWithDeadlines()
-        mockGetNextUpdatesQuarterlyReportingContentChecks(Future.failed(new Exception("api failure")))
+        mockGetNextUpdatesPageOptOutViewModels(Future.failed(new Exception("api failure")))
         mockObligations
         val result = TestNextUpdatesController.show()(fakeRequestWithActiveSession)
         status(result) shouldBe Status.INTERNAL_SERVER_ERROR

--- a/test/controllers/optOut/OptOutChooseTaxYearControllerSpec.scala
+++ b/test/controllers/optOut/OptOutChooseTaxYearControllerSpec.scala
@@ -95,7 +95,6 @@ class OptOutChooseTaxYearControllerSpec extends TestSupport
 
         setupMockAuthorisationSuccess(isAgent)
         setupMockGetIncomeSourceDetails()(businessesAndPropertyIncome)
-        mockNextUpdatesPageMultiYearOptOutViewModel(eligibleTaxYearResponse)
         mockFetchIntent(Future.successful(None))
         mockGetSubmissionCountForTaxYear(counts)
         mockRecallOptOutProposition(Future.successful(optOutProposition))
@@ -113,7 +112,6 @@ class OptOutChooseTaxYearControllerSpec extends TestSupport
 
         setupMockAuthorisationSuccess(isAgent)
         setupMockGetIncomeSourceDetails()(businessesAndPropertyIncome)
-        mockNextUpdatesPageMultiYearOptOutViewModel(eligibleTaxYearResponse)
         mockFetchIntent(Future.successful(Some(optOutTaxYear.taxYear)))
         mockGetSubmissionCountForTaxYear(counts)
         mockRecallOptOutProposition(Future.successful(optOutProposition))
@@ -140,7 +138,6 @@ class OptOutChooseTaxYearControllerSpec extends TestSupport
 
         setupMockAuthorisationSuccess(isAgent)
         setupMockGetIncomeSourceDetails()(businessesAndPropertyIncome)
-        mockNextUpdatesPageMultiYearOptOutViewModel(eligibleTaxYearResponse)
 
         mockGetSubmissionCountForTaxYear(counts)
         mockSaveIntent(currentTaxYear, Future.successful(true))
@@ -163,7 +160,6 @@ class OptOutChooseTaxYearControllerSpec extends TestSupport
 
         setupMockAuthorisationSuccess(isAgent)
         setupMockGetIncomeSourceDetails()(businessesAndPropertyIncome)
-        mockNextUpdatesPageMultiYearOptOutViewModel(eligibleTaxYearResponse)
 
         mockGetSubmissionCountForTaxYear(counts)
         mockSaveIntent(currentTaxYear, Future.successful(false))
@@ -186,7 +182,6 @@ class OptOutChooseTaxYearControllerSpec extends TestSupport
 
         setupMockAuthorisationSuccess(isAgent)
         setupMockGetIncomeSourceDetails()(businessesAndPropertyIncome)
-        mockNextUpdatesPageMultiYearOptOutViewModel(eligibleTaxYearResponse)
 
         mockGetSubmissionCountForTaxYear(counts)
         mockRecallOptOutProposition(Future.successful(optOutProposition))
@@ -212,7 +207,6 @@ class OptOutChooseTaxYearControllerSpec extends TestSupport
 
         setupMockAuthorisationSuccess(isAgent)
         setupMockGetIncomeSourceDetails()(businessesAndPropertyIncome)
-        mockNextUpdatesPageMultiYearOptOutViewModel(eligibleTaxYearResponse)
 
         mockGetSubmissionCountForTaxYear(counts)
         mockSaveIntent(currentTaxYear, Future.successful(false))
@@ -236,7 +230,6 @@ class OptOutChooseTaxYearControllerSpec extends TestSupport
 
         setupMockAuthorisationSuccess(isAgent)
         setupMockGetIncomeSourceDetails()(businessesAndPropertyIncome)
-        mockNextUpdatesPageMultiYearOptOutViewModel(eligibleTaxYearResponse)
 
         mockGetSubmissionCountForTaxYear(counts)
         mockSaveIntent(currentTaxYear, Future.successful(true))

--- a/test/mocks/services/MockCalculationListService.scala
+++ b/test/mocks/services/MockCalculationListService.scala
@@ -16,6 +16,7 @@
 
 package mocks.services
 
+import models.incomeSourceDetails.TaxYear
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, reset, when}
@@ -37,7 +38,7 @@ trait MockCalculationListService extends UnitSpec with BeforeAndAfterEach {
     when(mockCalculationListService.isTaxYearCrystallised(ArgumentMatchers.anyInt())(any(), any()))
       .thenReturn(Future.successful(false))
 
-  def setupMockIsTaxYearCrystallisedCall(taxYear: Int)(out: Future[Boolean]): Unit = {
+  def setupMockIsTaxYearCrystallisedCall(taxYear: TaxYear)(out: Future[Boolean]): Unit = {
     when(mockCalculationListService
       .isTaxYearCrystallised(ArgumentMatchers.eq(taxYear))(any, any))
       .thenReturn(out)

--- a/test/mocks/services/MockDateService.scala
+++ b/test/mocks/services/MockDateService.scala
@@ -16,6 +16,7 @@
 
 package mocks.services
 
+import models.incomeSourceDetails.TaxYear
 import org.mockito.Mockito.{mock, reset, when}
 import org.scalatest.BeforeAndAfterEach
 import services.DateService
@@ -30,8 +31,8 @@ trait MockDateService extends UnitSpec with BeforeAndAfterEach {
     reset(mockDateService)
   }
 
-  def setupMockGetCurrentTaxYearEnd(out: Int): Unit = {
-    when(mockDateService.getCurrentTaxYearEnd).thenReturn(out)
+  def setupMockGetCurrentTaxYearEnd(taxYear: TaxYear): Unit = {
+    when(mockDateService.getCurrentTaxYear).thenReturn(taxYear)
   }
 
 }

--- a/test/mocks/services/MockOptOutService.scala
+++ b/test/mocks/services/MockOptOutService.scala
@@ -47,10 +47,6 @@ trait MockOptOutService extends UnitSpec with BeforeAndAfterEach {
       .thenReturn(out)
   }
 
-  def mockNextUpdatesPageMultiYearOptOutViewModel(out: Future[Option[OptOutMultiYearViewModel]]): Unit = {
-    when(mockOptOutService.nextUpdatesPageOptOutViewModel()(any(), any(), any())).thenReturn(out)
-  }
-
   def mockGetSubmissionCountForTaxYear(out: Future[QuarterlyUpdatesCountForTaxYearModel]): Unit = {
     when(mockOptOutService.getQuarterlyUpdatesCountForOfferedYears(any[OptOutProposition])(any(), any(), any())).thenReturn(out)
   }

--- a/test/mocks/services/MockOptOutService.scala
+++ b/test/mocks/services/MockOptOutService.scala
@@ -37,8 +37,8 @@ trait MockOptOutService extends UnitSpec with BeforeAndAfterEach {
     reset(mockOptOutService)
   }
 
-  def mockGetNextUpdatesQuarterlyReportingContentChecks(out: Future[NextUpdatesQuarterlyReportingContentChecks]): Unit = {
-    when(mockOptOutService.getNextUpdatesQuarterlyReportingContentChecks(any(), any(), any()))
+  def mockGetNextUpdatesPageOptOutViewModels(out: Future[(NextUpdatesQuarterlyReportingContentChecks, Option[OptOutViewModel])]): Unit = {
+    when(mockOptOutService.nextUpdatesPageOptOutViewModels()(any(), any(), any()))
       .thenReturn(out)
   }
 

--- a/test/services/optout/OptOutServiceNextUpdatesPageOptOutViewModelSpec.scala
+++ b/test/services/optout/OptOutServiceNextUpdatesPageOptOutViewModelSpec.scala
@@ -22,9 +22,9 @@ import connectors.optout.OptOutUpdateRequestModel.OptOutUpdateResponseSuccess
 import mocks.services.{MockCalculationListService, MockDateService, MockITSAStatusService, MockITSAStatusUpdateConnector}
 import models.incomeSourceDetails.{TaxYear, UIJourneySessionData}
 import models.itsaStatus.{ITSAStatus, StatusDetail}
-import models.optout.{OptOutContextData, OptOutMultiYearViewModel, OptOutOneYearViewModel, OptOutSessionData}
+import models.optout.{OptOutMultiYearViewModel, OptOutOneYearViewModel, OptOutSessionData}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{mock, reset, verify, when}
+import org.mockito.Mockito.{mock, reset, when}
 import org.scalatest.BeforeAndAfter
 import repositories.UIJourneySessionDataRepository
 import services.NextUpdatesService
@@ -92,9 +92,9 @@ class OptOutServiceNextUpdatesPageOptOutViewModelSpec extends UnitSpec
           OptOutUpdateResponseSuccess(correlationId)
         ))
 
-        val result = service.nextUpdatesPageOptOutViewModel()
+        val result = service.nextUpdatesPageOptOutViewModels()
 
-        result.futureValue.get.isInstanceOf[OptOutOneYearViewModel] shouldBe true
+        result.futureValue._2.get.isInstanceOf[OptOutOneYearViewModel] shouldBe true
       }
     }
 
@@ -130,9 +130,9 @@ class OptOutServiceNextUpdatesPageOptOutViewModelSpec extends UnitSpec
           OptOutUpdateResponseSuccess(correlationId)
         ))
 
-        val result = service.nextUpdatesPageOptOutViewModel()
+        val result = service.nextUpdatesPageOptOutViewModels()
 
-        result.futureValue.get.isInstanceOf[OptOutMultiYearViewModel] shouldBe true
+        result.futureValue._2.get.isInstanceOf[OptOutMultiYearViewModel] shouldBe true
       }
     }
   }

--- a/test/services/optout/OptOutServiceSpec.scala
+++ b/test/services/optout/OptOutServiceSpec.scala
@@ -344,7 +344,7 @@ class OptOutServiceSpec extends UnitSpec
           currentYear, NoStatus,
           nextYear, NoStatus)
 
-        when(mockCalculationListService.isTaxYearCrystallised(previousYear)).thenReturn(Future.successful(false))
+        mockCrystallisedStatus(previousYear, false)
 
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         when(repository.set(any())).thenReturn(Future.successful(true))
@@ -369,7 +369,7 @@ class OptOutServiceSpec extends UnitSpec
           currentYear, NoStatus,
           nextYear, NoStatus)
 
-        when(mockCalculationListService.isTaxYearCrystallised(previousYear)).thenReturn(Future.successful(true))
+        mockCrystallisedStatus(previousYear, true)
 
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         when(repository.set(any())).thenReturn(Future.successful(true))
@@ -393,7 +393,7 @@ class OptOutServiceSpec extends UnitSpec
           currentYear, Voluntary,
           nextYear, Mandated)
 
-        when(mockCalculationListService.isTaxYearCrystallised(previousYear)).thenReturn(Future.successful(false))
+        mockCrystallisedStatus(previousYear, false)
 
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         when(repository.set(any())).thenReturn(Future.successful(true))
@@ -417,7 +417,7 @@ class OptOutServiceSpec extends UnitSpec
           currentYear, NoStatus,
           nextYear, Voluntary)
 
-        when(mockCalculationListService.isTaxYearCrystallised(previousYear)).thenReturn(Future.successful(false))
+        mockCrystallisedStatus(previousYear, false)
 
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         when(repository.set(any())).thenReturn(Future.successful(true))
@@ -441,7 +441,7 @@ class OptOutServiceSpec extends UnitSpec
             currentYear, Mandated,
             nextYear, Mandated)
 
-          when(mockCalculationListService.isTaxYearCrystallised(previousYear)).thenReturn(Future.successful(false))
+          mockCrystallisedStatus(previousYear, false)
 
           when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
           when(repository.set(any())).thenReturn(Future.successful(true))
@@ -470,7 +470,7 @@ class OptOutServiceSpec extends UnitSpec
               currentYear, Voluntary,
               nextYear, Mandated)
 
-            when(mockCalculationListService.isTaxYearCrystallised(previousYear)).thenReturn(Future.successful(false))
+            mockCrystallisedStatus(previousYear, false)
 
             when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
             when(repository.set(any())).thenReturn(Future.successful(true))
@@ -500,7 +500,7 @@ class OptOutServiceSpec extends UnitSpec
 
           when(mockITSAStatusService.getStatusTillAvailableFutureYears(previousYear)).thenReturn(Future.failed(new RuntimeException("some api error")))
 
-          when(mockCalculationListService.isTaxYearCrystallised(previousYear)).thenReturn(Future.successful(false))
+          mockCrystallisedStatus(previousYear, false)
 
           val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -733,6 +733,10 @@ class OptOutServiceSpec extends UnitSpec
       nextYear -> StatusDetail("", nextYearStatus, "")
     )
     when(mockITSAStatusService.getStatusTillAvailableFutureYears(previousYear)).thenReturn(Future.successful(taxYearStatusDetailMap))
+  }
+
+  private def mockCrystallisedStatus(taxYear: TaxYear, crystallisedStatus: Boolean): Unit = {
+    when(mockCalculationListService.isTaxYearCrystallised(taxYear)).thenReturn(Future.successful(crystallisedStatus))
   }
 
 }

--- a/test/services/optout/OptOutServiceSpec.scala
+++ b/test/services/optout/OptOutServiceSpec.scala
@@ -547,9 +547,9 @@ class OptOutServiceSpec extends UnitSpec
     "OptOutService.getNextUpdatesQuarterlyReportingContentChecks" when {
       "ITSA Status from CY-1 till future years and Calculation State for CY-1 is available" should {
         "return NextUpdatesQuarterlyReportingContentCheck" in {
-          setupMockIsTaxYearCrystallisedCall(previousTaxYear.endYear)(Future.successful(crystallised))
+          setupMockIsTaxYearCrystallisedCall(previousTaxYear)(Future.successful(crystallised))
           setupMockGetStatusTillAvailableFutureYears(previousTaxYear)(Future.successful(yearToStatus))
-          setupMockGetCurrentTaxYearEnd(taxYear.endYear)
+          setupMockGetCurrentTaxYearEnd(taxYear)
 
           val expected = NextUpdatesQuarterlyReportingContentChecks(
             currentYearItsaStatus = true,
@@ -562,9 +562,9 @@ class OptOutServiceSpec extends UnitSpec
 
       "Calculation State for CY-1 is unavailable" should {
         "return NextUpdatesQuarterlyReportingContentCheck" in {
-          setupMockIsTaxYearCrystallisedCall(previousTaxYear.endYear)(Future.failed(error))
+          setupMockIsTaxYearCrystallisedCall(previousTaxYear)(Future.failed(error))
           setupMockGetStatusTillAvailableFutureYears(previousTaxYear)(Future.successful(yearToStatus))
-          setupMockGetCurrentTaxYearEnd(taxYear.endYear)
+          setupMockGetCurrentTaxYearEnd(taxYear)
 
           service.getNextUpdatesQuarterlyReportingContentChecks.failed.map { ex =>
             ex shouldBe a[RuntimeException]
@@ -575,9 +575,9 @@ class OptOutServiceSpec extends UnitSpec
 
       "ITSA Status from CY-1 till future years is unavailable" should {
         "return NextUpdatesQuarterlyReportingContentCheck" in {
-          setupMockIsTaxYearCrystallisedCall(previousTaxYear.endYear)(Future.successful(crystallised))
+          setupMockIsTaxYearCrystallisedCall(previousTaxYear)(Future.successful(crystallised))
           setupMockGetStatusTillAvailableFutureYears(previousTaxYear)(Future.failed(error))
-          setupMockGetCurrentTaxYearEnd(taxYear.endYear)
+          setupMockGetCurrentTaxYearEnd(taxYear)
 
           service.getNextUpdatesQuarterlyReportingContentChecks.failed.map { ex =>
             ex shouldBe a[RuntimeException]

--- a/test/services/optout/OptOutServiceSpec.scala
+++ b/test/services/optout/OptOutServiceSpec.scala
@@ -351,9 +351,9 @@ class OptOutServiceSpec extends UnitSpec
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         when(repository.set(any())).thenReturn(Future.successful(true))
 
-        val response = service.nextUpdatesPageOptOutViewModel()
+        val response = service.nextUpdatesPageOptOutViewModels()
 
-        response.futureValue shouldBe Some(OptOutOneYearViewModel(TaxYear.forYearEnd(2023), None))
+        response.futureValue._2 shouldBe Some(OptOutOneYearViewModel(TaxYear.forYearEnd(2023), None))
 
       }
     }
@@ -378,9 +378,9 @@ class OptOutServiceSpec extends UnitSpec
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         when(repository.set(any())).thenReturn(Future.successful(true))
 
-        val response = service.nextUpdatesPageOptOutViewModel()
+        val response = service.nextUpdatesPageOptOutViewModels()
 
-        response.futureValue shouldBe noOptOutOptionAvailable
+        response.futureValue._2 shouldBe noOptOutOptionAvailable
       }
     }
 
@@ -404,9 +404,9 @@ class OptOutServiceSpec extends UnitSpec
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         when(repository.set(any())).thenReturn(Future.successful(true))
 
-        val response = service.nextUpdatesPageOptOutViewModel()
+        val response = service.nextUpdatesPageOptOutViewModels()
 
-        response.futureValue shouldBe Some(OptOutOneYearViewModel(TaxYear.forYearEnd(2024), Some(OneYearOptOutFollowedByMandated)))
+        response.futureValue._2 shouldBe Some(OptOutOneYearViewModel(TaxYear.forYearEnd(2024), Some(OneYearOptOutFollowedByMandated)))
       }
     }
 
@@ -430,9 +430,9 @@ class OptOutServiceSpec extends UnitSpec
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         when(repository.set(any())).thenReturn(Future.successful(true))
 
-        val response = service.nextUpdatesPageOptOutViewModel()
+        val response = service.nextUpdatesPageOptOutViewModels()
 
-        response.futureValue shouldBe Some(OptOutOneYearViewModel(TaxYear.forYearEnd(2025), Some(NextYearOptOut)))
+        response.futureValue._2 shouldBe Some(OptOutOneYearViewModel(TaxYear.forYearEnd(2025), Some(NextYearOptOut)))
       }
     }
 
@@ -456,9 +456,9 @@ class OptOutServiceSpec extends UnitSpec
           when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
           when(repository.set(any())).thenReturn(Future.successful(true))
 
-          val response = service.nextUpdatesPageOptOutViewModel()
+          val response = service.nextUpdatesPageOptOutViewModels()
 
-          val model = response.futureValue.get
+          val model = response.futureValue._2.get
 
           model match {
             case m: OptOutOneYearViewModel =>
@@ -487,9 +487,9 @@ class OptOutServiceSpec extends UnitSpec
             when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
             when(repository.set(any())).thenReturn(Future.successful(true))
 
-            val response = service.nextUpdatesPageOptOutViewModel()
+            val response = service.nextUpdatesPageOptOutViewModels()
 
-            val model = response.futureValue.get
+            val model = response.futureValue._2.get
             model match {
               case m: OptOutOneYearViewModel =>
                 m.oneYearOptOutTaxYear shouldBe TaxYear.forYearEnd(currentYear)
@@ -514,7 +514,7 @@ class OptOutServiceSpec extends UnitSpec
 
           when(mockCalculationListService.isTaxYearCrystallised(previousYear)).thenReturn(Future.successful(false))
 
-          val response = service.nextUpdatesPageOptOutViewModel()
+          val response = service.nextUpdatesPageOptOutViewModels()
 
           response.failed.futureValue.getMessage shouldBe apiError
         }
@@ -537,16 +537,20 @@ class OptOutServiceSpec extends UnitSpec
 
           when(mockCalculationListService.isTaxYearCrystallised(previousYear)).thenReturn(Future.failed(new RuntimeException("some api error")))
 
-          val response = service.nextUpdatesPageOptOutViewModel()
+          val response = service.nextUpdatesPageOptOutViewModels()
 
           response.failed.futureValue.getMessage shouldBe apiError
         }
       }
     }
 
-    "OptOutService.getNextUpdatesQuarterlyReportingContentChecks" when {
+    "OptOutService.nextUpdatesPageOptOutViewModels" when {
       "ITSA Status from CY-1 till future years and Calculation State for CY-1 is available" should {
         "return NextUpdatesQuarterlyReportingContentCheck" in {
+          // Because we're saving the status as well as building view models...
+          when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
+          when(repository.set(any())).thenReturn(Future.successful(true))
+
           setupMockIsTaxYearCrystallisedCall(previousTaxYear)(Future.successful(crystallised))
           setupMockGetStatusTillAvailableFutureYears(previousTaxYear)(Future.successful(yearToStatus))
           setupMockGetCurrentTaxYearEnd(taxYear)
@@ -556,7 +560,7 @@ class OptOutServiceSpec extends UnitSpec
             previousYearItsaStatus = false,
             previousYearCrystallisedStatus = crystallised)
 
-          service.getNextUpdatesQuarterlyReportingContentChecks.futureValue shouldBe expected
+          service.nextUpdatesPageOptOutViewModels().futureValue._1 shouldBe expected
         }
       }
 
@@ -566,7 +570,7 @@ class OptOutServiceSpec extends UnitSpec
           setupMockGetStatusTillAvailableFutureYears(previousTaxYear)(Future.successful(yearToStatus))
           setupMockGetCurrentTaxYearEnd(taxYear)
 
-          service.getNextUpdatesQuarterlyReportingContentChecks.failed.map { ex =>
+          service.nextUpdatesPageOptOutViewModels().failed.map { ex =>
             ex shouldBe a[RuntimeException]
             ex.getMessage shouldBe error.getMessage
           }
@@ -579,7 +583,7 @@ class OptOutServiceSpec extends UnitSpec
           setupMockGetStatusTillAvailableFutureYears(previousTaxYear)(Future.failed(error))
           setupMockGetCurrentTaxYearEnd(taxYear)
 
-          service.getNextUpdatesQuarterlyReportingContentChecks.failed.map { ex =>
+          service.nextUpdatesPageOptOutViewModels().failed.map { ex =>
             ex shouldBe a[RuntimeException]
             ex.getMessage shouldBe error.getMessage
           }

--- a/test/services/optout/OptOutServiceSpec.scala
+++ b/test/services/optout/OptOutServiceSpec.scala
@@ -342,9 +342,9 @@ class OptOutServiceSpec extends UnitSpec
         stubOptOut(
           currentTaxYear = taxYear2023_2024,
           previousYearCrystallisedStatus = false,
-          previousTaxYearStatus = Voluntary,
-          currentTaxYearStatus = NoStatus,
-          nextTaxYearStatus = NoStatus)
+          previousYearStatus = Voluntary,
+          currentYearStatus = NoStatus,
+          nextYearStatus = NoStatus)
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -360,9 +360,9 @@ class OptOutServiceSpec extends UnitSpec
         stubOptOut(
           currentTaxYear = taxYear2023_2024,
           previousYearCrystallisedStatus = true,
-          previousTaxYearStatus = Voluntary,
-          currentTaxYearStatus = NoStatus,
-          nextTaxYearStatus = NoStatus)
+          previousYearStatus = Voluntary,
+          currentYearStatus = NoStatus,
+          nextYearStatus = NoStatus)
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -377,9 +377,9 @@ class OptOutServiceSpec extends UnitSpec
         stubOptOut(
           currentTaxYear = taxYear2023_2024,
           previousYearCrystallisedStatus = false,
-          previousTaxYearStatus = NoStatus,
-          currentTaxYearStatus = Voluntary,
-          nextTaxYearStatus = Mandated)
+          previousYearStatus = NoStatus,
+          currentYearStatus = Voluntary,
+          nextYearStatus = Mandated)
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -394,9 +394,9 @@ class OptOutServiceSpec extends UnitSpec
         stubOptOut(
           currentTaxYear = taxYear2023_2024,
           previousYearCrystallisedStatus = false,
-          previousTaxYearStatus = NoStatus,
-          currentTaxYearStatus = NoStatus,
-          nextTaxYearStatus = Voluntary)
+          previousYearStatus = NoStatus,
+          currentYearStatus = NoStatus,
+          nextYearStatus = Voluntary)
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -411,9 +411,9 @@ class OptOutServiceSpec extends UnitSpec
           stubOptOut(
             currentTaxYear = taxYear2023_2024,
             previousYearCrystallisedStatus = false,
-            previousTaxYearStatus = Voluntary,
-            currentTaxYearStatus = Mandated,
-            nextTaxYearStatus = Mandated)
+            previousYearStatus = Voluntary,
+            currentYearStatus = Mandated,
+            nextYearStatus = Mandated)
 
           val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -433,9 +433,9 @@ class OptOutServiceSpec extends UnitSpec
             stubOptOut(
               currentTaxYear = taxYear2023_2024,
               previousYearCrystallisedStatus = false,
-              previousTaxYearStatus = Mandated,
-              currentTaxYearStatus = Voluntary,
-              nextTaxYearStatus = Mandated)
+              previousYearStatus = Mandated,
+              currentYearStatus = Voluntary,
+              nextYearStatus = Mandated)
 
             val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -680,18 +680,18 @@ class OptOutServiceSpec extends UnitSpec
 
   private def stubOptOut(currentTaxYear: TaxYear,
                          previousYearCrystallisedStatus: Boolean,
-                         previousTaxYearStatus: Value,
-                         currentTaxYearStatus: Value,
-                         nextTaxYearStatus: Value): Unit = {
+                         previousYearStatus: Value,
+                         currentYearStatus: Value,
+                         nextYearStatus: Value): Unit = {
 
     val (previousYear, currentYear, nextYear) = taxYears(currentTaxYear)
 
     stubCurrentTaxYear(currentYear)
 
     stubItsaStatuses(
-      previousYear, previousTaxYearStatus,
-      currentYear, currentTaxYearStatus,
-      nextYear, nextTaxYearStatus)
+      previousYear, previousYearStatus,
+      currentYear, currentYearStatus,
+      nextYear, nextYearStatus)
 
     stubCrystallisedStatus(previousYear, previousYearCrystallisedStatus)
 

--- a/test/services/optout/OptOutServiceSpec.scala
+++ b/test/services/optout/OptOutServiceSpec.scala
@@ -335,7 +335,7 @@ class OptOutServiceSpec extends UnitSpec
 
   "OptOutService.nextUpdatesPageOneYearOptOutViewModel" when {
 
-    s"PY is $Voluntary, CY is $NoStatus, NY is $NoStatus and PY is NOT finalised" should {
+    "PY is Voluntary, CY is NoStatus, NY is NoStatus and PY is NOT finalised" should {
 
       "offer PY as OptOut Option" in {
 
@@ -353,7 +353,7 @@ class OptOutServiceSpec extends UnitSpec
       }
     }
 
-    s"PY is $Voluntary, CY is $NoStatus NY is $NoStatus and PY is finalised" should {
+    "PY is Voluntary, CY is NoStatus NY is NoStatus and PY is finalised" should {
 
       "offer No OptOut Option" in {
 
@@ -370,7 +370,7 @@ class OptOutServiceSpec extends UnitSpec
       }
     }
 
-    s"PY is $NoStatus, CY is $Voluntary, NY is $Mandated" should {
+    "PY is NoStatus, CY is Voluntary, NY is Mandated" should {
 
       "offer CY OptOut Option" in {
 
@@ -387,7 +387,7 @@ class OptOutServiceSpec extends UnitSpec
       }
     }
 
-    s"PY is $NoStatus, CY is $NoStatus, NY is $Voluntary" should {
+    "PY is NoStatus, CY is NoStatus, NY is Voluntary" should {
 
       "offer NY OptOut Option" in {
 
@@ -405,8 +405,8 @@ class OptOutServiceSpec extends UnitSpec
     }
 
     "Single Year OptOut" when {
-      s"PY : PY is $Voluntary, CY is $Mandated, NY is $Mandated and PY is NOT crystallised" should {
-        s"offer PY OptOut Option with a warning as following year (CY) is $Mandated " in {
+      "PY : PY is Voluntary, CY is Mandated, NY is Mandated and PY is NOT crystallised" should {
+        "offer PY OptOut Option with a warning as following year (CY) is Mandated " in {
 
           stubOptOut(
             currentTaxYear = taxYear2023_2024,
@@ -427,8 +427,8 @@ class OptOutServiceSpec extends UnitSpec
           }
 
         }
-        s"CY : PY is $Mandated, CY is $Voluntary, NY is $Mandated " should {
-          s"offer CY OptOut Option with a warning as following year (NY) is $Mandated " in {
+        "CY : PY is Mandated, CY is Voluntary, NY is Mandated " should {
+          "offer CY OptOut Option with a warning as following year (NY) is Mandated " in {
 
             stubOptOut(
               currentTaxYear = taxYear2023_2024,

--- a/test/services/optout/OptOutServiceSpec.scala
+++ b/test/services/optout/OptOutServiceSpec.scala
@@ -346,8 +346,7 @@ class OptOutServiceSpec extends UnitSpec
 
         stubCrystallisedStatus(previousYear, false)
 
-        when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
-        when(repository.set(any())).thenReturn(Future.successful(true))
+        allowWriteOfOptOutDataToMongoToSucceed
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -371,8 +370,7 @@ class OptOutServiceSpec extends UnitSpec
 
         stubCrystallisedStatus(previousYear, true)
 
-        when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
-        when(repository.set(any())).thenReturn(Future.successful(true))
+        allowWriteOfOptOutDataToMongoToSucceed
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -395,8 +393,7 @@ class OptOutServiceSpec extends UnitSpec
 
         stubCrystallisedStatus(previousYear, false)
 
-        when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
-        when(repository.set(any())).thenReturn(Future.successful(true))
+        allowWriteOfOptOutDataToMongoToSucceed
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -419,8 +416,7 @@ class OptOutServiceSpec extends UnitSpec
 
         stubCrystallisedStatus(previousYear, false)
 
-        when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
-        when(repository.set(any())).thenReturn(Future.successful(true))
+        allowWriteOfOptOutDataToMongoToSucceed
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -443,8 +439,7 @@ class OptOutServiceSpec extends UnitSpec
 
           stubCrystallisedStatus(previousYear, false)
 
-          when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
-          when(repository.set(any())).thenReturn(Future.successful(true))
+          allowWriteOfOptOutDataToMongoToSucceed
 
           val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -472,8 +467,7 @@ class OptOutServiceSpec extends UnitSpec
 
             stubCrystallisedStatus(previousYear, false)
 
-            when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
-            when(repository.set(any())).thenReturn(Future.successful(true))
+            allowWriteOfOptOutDataToMongoToSucceed
 
             val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -534,8 +528,7 @@ class OptOutServiceSpec extends UnitSpec
       "ITSA Status from CY-1 till future years and Calculation State for CY-1 is available" should {
         "return NextUpdatesQuarterlyReportingContentCheck" in {
           // Because we're saving the status as well as building view models...
-          when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
-          when(repository.set(any())).thenReturn(Future.successful(true))
+          allowWriteOfOptOutDataToMongoToSucceed
 
           setupMockIsTaxYearCrystallisedCall(previousTaxYear)(Future.successful(crystallised))
           setupMockGetStatusTillAvailableFutureYears(previousTaxYear)(Future.successful(yearToStatus))
@@ -737,6 +730,11 @@ class OptOutServiceSpec extends UnitSpec
 
   private def stubCrystallisedStatus(taxYear: TaxYear, crystallisedStatus: Boolean): Unit = {
     when(mockCalculationListService.isTaxYearCrystallised(taxYear)).thenReturn(Future.successful(crystallisedStatus))
+  }
+
+  private def allowWriteOfOptOutDataToMongoToSucceed(): Unit = {
+    when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
+    when(repository.set(any())).thenReturn(Future.successful(true))
   }
 
 }

--- a/test/services/optout/OptOutServiceSpec.scala
+++ b/test/services/optout/OptOutServiceSpec.scala
@@ -337,7 +337,7 @@ class OptOutServiceSpec extends UnitSpec
 
         val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = 2024)
 
-        when(mockDateService.getCurrentTaxYear).thenReturn(currentYear)
+        stubCurrentTaxYear(currentYear)
 
         stubItsaStatuses(
           previousYear, Voluntary,
@@ -361,7 +361,7 @@ class OptOutServiceSpec extends UnitSpec
 
         val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = 2024)
 
-        when(mockDateService.getCurrentTaxYear).thenReturn(currentYear)
+        stubCurrentTaxYear(currentYear)
 
         stubItsaStatuses(
           previousYear, Voluntary,
@@ -384,7 +384,7 @@ class OptOutServiceSpec extends UnitSpec
 
         val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = 2024)
 
-        when(mockDateService.getCurrentTaxYear).thenReturn(currentYear)
+        stubCurrentTaxYear(currentYear)
 
         stubItsaStatuses(
           previousYear, NoStatus,
@@ -407,7 +407,7 @@ class OptOutServiceSpec extends UnitSpec
 
         val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = 2024)
 
-        when(mockDateService.getCurrentTaxYear).thenReturn(currentYear)
+        stubCurrentTaxYear(currentYear)
 
         stubItsaStatuses(
           previousYear, NoStatus,
@@ -430,7 +430,7 @@ class OptOutServiceSpec extends UnitSpec
 
           val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = 2024)
 
-          when(mockDateService.getCurrentTaxYear).thenReturn(currentYear)
+          stubCurrentTaxYear(currentYear)
 
           stubItsaStatuses(
             previousYear, Voluntary,
@@ -458,7 +458,7 @@ class OptOutServiceSpec extends UnitSpec
 
             val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = 2024)
 
-            when(mockDateService.getCurrentTaxYear).thenReturn(currentYear)
+            stubCurrentTaxYear(currentYear)
 
             stubItsaStatuses(
               previousYear, Mandated,
@@ -490,7 +490,7 @@ class OptOutServiceSpec extends UnitSpec
 
           val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = 2024)
 
-          when(mockDateService.getCurrentTaxYear).thenReturn(currentYear)
+          stubCurrentTaxYear(currentYear)
 
           when(mockITSAStatusService.getStatusTillAvailableFutureYears(previousYear)).thenReturn(Future.failed(new RuntimeException("some api error")))
 
@@ -508,7 +508,7 @@ class OptOutServiceSpec extends UnitSpec
 
           val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = 2024)
 
-          when(mockDateService.getCurrentTaxYear).thenReturn(currentYear)
+          stubCurrentTaxYear(currentYear)
 
           stubItsaStatuses(
             previousYear, NoStatus,
@@ -589,7 +589,7 @@ class OptOutServiceSpec extends UnitSpec
       s"PY is $statusPY, CY is $statusCY, NY is $statusNY and PY is ${if (!crystallisedPY) "NOT "}finalised" should {
         s"offer ${getTaxYearText(optOutTaxYear.taxYear)} with state $state" in {
 
-          when(mockDateService.getCurrentTaxYear).thenReturn(CY)
+          stubCurrentTaxYear(CY)
 
           when(nextUpdatesService.getQuarterlyUpdatesCounts(ArgumentMatchers.eq(optOutTaxYear.taxYear))(any(), any()))
             .thenReturn(Future.successful(QuarterlyUpdatesCountForTaxYear(optOutTaxYear.taxYear, 0)))
@@ -638,7 +638,7 @@ class OptOutServiceSpec extends UnitSpec
       s"PY is $statusPY, CY is $statusCY, NY is $statusNY and PY is ${if (!crystallisedPY) "NOT "}finalised" should {
         s"offer ${getTaxYearText(intent)}" in {
 
-          when(mockDateService.getCurrentTaxYear).thenReturn(CY)
+          stubCurrentTaxYear(CY)
 
           when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
           val sessionData = Some(OptOutSessionData(Some(buildOptOutContextData(crystallisedPY, statusPY, statusCY, statusNY)),
@@ -691,7 +691,7 @@ class OptOutServiceSpec extends UnitSpec
       s"PY is $statusPY, CY is $statusCY, NY is $statusNY and PY is ${if (!crystallisedPY) "NOT "}finalised" should {
         s"return  $viewModel" in {
 
-          when(mockDateService.getCurrentTaxYear).thenReturn(CY)
+          stubCurrentTaxYear(CY)
 
           when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
           val optOutSessionData = OptOutSessionData(Some(buildOptOutContextData(crystallisedPY, statusPY, statusCY, statusNY)),
@@ -715,6 +715,10 @@ class OptOutServiceSpec extends UnitSpec
     val previousYear = currentYear.previousYear
     val nextTaxYear = TaxYear.forYearEnd(currentTaxYearEnd + 1)
     (previousYear, currentYear, nextTaxYear)
+  }
+
+  private def stubCurrentTaxYear(currentYear: TaxYear): Unit = {
+    when(mockDateService.getCurrentTaxYear).thenReturn(currentYear)
   }
 
   private def stubItsaStatuses(previousYear: TaxYear, previousYearStatus: Value,

--- a/test/services/optout/OptOutServiceSpec.scala
+++ b/test/services/optout/OptOutServiceSpec.scala
@@ -346,7 +346,7 @@ class OptOutServiceSpec extends UnitSpec
 
         stubCrystallisedStatus(previousYear, false)
 
-        allowWriteOfOptOutDataToMongoToSucceed
+        allowWriteOfOptOutDataToMongoToSucceed()
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -370,7 +370,7 @@ class OptOutServiceSpec extends UnitSpec
 
         stubCrystallisedStatus(previousYear, true)
 
-        allowWriteOfOptOutDataToMongoToSucceed
+        allowWriteOfOptOutDataToMongoToSucceed()
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -393,7 +393,7 @@ class OptOutServiceSpec extends UnitSpec
 
         stubCrystallisedStatus(previousYear, false)
 
-        allowWriteOfOptOutDataToMongoToSucceed
+        allowWriteOfOptOutDataToMongoToSucceed()
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -416,7 +416,7 @@ class OptOutServiceSpec extends UnitSpec
 
         stubCrystallisedStatus(previousYear, false)
 
-        allowWriteOfOptOutDataToMongoToSucceed
+        allowWriteOfOptOutDataToMongoToSucceed()
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -439,7 +439,7 @@ class OptOutServiceSpec extends UnitSpec
 
           stubCrystallisedStatus(previousYear, false)
 
-          allowWriteOfOptOutDataToMongoToSucceed
+          allowWriteOfOptOutDataToMongoToSucceed()
 
           val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -467,7 +467,7 @@ class OptOutServiceSpec extends UnitSpec
 
             stubCrystallisedStatus(previousYear, false)
 
-            allowWriteOfOptOutDataToMongoToSucceed
+            allowWriteOfOptOutDataToMongoToSucceed()
 
             val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -528,7 +528,7 @@ class OptOutServiceSpec extends UnitSpec
       "ITSA Status from CY-1 till future years and Calculation State for CY-1 is available" should {
         "return NextUpdatesQuarterlyReportingContentCheck" in {
           // Because we're saving the status as well as building view models...
-          allowWriteOfOptOutDataToMongoToSucceed
+          allowWriteOfOptOutDataToMongoToSucceed()
 
           setupMockIsTaxYearCrystallisedCall(previousTaxYear)(Future.successful(crystallised))
           setupMockGetStatusTillAvailableFutureYears(previousTaxYear)(Future.successful(yearToStatus))

--- a/test/services/optout/OptOutServiceSpec.scala
+++ b/test/services/optout/OptOutServiceSpec.scala
@@ -344,7 +344,7 @@ class OptOutServiceSpec extends UnitSpec
           currentYear, NoStatus,
           nextYear, NoStatus)
 
-        mockCrystallisedStatus(previousYear, false)
+        stubCrystallisedStatus(previousYear, false)
 
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         when(repository.set(any())).thenReturn(Future.successful(true))
@@ -369,7 +369,7 @@ class OptOutServiceSpec extends UnitSpec
           currentYear, NoStatus,
           nextYear, NoStatus)
 
-        mockCrystallisedStatus(previousYear, true)
+        stubCrystallisedStatus(previousYear, true)
 
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         when(repository.set(any())).thenReturn(Future.successful(true))
@@ -393,7 +393,7 @@ class OptOutServiceSpec extends UnitSpec
           currentYear, Voluntary,
           nextYear, Mandated)
 
-        mockCrystallisedStatus(previousYear, false)
+        stubCrystallisedStatus(previousYear, false)
 
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         when(repository.set(any())).thenReturn(Future.successful(true))
@@ -417,7 +417,7 @@ class OptOutServiceSpec extends UnitSpec
           currentYear, NoStatus,
           nextYear, Voluntary)
 
-        mockCrystallisedStatus(previousYear, false)
+        stubCrystallisedStatus(previousYear, false)
 
         when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
         when(repository.set(any())).thenReturn(Future.successful(true))
@@ -441,7 +441,7 @@ class OptOutServiceSpec extends UnitSpec
             currentYear, Mandated,
             nextYear, Mandated)
 
-          mockCrystallisedStatus(previousYear, false)
+          stubCrystallisedStatus(previousYear, false)
 
           when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
           when(repository.set(any())).thenReturn(Future.successful(true))
@@ -470,7 +470,7 @@ class OptOutServiceSpec extends UnitSpec
               currentYear, Voluntary,
               nextYear, Mandated)
 
-            mockCrystallisedStatus(previousYear, false)
+            stubCrystallisedStatus(previousYear, false)
 
             when(hc.sessionId).thenReturn(Some(SessionId(sessionIdValue)))
             when(repository.set(any())).thenReturn(Future.successful(true))
@@ -500,7 +500,7 @@ class OptOutServiceSpec extends UnitSpec
 
           when(mockITSAStatusService.getStatusTillAvailableFutureYears(previousYear)).thenReturn(Future.failed(new RuntimeException("some api error")))
 
-          mockCrystallisedStatus(previousYear, false)
+          stubCrystallisedStatus(previousYear, false)
 
           val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -735,7 +735,7 @@ class OptOutServiceSpec extends UnitSpec
     when(mockITSAStatusService.getStatusTillAvailableFutureYears(previousYear)).thenReturn(Future.successful(taxYearStatusDetailMap))
   }
 
-  private def mockCrystallisedStatus(taxYear: TaxYear, crystallisedStatus: Boolean): Unit = {
+  private def stubCrystallisedStatus(taxYear: TaxYear, crystallisedStatus: Boolean): Unit = {
     when(mockCalculationListService.isTaxYearCrystallised(taxYear)).thenReturn(Future.successful(crystallisedStatus))
   }
 

--- a/test/services/optout/OptOutServiceSpec.scala
+++ b/test/services/optout/OptOutServiceSpec.scala
@@ -335,18 +335,12 @@ class OptOutServiceSpec extends UnitSpec
 
       "offer PY as OptOut Option" in {
 
-        val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = 2024)
-
-        stubCurrentTaxYear(currentYear)
-
-        stubItsaStatuses(
-          previousYear, Voluntary,
-          currentYear, NoStatus,
-          nextYear, NoStatus)
-
-        stubCrystallisedStatus(previousYear, false)
-
-        allowWriteOfOptOutDataToMongoToSucceed()
+        stubOptOut(
+          currentTaxYearEnd = 2024,
+          previousYearCrystallisedStatus = false,
+          previousTaxYearStatus = Voluntary,
+          currentTaxYearStatus = NoStatus,
+          nextTaxYearStatus = NoStatus)
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -359,18 +353,12 @@ class OptOutServiceSpec extends UnitSpec
 
       "offer No OptOut Option" in {
 
-        val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = 2024)
-
-        stubCurrentTaxYear(currentYear)
-
-        stubItsaStatuses(
-          previousYear, Voluntary,
-          currentYear, NoStatus,
-          nextYear, NoStatus)
-
-        stubCrystallisedStatus(previousYear, true)
-
-        allowWriteOfOptOutDataToMongoToSucceed()
+        stubOptOut(
+          currentTaxYearEnd = 2024,
+          previousYearCrystallisedStatus = true,
+          previousTaxYearStatus = Voluntary,
+          currentTaxYearStatus = NoStatus,
+          nextTaxYearStatus = NoStatus)
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -382,18 +370,12 @@ class OptOutServiceSpec extends UnitSpec
 
       "offer CY OptOut Option" in {
 
-        val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = 2024)
-
-        stubCurrentTaxYear(currentYear)
-
-        stubItsaStatuses(
-          previousYear, NoStatus,
-          currentYear, Voluntary,
-          nextYear, Mandated)
-
-        stubCrystallisedStatus(previousYear, false)
-
-        allowWriteOfOptOutDataToMongoToSucceed()
+        stubOptOut(
+          currentTaxYearEnd = 2024,
+          previousYearCrystallisedStatus = false,
+          previousTaxYearStatus = NoStatus,
+          currentTaxYearStatus = Voluntary,
+          nextTaxYearStatus = Mandated)
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -405,18 +387,12 @@ class OptOutServiceSpec extends UnitSpec
 
       "offer NY OptOut Option" in {
 
-        val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = 2024)
-
-        stubCurrentTaxYear(currentYear)
-
-        stubItsaStatuses(
-          previousYear, NoStatus,
-          currentYear, NoStatus,
-          nextYear, Voluntary)
-
-        stubCrystallisedStatus(previousYear, false)
-
-        allowWriteOfOptOutDataToMongoToSucceed()
+        stubOptOut(
+          currentTaxYearEnd = 2024,
+          previousYearCrystallisedStatus = false,
+          previousTaxYearStatus = NoStatus,
+          currentTaxYearStatus = NoStatus,
+          nextTaxYearStatus = Voluntary)
 
         val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -428,18 +404,12 @@ class OptOutServiceSpec extends UnitSpec
       s"PY : PY is $Voluntary, CY is $Mandated, NY is $Mandated and PY is NOT crystallised" should {
         s"offer PY OptOut Option with a warning as following year (CY) is $Mandated " in {
 
-          val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = 2024)
-
-          stubCurrentTaxYear(currentYear)
-
-          stubItsaStatuses(
-            previousYear, Voluntary,
-            currentYear, Mandated,
-            nextYear, Mandated)
-
-          stubCrystallisedStatus(previousYear, false)
-
-          allowWriteOfOptOutDataToMongoToSucceed()
+          val (previousYear, _, _) = stubOptOut(
+            currentTaxYearEnd = 2024,
+            previousYearCrystallisedStatus = false,
+            previousTaxYearStatus = Voluntary,
+            currentTaxYearStatus = Mandated,
+            nextTaxYearStatus = Mandated)
 
           val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -456,18 +426,12 @@ class OptOutServiceSpec extends UnitSpec
         s"CY : PY is $Mandated, CY is $Voluntary, NY is $Mandated " should {
           s"offer CY OptOut Option with a warning as following year (NY) is $Mandated " in {
 
-            val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = 2024)
-
-            stubCurrentTaxYear(currentYear)
-
-            stubItsaStatuses(
-              previousYear, Mandated,
-              currentYear, Voluntary,
-              nextYear, Mandated)
-
-            stubCrystallisedStatus(previousYear, false)
-
-            allowWriteOfOptOutDataToMongoToSucceed()
+            val (_, currentYear, _) = stubOptOut(
+              currentTaxYearEnd = 2024,
+              previousYearCrystallisedStatus = false,
+              previousTaxYearStatus = Mandated,
+              currentTaxYearStatus = Voluntary,
+              nextTaxYearStatus = Mandated)
 
             val response = service.nextUpdatesPageOptOutViewModels()
 
@@ -708,6 +672,28 @@ class OptOutServiceSpec extends UnitSpec
 
     }
 
+  }
+
+  private def stubOptOut(currentTaxYearEnd: Int,
+                         previousYearCrystallisedStatus: Boolean,
+                         previousTaxYearStatus: Value,
+                         currentTaxYearStatus: Value,
+                         nextTaxYearStatus: Value): (TaxYear, TaxYear, TaxYear) = {
+
+    val (previousYear, currentYear, nextYear) = taxYears(currentTaxYearEnd = currentTaxYearEnd)
+
+    stubCurrentTaxYear(currentYear)
+
+    stubItsaStatuses(
+      previousYear, previousTaxYearStatus,
+      currentYear, currentTaxYearStatus,
+      nextYear, nextTaxYearStatus)
+
+    stubCrystallisedStatus(previousYear, previousYearCrystallisedStatus)
+
+    allowWriteOfOptOutDataToMongoToSucceed()
+
+    (previousYear, currentYear, nextYear)
   }
 
   private def taxYears(currentTaxYearEnd: Int): (TaxYear, TaxYear, TaxYear) = {

--- a/test/services/optout/OptOutServiceSpec.scala
+++ b/test/services/optout/OptOutServiceSpec.scala
@@ -682,7 +682,7 @@ class OptOutServiceSpec extends UnitSpec
                          previousYearCrystallisedStatus: Boolean,
                          previousTaxYearStatus: Value,
                          currentTaxYearStatus: Value,
-                         nextTaxYearStatus: Value): (TaxYear, TaxYear, TaxYear) = {
+                         nextTaxYearStatus: Value): Unit = {
 
     val (previousYear, currentYear, nextYear) = taxYears(currentTaxYear)
 
@@ -696,8 +696,6 @@ class OptOutServiceSpec extends UnitSpec
     stubCrystallisedStatus(previousYear, previousYearCrystallisedStatus)
 
     allowWriteOfOptOutDataToMongoToSucceed()
-
-    (previousYear, currentYear, nextYear)
   }
 
   private def taxYears(currentYear: TaxYear): (TaxYear, TaxYear, TaxYear) = {


### PR DESCRIPTION
Prevents 2 calls to get Opt Out data when showing the Next Updates page.

This PR replaces [the previous PR](https://github.com/hmrc/income-tax-view-change-frontend/pull/2382) that now has too many conflicts to easily merge.