### PR TITLE
MISUV-7552:

### DIFF
--- a/app/services/claimToAdjustPoa/ClaimToAdjustHelper.scala
+++ b/app/services/claimToAdjustPoa/ClaimToAdjustHelper.scala
@@ -17,6 +17,7 @@
 package services.claimToAdjustPoa
 
 import auth.MtdItUser
+import cats.data.NonEmptyList
 import connectors.{CalculationListConnector, ChargeHistoryConnector}
 import exceptions.MissingFieldException
 import models.calculationList.{CalculationListErrorModel, CalculationListModel}
@@ -117,7 +118,7 @@ trait ClaimToAdjustHelper {
     }
   }
 
-  protected def checkCrystallisation(nino: Nino, taxYearList: List[TaxYear])
+  protected def checkCrystallisation(nino: Nino, taxYearList: NonEmptyList[TaxYear])
                                     (implicit hc: HeaderCarrier, dateService: DateServiceInterface,
                                      calculationListConnector: CalculationListConnector, ec: ExecutionContext): Future[Option[TaxYear]] = {
     taxYearList.foldLeft(Future.successful(Option.empty[TaxYear])) { (acc, item) =>
@@ -131,13 +132,14 @@ trait ClaimToAdjustHelper {
     }
   }
 
-  protected def getPoaAdjustableTaxYears(implicit dateService: DateServiceInterface): List[TaxYear] = {
+  // Sorted NonEmptyList with the TaxYear's
+  protected def getPoaAdjustableTaxYears(implicit dateService: DateServiceInterface): NonEmptyList[TaxYear] = {
     if (dateService.isAfterTaxReturnDeadlineButBeforeTaxYearEnd) {
-      List(
+      NonEmptyList.one(
         TaxYear.makeTaxYearWithEndYear(dateService.getCurrentTaxYearEnd)
       )
     } else {
-      List(
+      NonEmptyList.of(
         TaxYear.makeTaxYearWithEndYear(dateService.getCurrentTaxYearEnd).addYears(-1),
         TaxYear.makeTaxYearWithEndYear(dateService.getCurrentTaxYearEnd)
       ).sortBy(_.endYear)

--- a/test/testConstants/claimToAdjustPOA/ClaimToAdjustPOATestConstants.scala
+++ b/test/testConstants/claimToAdjustPOA/ClaimToAdjustPOATestConstants.scala
@@ -84,7 +84,7 @@ object ClaimToAdjustPOATestConstants {
   val userPOADetails2024: FinancialDetailsModel = FinancialDetailsModel(
     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None, None),
     documentDetails = List(genericDocumentDetailPOA1(2024), genericDocumentDetailPOA2(2024)),
-    financialDetails = List.empty,
+    financialDetails = List(genericFinancialDetailPOA1(2023, 150.00)),
   )
 
   def financialDetailsWithUnpaidPoAs(taxYearEnd: Int): FinancialDetailsModel = FinancialDetailsModel(
@@ -96,7 +96,7 @@ object ClaimToAdjustPOATestConstants {
   def genericUserPOADetails(taxYearEnd: Int): FinancialDetailsModel = FinancialDetailsModel(
     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None, None),
     documentDetails = List(genericDocumentDetailPOA1(taxYearEnd), genericDocumentDetailPOA2(taxYearEnd)),
-    financialDetails = List.empty,
+    financialDetails = List(genericFinancialDetailPOA1(2023, 150.00)),
   )
 
   def genericUserPOADetailsPOA1Only(taxYearEnd: Int): FinancialDetailsModel = FinancialDetailsModel(
@@ -126,7 +126,7 @@ object ClaimToAdjustPOATestConstants {
   val userNoPOADetails: FinancialDetailsModel = FinancialDetailsModel(
     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None, None),
     documentDetails = List.empty,
-    financialDetails = List.empty,
+    financialDetails = List(genericFinancialDetailPOA1(2023, 150.00)),
   )
 
   def financialDetailsErrorModel(errorCode: Int = 404): FinancialDetailsErrorModel = FinancialDetailsErrorModel(errorCode, "There was an error...")

--- a/test/testConstants/claimToAdjustPOA/ClaimToAdjustPOATestConstants.scala
+++ b/test/testConstants/claimToAdjustPOA/ClaimToAdjustPOATestConstants.scala
@@ -20,8 +20,6 @@ import models.claimToAdjustPoa.{PaymentOnAccountViewModel, WhatYouNeedToKnowView
 import models.core.NormalMode
 import models.financialDetails._
 import models.incomeSourceDetails.TaxYear
-import controllers.claimToAdjustPoa.SelectYourReasonController
-import controllers.claimToAdjustPoa.routes.SelectYourReasonController
 
 import java.time.LocalDate
 
@@ -114,19 +112,19 @@ object ClaimToAdjustPOATestConstants {
   val userPOADetails2023OnlyPOA1: FinancialDetailsModel = FinancialDetailsModel(
     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None, None),
     documentDetails = List(genericDocumentDetailPOA1(2023)),
-    financialDetails = List.empty,
+    financialDetails = List.empty
   )
 
   val userPOADetails2023OnlyPOA2: FinancialDetailsModel = FinancialDetailsModel(
     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None, None),
     documentDetails = List(genericDocumentDetailPOA2(2023)),
-    financialDetails = List.empty,
+    financialDetails = List.empty
   )
 
   val userNoPOADetails: FinancialDetailsModel = FinancialDetailsModel(
     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None, None),
     documentDetails = List.empty,
-    financialDetails = List(genericFinancialDetailPOA1(2023, 150.00)),
+    financialDetails = List.empty
   )
 
   def financialDetailsErrorModel(errorCode: Int = 404): FinancialDetailsErrorModel = FinancialDetailsErrorModel(errorCode, "There was an error...")


### PR DESCRIPTION
  * small refactoring as a part of analysis for the next story: MISUV-7552 (not in the sprint)
  ** use NonEmptyList when extracting list of candidate TaxYear's;
  ** remove boiler plate code with the use of EitherT in the next methods:
     getAmendablePoaViewModel;
  ** fix failing UTs: found issues in the tests data set up: 1553 ~FinancialDetails section is mandatory;
      