### PR TITLE
MISUV-7810-ctaService-getCH-fetch-poa-charge-not-head

### DIFF
--- a/app/services/claimToAdjustPoa/ClaimToAdjustHelper.scala
+++ b/app/services/claimToAdjustPoa/ClaimToAdjustHelper.scala
@@ -90,7 +90,7 @@ trait ClaimToAdjustHelper {
                                 (implicit hc: HeaderCarrier, user: MtdItUser[_], ec: ExecutionContext): Future[Either[Throwable, Option[ChargeHistoryModel]]] = {
     chargeHistoryConnector.getChargeHistory(user.nino, chargeReference).map {
       case ChargesHistoryModel(_, _, _, chargeHistoryDetails) => chargeHistoryDetails match {
-        case Some(detailsList) => Right(detailsList.headOption)
+        case Some(detailsList) => Right(extractPoaChargeHistory(detailsList))
         case None => Right(None)
       }
       case ChargesHistoryErrorModel(code, message) =>
@@ -187,5 +187,10 @@ trait ClaimToAdjustHelper {
         Logger("application").error("getChargeHistory returned a non-valid response")
         Left(new Exception(s"Error retrieving charge history code: $code message: $message"))
     }
+  }
+
+  private def extractPoaChargeHistory(chargeHistories: List[ChargeHistoryModel]): Option[ChargeHistoryModel] = {
+    // We are not differentiating between POA 1 & 2 as records for both should match since they are always amended together
+    chargeHistories.find(chargeHistoryModel => chargeHistoryModel.isPoA)
   }
 }

--- a/it/test/testConstants/IncomeSourceIntegrationTestConstants.scala
+++ b/it/test/testConstants/IncomeSourceIntegrationTestConstants.scala
@@ -1138,7 +1138,7 @@ object IncomeSourceIntegrationTestConstants {
         "taxYear" -> "2019",
         "documentId" -> documentId,
         "documentDate" -> "2018-02-14",
-        "documentDescription" -> "ITSA - POA 1",
+        "documentDescription" -> "ITSA- POA 1",
         "totalAmount" -> amount,
         "reversalDate" -> "2019-02-14",
         "reversalReason" -> "Customer Request",

--- a/it/test/testConstants/IncomeSourceIntegrationTestConstants.scala
+++ b/it/test/testConstants/IncomeSourceIntegrationTestConstants.scala
@@ -315,7 +315,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear,
         "transactionId" -> "1040000123",
-        "documentDescription" -> "ITSA- POA 1",
+        "documentDescription" -> poa1Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29"
@@ -426,7 +426,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000124",
-        "documentDescription" -> "ITSA- POA 1",
+        "documentDescription" -> poa1Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",
@@ -437,7 +437,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000125",
-        "documentDescription" -> "ITSA - POA 2",
+        "documentDescription" -> poa2Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",
@@ -541,7 +541,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000124",
-        "documentDescription" -> "ITSA- POA 1",
+        "documentDescription" -> poa1Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",
@@ -551,7 +551,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000125",
-        "documentDescription" -> "ITSA - POA 2",
+        "documentDescription" -> poa2Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",
@@ -657,7 +657,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000124",
-        "documentDescription" -> "ITSA- POA 1",
+        "documentDescription" -> poa1Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",
@@ -672,7 +672,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000125",
-        "documentDescription" -> "ITSA - POA 2",
+        "documentDescription" -> poa2Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",
@@ -747,7 +747,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000124",
-        "documentDescription" -> "ITSA- POA 1",
+        "documentDescription" -> poa1Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",
@@ -761,7 +761,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000125",
-        "documentDescription" -> "ITSA - POA 2",
+        "documentDescription" -> poa2Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",
@@ -896,7 +896,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000126",
-        "documentDescription" -> "ITSA - POA 2",
+        "documentDescription" -> poa2Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",
@@ -1017,7 +1017,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000124",
-        "documentDescription" -> "ITSA- POA 1",
+        "documentDescription" -> poa1Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",
@@ -1027,7 +1027,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000125",
-        "documentDescription" -> "ITSA - POA 2",
+        "documentDescription" -> poa2Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",
@@ -1129,6 +1129,9 @@ object IncomeSourceIntegrationTestConstants {
     "message" -> "ERROR MESSAGE"
   )
 
+  private val poa1Description: String = "ITSA- POA 1"
+  private val poa2Description: String = "ITSA - POA 2"
+
   def testChargeHistoryJson(mtdBsa: String, documentId: String, amount: BigDecimal): JsValue = Json.obj(
     "idType" -> "MTDBSA",
     "idValue" -> mtdBsa,
@@ -1138,7 +1141,7 @@ object IncomeSourceIntegrationTestConstants {
         "taxYear" -> "2019",
         "documentId" -> documentId,
         "documentDate" -> "2018-02-14",
-        "documentDescription" -> "ITSA- POA 1",
+        "documentDescription" -> poa1Description,
         "totalAmount" -> amount,
         "reversalDate" -> "2019-02-14",
         "reversalReason" -> "Customer Request",
@@ -1178,7 +1181,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000124",
-        "documentDescription" -> "ITSA- POA 1",
+        "documentDescription" -> poa1Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",
@@ -1187,7 +1190,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000125",
-        "documentDescription" -> "ITSA - POA 2",
+        "documentDescription" -> poa2Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",
@@ -1355,7 +1358,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000124",
-        "documentDescription" -> "ITSA- POA 1",
+        "documentDescription" -> poa1Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",
@@ -1364,7 +1367,7 @@ object IncomeSourceIntegrationTestConstants {
       Json.obj(
         "taxYear" -> taxYear.toInt,
         "transactionId" -> "1040000125",
-        "documentDescription" -> "ITSA - POA 2",
+        "documentDescription" -> poa2Description,
         "outstandingAmount" -> outstandingAmount,
         "originalAmount" -> originalAmount,
         "documentDate" -> "2018-03-29",

--- a/test/services/claimToAdjust/ClaimToAdjustServiceSpec.scala
+++ b/test/services/claimToAdjust/ClaimToAdjustServiceSpec.scala
@@ -89,13 +89,13 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
     financialDetails = List.empty
   )
 
-   def financialDetailsModelBothPoAsWithOutstandingAmount(taxYear: Int, outstandingAmount: BigDecimal): FinancialDetailsModel = {
-     val poaFinancialDetailsModel = genericUserPOADetails(taxYear)
-     poaFinancialDetailsModel
-       .copy(
-         documentDetails = poaFinancialDetailsModel.documentDetails.map(_.copy(outstandingAmount = outstandingAmount)),
-         financialDetails = List(genericFinancialDetailPOA1(taxYear, outstandingAmount), genericFinancialDetailPOA2(taxYear, outstandingAmount)))
-   }
+  def financialDetailsModelBothPoAsWithOutstandingAmount(taxYear: Int, outstandingAmount: BigDecimal): FinancialDetailsModel = {
+    val poaFinancialDetailsModel = genericUserPOADetails(taxYear)
+    poaFinancialDetailsModel
+      .copy(
+        documentDetails = poaFinancialDetailsModel.documentDetails.map(_.copy(outstandingAmount = outstandingAmount)),
+        financialDetails = List(genericFinancialDetailPOA1(taxYear, outstandingAmount), genericFinancialDetailPOA2(taxYear, outstandingAmount)))
+  }
 
   "getPoaTaxYearForEntryPoint method" should {
     "return a future of a right with an option containing a TaxYear" when {
@@ -235,9 +235,9 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
   "getAmendablePoaViewModel" should {
     "return a future right with AmendablePoaViewModel when POAs are unpaid" in {
 
-      val taxYear:Int = 2023
+      val taxYear: Int = 2023
 
-      val outstandingAmount:BigDecimal = 1250.0
+      val outstandingAmount: BigDecimal = 1250.0
 
       val chargeHistories: List[ChargeHistoryModel] = List(
         ChargeHistoryModel(s"$taxYear", "1040000124", LocalDate.of(taxYear, 2, 14), "ITSA- POA 1", 2500, LocalDate.of(taxYear + 1, 2, 14), "Customer Request", Some("001")),
@@ -258,25 +258,25 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
       val result = f.testClaimToAdjustService.getAmendablePoaViewModel(testUserNino)
 
       result.futureValue shouldBe Right(
-          PaymentOnAccountViewModel(
-            poaOneTransactionId = "DOCID01",
-            poaTwoTransactionId = "DOCID02",
-            taxYear = TaxYear(taxYear - 1, taxYear),
-            previouslyAdjusted = Some(true),
-            totalAmountOne = 150.00,
-            totalAmountTwo = 250.00,
-            relevantAmountOne = 100.00,
-            relevantAmountTwo = 100.00,
-            partiallyPaid = true,
-            fullyPaid = false))
-      }
+        PaymentOnAccountViewModel(
+          poaOneTransactionId = "DOCID01",
+          poaTwoTransactionId = "DOCID02",
+          taxYear = TaxYear(taxYear - 1, taxYear),
+          previouslyAdjusted = Some(true),
+          totalAmountOne = 150.00,
+          totalAmountTwo = 250.00,
+          relevantAmountOne = 100.00,
+          relevantAmountTwo = 100.00,
+          partiallyPaid = true,
+          fullyPaid = false))
+    }
 
 
     "return a future right with AmendablePoaViewModel when POAs are paid" in {
 
-      val taxYear:Int = 2023
+      val taxYear: Int = 2023
 
-      val outstandingAmount:BigDecimal = 0.0
+      val outstandingAmount: BigDecimal = 0.0
 
       val chargeHistories: List[ChargeHistoryModel] = List(
         ChargeHistoryModel(s"$taxYear", "1040000124", LocalDate.of(taxYear, 2, 14), "ITSA- POA 1", 2500, LocalDate.of(taxYear + 1, 2, 14), "Customer Request", Some("001")),
@@ -297,23 +297,23 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
       val result = f.testClaimToAdjustService.getAmendablePoaViewModel(testUserNino)
 
       result.futureValue shouldBe Right(
-          PaymentOnAccountViewModel(
-            poaOneTransactionId = "DOCID01",
-            poaTwoTransactionId = "DOCID02",
-            taxYear = TaxYear(taxYear - 1, taxYear),
-            previouslyAdjusted = Some(true),
-            totalAmountOne = 150.00,
-            totalAmountTwo = 250.00,
-            relevantAmountOne = 100.00,
-            relevantAmountTwo = 100.00,
-            partiallyPaid = true,
-            fullyPaid = true))
+        PaymentOnAccountViewModel(
+          poaOneTransactionId = "DOCID01",
+          poaTwoTransactionId = "DOCID02",
+          taxYear = TaxYear(taxYear - 1, taxYear),
+          previouslyAdjusted = Some(true),
+          totalAmountOne = 150.00,
+          totalAmountTwo = 250.00,
+          relevantAmountOne = 100.00,
+          relevantAmountTwo = 100.00,
+          partiallyPaid = true,
+          fullyPaid = true))
 
     }
 
     "return a future left with an exception when an exception is thrown" in {
 
-      val taxYear:Int = 2023
+      val taxYear: Int = 2023
 
       setupGetCalculationList(testNino, "22-23")(calculationListSuccessResponseModelNonCrystallised)
 
@@ -343,7 +343,7 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
 
     "return a future right with PoAAmountViewModel when POAs are unpaid" in {
 
-      val taxYear:Int = 2023
+      val taxYear: Int = 2023
 
       val chargeHistories: List[ChargeHistoryModel] = List(
         ChargeHistoryModel(s"$taxYear", "1040000124", LocalDate.of(taxYear, 2, 14), "ITSA- POA 1", 2500, LocalDate.of(taxYear + 1, 2, 14), "Customer Request", Some("001")),
@@ -370,9 +370,9 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
 
     "return a future right with PoAAmountViewModel when POAs are paid" in {
 
-      val taxYear:Int = 2023
+      val taxYear: Int = 2023
 
-      val outstandingAmount:BigDecimal = 0.0
+      val outstandingAmount: BigDecimal = 0.0
 
       val chargeHistories: List[ChargeHistoryModel] = List(
         ChargeHistoryModel(s"$taxYear", "1040000124", LocalDate.of(taxYear, 2, 14), "ITSA- POA 1", 2500, LocalDate.of(taxYear + 1, 2, 14), "Customer Request", Some("001")),

--- a/test/services/claimToAdjust/ClaimToAdjustServiceSpec.scala
+++ b/test/services/claimToAdjust/ClaimToAdjustServiceSpec.scala
@@ -351,7 +351,7 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
     }
   }
 
-  "getEnterPoAAmountViewModel" should {
+  "getPoaViewModelWithAdjustmentReason" should {
 
     "return a future right with PoAAmountViewModel when POAs are unpaid" in {
 
@@ -438,6 +438,37 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
           result.isLeft shouldBe true
           result.left.exists(_.getMessage == "No financial details found for this charge") shouldBe true
         }
+      }
+    }
+
+    "return a future right with PoAAmountViewModel when POAs are not at the head of the list of charges" in {
+
+      val taxYear: Int = 2023
+
+      val chargeHistoriesNoPoaAtHead: List[ChargeHistoryModel] = List(
+        chargeHistoryModelNoPOA(taxYear),
+        ChargeHistoryModel(s"$taxYear", "1040000124", LocalDate.of(taxYear, 2, 14), "ITSA- POA 1", 2500, LocalDate.of(taxYear + 1, 2, 14), "Customer Request", Some("001")),
+        ChargeHistoryModel(s"$taxYear", "1040000125", LocalDate.of(taxYear, 2, 14), "ITSA - POA 2", 2500, LocalDate.of(taxYear + 1, 2, 14), "Customer Request", Some("002")))
+
+      setupGetCalculationList(testNino, "22-23")(calculationListSuccessResponseModelNonCrystallised)
+
+      setupGetChargeHistory(testNino, Some("ABCD1234"))(ChargesHistoryModel(
+        idType = "NINO",
+        idValue = testNino,
+        regimeType = "ITSA",
+        chargeHistoryDetails = Some(chargeHistoriesNoPoaAtHead)
+      ))
+
+      setupMockGetFinancialDetails(taxYear, testNino)(financialDetailsWithUnpaidPoAs(taxYear))
+
+      val f = fixture(LocalDate.of(taxYear, 8, 27))
+
+      val result = f.testClaimToAdjustService.getPoaViewModelWithAdjustmentReason(testUserNino)
+
+      whenReady(result) {
+        result =>
+          result shouldBe Right(
+            PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2022, 2023), 150.00, 250.00, 100.00, 100.00, Some(true), false, false))
       }
     }
   }

--- a/test/services/claimToAdjust/ClaimToAdjustServiceSpec.scala
+++ b/test/services/claimToAdjust/ClaimToAdjustServiceSpec.scala
@@ -34,7 +34,8 @@ import uk.gov.hmrc.auth.core.AffinityGroup.Individual
 import java.time.LocalDate
 import scala.language.reflectiveCalls
 
-class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConnector with MockChargeHistoryConnector with MockFinancialDetailsService with MockCalculationListConnector {
+class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConnector with MockChargeHistoryConnector
+  with MockFinancialDetailsService with MockCalculationListConnector {
 
   def fixture(date: LocalDate) = new {
     implicit val mockDateService: DateService = new DateService {
@@ -88,7 +89,7 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
     financialDetails = List.empty
   )
 
-   def financialDetailsModelBothPoAsWithOutstandingAmount(taxYear: Int, outstandingAmount: BigDecimal) = {
+   def financialDetailsModelBothPoAsWithOutstandingAmount(taxYear: Int, outstandingAmount: BigDecimal): FinancialDetailsModel = {
      val poaFinancialDetailsModel = genericUserPOADetails(taxYear)
      poaFinancialDetailsModel
        .copy(
@@ -107,9 +108,8 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
         val f = fixture(LocalDate.of(2023, 8, 27))
         val result = f.testClaimToAdjustService.getPoaTaxYearForEntryPoint(testUserNino)
 
-        whenReady(result) {
-          result => result shouldBe Right(Some(TaxYear(startYear = 2022, endYear = 2023)))
-        }
+        result.futureValue shouldBe Right(Some(TaxYear(startYear = 2022, endYear = 2023)))
+
       }
       "a user has two sets of document details relating to PoA data. The second year is a CTA amendable year. Only the second year is non-crystallised" in {
         setupGetCalculationList(testNino, "22-23")(calculationListSuccessResponseModelCrystallised)
@@ -120,9 +120,8 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
         val f = fixture(LocalDate.of(2023, 8, 27))
         val result = f.testClaimToAdjustService.getPoaTaxYearForEntryPoint(testUserNino)
 
-        whenReady(result) {
-          result => result shouldBe Right(Some(TaxYear(startYear = 2023, endYear = 2024)))
-        }
+        result.futureValue shouldBe Right(Some(TaxYear(startYear = 2023, endYear = 2024)))
+
       }
       "a user has only one CTA amendable year. This year has POA data and is not crystallised" in {
         setupGetCalculationList(testNino, "23-24")(calculationListSuccessResponseModelNonCrystallised)
@@ -131,9 +130,8 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
         val f = fixture(LocalDate.of(2024, 4, 1))
         val result = f.testClaimToAdjustService.getPoaTaxYearForEntryPoint(testUserNino)
 
-        whenReady(result) {
-          result => result shouldBe Right(Some(TaxYear(startYear = 2023, endYear = 2024)))
-        }
+        result.futureValue shouldBe Right(Some(TaxYear(startYear = 2023, endYear = 2024)))
+
       }
     }
     "return a future right which is empty" when {
@@ -146,9 +144,8 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
         val f = fixture(LocalDate.of(2023, 8, 27))
         val result = f.testClaimToAdjustService.getPoaTaxYearForEntryPoint(testUserNino)
 
-        whenReady(result) {
-          result => result shouldBe Right(None)
-        }
+        result.futureValue shouldBe Right(None)
+
       }
     }
     "return an exception" when {
@@ -162,9 +159,8 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
         val f = fixture(LocalDate.of(2023, 8, 27))
         val result = f.testClaimToAdjustService.getPoaTaxYearForEntryPoint(testUserNino)
 
-        whenReady(result) {
-          result => result.toString shouldBe Left(new Exception("There was an error whilst fetching financial details data")).toString
-        }
+        result.futureValue.toString shouldBe Left(new Exception("There was an error whilst fetching financial details data")).toString
+
       }
     }
   }
@@ -180,9 +176,8 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
         val f = fixture(LocalDate.of(2023, 8, 27))
         val result = f.testClaimToAdjustService.getPoaForNonCrystallisedTaxYear(testUserNino)
 
-        whenReady(result) {
-          result => result shouldBe Right(Some(PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2022, 2023), 150.00, 250.00, 100.00, 100.00, None, false, false)))
-        }
+        result.futureValue shouldBe Right(Some(PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2022, 2023), 150.00, 250.00, 100.00, 100.00, None, partiallyPaid = false, fullyPaid = false)))
+
       }
       "a user has two sets of document details relating to PoA data. The second year is a CTA amendable year. Only the second year is non-crystallised" in {
         setupGetCalculationList(testNino, "22-23")(calculationListSuccessResponseModelCrystallised)
@@ -193,9 +188,8 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
         val f = fixture(LocalDate.of(2023, 8, 27))
         val result = f.testClaimToAdjustService.getPoaForNonCrystallisedTaxYear(testUserNino)
 
-        whenReady(result) {
-          result => result shouldBe Right(Some(PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2023, 2024), 150.00, 250.00, 100.00, 100.00, None, false, false)))
-        }
+        result.futureValue shouldBe Right(Some(PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2023, 2024), 150.00, 250.00, 100.00, 100.00, None, partiallyPaid = false, fullyPaid = false)))
+
       }
       "a user has only one CTA amendable year. This year has POA data and is not crystallised" in {
         setupGetCalculationList(testNino, "23-24")(calculationListSuccessResponseModelNonCrystallised)
@@ -203,9 +197,8 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
 
         val f = fixture(LocalDate.of(2024, 4, 1))
         val result = f.testClaimToAdjustService.getPoaForNonCrystallisedTaxYear(testUserNino)
-        whenReady(result) {
-          result => result shouldBe Right(Some(PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2023, 2024), 150.00, 250.00, 100.00, 100.00, None, false, false)))
-        }
+        result.futureValue shouldBe Right(Some(PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2023, 2024), 150.00, 250.00, 100.00, 100.00, None, partiallyPaid = false, fullyPaid = false)))
+
       }
     }
     "return a future right which is empty" when {
@@ -218,9 +211,8 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
         val f = fixture(LocalDate.of(2023, 8, 27))
         val result = f.testClaimToAdjustService.getPoaForNonCrystallisedTaxYear(testUserNino)
 
-        whenReady(result) {
-          result => result shouldBe Right(None)
-        }
+        result.futureValue shouldBe Right(None)
+
       }
     }
     "return an exception" when {
@@ -234,9 +226,8 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
         val f = fixture(LocalDate.of(2023, 8, 27))
         val result = f.testClaimToAdjustService.getPoaForNonCrystallisedTaxYear(testUserNino)
 
-        whenReady(result) {
-          result => result.toString shouldBe Left(new Exception("There was an error whilst fetching financial details data")).toString
-        }
+        result.futureValue.toString shouldBe Left(new Exception("There was an error whilst fetching financial details data")).toString
+
       }
     }
   }
@@ -266,8 +257,7 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
       val f = fixture(LocalDate.of(taxYear, 8, 27))
       val result = f.testClaimToAdjustService.getAmendablePoaViewModel(testUserNino)
 
-      whenReady(result) {
-        result => result shouldBe Right(
+      result.futureValue shouldBe Right(
           PaymentOnAccountViewModel(
             poaOneTransactionId = "DOCID01",
             poaTwoTransactionId = "DOCID02",
@@ -280,7 +270,7 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
             partiallyPaid = true,
             fullyPaid = false))
       }
-    }
+
 
     "return a future right with AmendablePoaViewModel when POAs are paid" in {
 
@@ -306,8 +296,7 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
       val f = fixture(LocalDate.of(taxYear, 8, 27))
       val result = f.testClaimToAdjustService.getAmendablePoaViewModel(testUserNino)
 
-      whenReady(result) {
-        result => result shouldBe Right(
+      result.futureValue shouldBe Right(
           PaymentOnAccountViewModel(
             poaOneTransactionId = "DOCID01",
             poaTwoTransactionId = "DOCID02",
@@ -319,7 +308,7 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
             relevantAmountTwo = 100.00,
             partiallyPaid = true,
             fullyPaid = true))
-      }
+
     }
 
     "return a future left with an exception when an exception is thrown" in {
@@ -340,14 +329,13 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
       ))
 
       val f = fixture(LocalDate.of(taxYear, 8, 27))
-      val result = f.testClaimToAdjustService.getAmendablePoaViewModel(testUserNino)
+      val futureResult = f.testClaimToAdjustService.getAmendablePoaViewModel(testUserNino)
 
-      whenReady(result) {
-        result => {
-          result.isLeft shouldBe true
-          result.left.exists(_.getMessage == "Failed to retrieve non-crystallised financial details") shouldBe true
-        }
-      }
+      val result = futureResult.futureValue
+
+      result.isLeft shouldBe true
+      result.left.exists(_.getMessage == "Failed to retrieve non-crystallised financial details") shouldBe true
+
     }
   }
 
@@ -376,10 +364,8 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
 
       val result = f.testClaimToAdjustService.getPoaViewModelWithAdjustmentReason(testUserNino)
 
-      whenReady(result) {
-        result => result shouldBe Right(
-          PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2022, 2023), 150.00, 250.00, 100.00, 100.00, Some(true), false, false))
-      }
+      result.futureValue shouldBe Right(PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2022, 2023), 150.00, 250.00, 100.00, 100.00, Some(true), partiallyPaid = false, fullyPaid = false))
+
     }
 
     "return a future right with PoAAmountViewModel when POAs are paid" in {
@@ -407,10 +393,8 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
 
       val result = f.testClaimToAdjustService.getPoaViewModelWithAdjustmentReason(testUserNino)
 
-      whenReady(result) {
-        result => result shouldBe Right(
-          PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2022, 2023), 150.00, 250.00, 100.00, 100.00, Some(true), true, true))
-      }
+      result.futureValue shouldBe Right(PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2022, 2023), 150.00, 250.00, 100.00, 100.00, Some(true), partiallyPaid = true, fullyPaid = true))
+
     }
 
     "return a future left with an exception when an exception is thrown" in {
@@ -431,14 +415,13 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
       ))
 
       val f = fixture(LocalDate.of(taxYear, 8, 27))
-      val result = f.testClaimToAdjustService.getPoaViewModelWithAdjustmentReason(testUserNino)
+      val futureResult = f.testClaimToAdjustService.getPoaViewModelWithAdjustmentReason(testUserNino)
 
-      whenReady(result) {
-        result => {
-          result.isLeft shouldBe true
-          result.left.exists(_.getMessage == "No financial details found for this charge") shouldBe true
-        }
-      }
+      val result = futureResult.futureValue
+
+      result.isLeft shouldBe true
+      result.left.exists(_.getMessage == "No financial details found for this charge") shouldBe true
+
     }
 
     "return a future right with PoAAmountViewModel when POA 1 is not at the head of the list of charges" in {
@@ -464,11 +447,8 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
 
       val result = f.testClaimToAdjustService.getPoaViewModelWithAdjustmentReason(testUserNino)
 
-      whenReady(result) {
-        result =>
-          result shouldBe Right(
-            PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2022, 2023), 150.00, 250.00, 100.00, 100.00, Some(true), false, false))
-      }
+      result.futureValue shouldBe Right(PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2022, 2023), 150.00, 250.00, 100.00, 100.00, Some(true), partiallyPaid = false, fullyPaid = false))
+
     }
     "return a future right with PoAAmountViewModel when POA 2 is not at the head of the list of charges" in {
 
@@ -493,11 +473,7 @@ class ClaimToAdjustServiceSpec extends TestSupport with MockFinancialDetailsConn
 
       val result = f.testClaimToAdjustService.getPoaViewModelWithAdjustmentReason(testUserNino)
 
-      whenReady(result) {
-        result =>
-          result shouldBe Right(
-            PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2022, 2023), 150.00, 250.00, 100.00, 100.00, Some(true), false, false))
-      }
+      result.futureValue shouldBe Right(PaymentOnAccountViewModel("DOCID01", "DOCID02", TaxYear(2022, 2023), 150.00, 250.00, 100.00, 100.00, Some(true), partiallyPaid = false, fullyPaid = false))
     }
   }
 }

--- a/test/testConstants/claimToAdjustPOA/ClaimToAdjustPOATestConstants.scala
+++ b/test/testConstants/claimToAdjustPOA/ClaimToAdjustPOATestConstants.scala
@@ -22,6 +22,7 @@ import models.financialDetails._
 import models.incomeSourceDetails.TaxYear
 import controllers.claimToAdjustPoa.SelectYourReasonController
 import controllers.claimToAdjustPoa.routes.SelectYourReasonController
+import models.chargeHistory.ChargeHistoryModel
 
 import java.time.LocalDate
 
@@ -149,5 +150,7 @@ object ClaimToAdjustPOATestConstants {
   val fixedDate: LocalDate = LocalDate.of(2023, 12, 15)
 
   def whatYouNeedToKnowViewModel(isAgent: Boolean, showIncreaseAfterPaymentContent: Boolean): WhatYouNeedToKnowViewModel = WhatYouNeedToKnowViewModel(poaTaxYear = TaxYear(fixedDate.getYear, fixedDate.getYear + 1), showIncreaseAfterPaymentContent, controllers.claimToAdjustPoa.routes.SelectYourReasonController.show(isAgent, NormalMode).url)
+
+  def chargeHistoryModelNoPOA(taxYear: Int): ChargeHistoryModel = ChargeHistoryModel(s"${taxYear.toString}", "1040000124", LocalDate.of(taxYear, 7, 6), "documentDescription", 1500, LocalDate.of(2018, 7, 6), "amended return", None)
 
 }


### PR DESCRIPTION
amended the getChargeHistory method in ClaimToAdjustHelper to fetch only POA charge histories, rather than just grabbing the item at the top of the list