### PR TITLE
MISUV-7973 Payment, credit and refund history tax year font size should match V&C service pages

### DIFF
--- a/app/views/PaymentHistory.scala.html
+++ b/app/views/PaymentHistory.scala.html
@@ -88,7 +88,7 @@ btaNavPartial: Option[Html] = None, origin: Option[String] = None)(implicit requ
                     </a>
                     @if(payment.isCredit) {
                     <br>
-                    <a class="govuk-text" style="font-size: 16.5px;">
+                    <a class="govuk-body-s">
                         @messages("paymentHistory.taxYear", payment.getTaxYear.startYear.toString, payment.getTaxYear.endYear.toString)
                     </a>
                     }

--- a/app/views/PaymentHistory.scala.html
+++ b/app/views/PaymentHistory.scala.html
@@ -88,7 +88,7 @@ btaNavPartial: Option[Html] = None, origin: Option[String] = None)(implicit requ
                     </a>
                     @if(payment.isCredit) {
                     <br>
-                    <a class="govuk-text">
+                    <a class="govuk-text" style="font-size: 16.5px;">
                         @messages("paymentHistory.taxYear", payment.getTaxYear.startYear.toString, payment.getTaxYear.endYear.toString)
                     </a>
                     }


### PR DESCRIPTION
Added a short line in the view page to change the font size to 16.5 for the tax year credits