### PR TITLE
WIP => Time machine fs dynamic load

### DIFF
--- a/app/actors/TimeMachineMonitorActor.scala
+++ b/app/actors/TimeMachineMonitorActor.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package actors
+
+import com.typesafe.config.ConfigFactory
+import org.apache.pekko.actor.{Actor, Props}
+import play.api.{Configuration, Logger}
+import repositories.admin.FeatureSwitchRepository
+
+object TimeMachineMonitorActor {
+  def props(config: Configuration, featureSwitchRepository: FeatureSwitchRepository): Props =
+    Props[TimeMachineMonitorActor](new TimeMachineMonitorActor(config, featureSwitchRepository))
+  private case object Realod
+}
+
+// TODO: avoid using classical Actors / use Typed version instead
+class TimeMachineMonitorActor(val config: Configuration) extends Actor  {
+  import TimeMachineMonitorActor._
+  import scala.concurrent.duration._
+
+  context.system.scheduler.scheduleOnce(5.seconds, self, Realod)(context.dispatcher)
+
+  def receive = {
+    case Realod  =>
+      Logger("application").info("TimeMachineMonitorActor -> reload")
+
+      // TODO: call FeatureSwitch Service
+      System.setProperty("feature-switch.enable-time-machine", "true")
+      ConfigFactory.invalidateCaches()
+      val cfg = ConfigFactory.load(config.underlying)
+      val newConfig = cfg.getConfig("feature-switch")
+      val fsTimeMachine = newConfig.getString("enable-time-machine")
+      Logger("application").info(s"TimeMachineMonitorActor -> $fsTimeMachine")
+
+
+
+      context.system.scheduler.scheduleOnce(5.seconds, self, Realod)(context.dispatcher)
+  }
+
+  /*
+
+System.setProperty("a.b.c", "100")
+ConfigFactory.invalidateCaches()
+val config = ConfigFactory.load("sample1")
+config.getDouble("a.b.c") should be (100.0)
+
+   */
+}

--- a/app/actors/TimeMachineMonitorActor.scala
+++ b/app/actors/TimeMachineMonitorActor.scala
@@ -75,7 +75,8 @@ class TimeMachineMonitorActor(val config: Configuration,
       getTimeMachineFs()
         .map(_ => WaitForNew).pipeTo(self)
 
-    // TODO: call FeatureSwitch Service
+    // Original example how to reload TypeSafe config
+    //  https://stackoverflow.com/questions/52557484/how-to-refresh-application-conf-at-runtime
     //      System.setProperty("feature-switch.enable-time-machine", "true")
     //      ConfigFactory.invalidateCaches()
     //      val cfg = ConfigFactory.load(config.underlying)

--- a/app/actors/TimeMachineMonitorActor.scala
+++ b/app/actors/TimeMachineMonitorActor.scala
@@ -51,6 +51,8 @@ class TimeMachineMonitorActor(val config: Configuration,
       .getFeatureSwitch(TimeMachine)
       .flatMap { res =>
         Logger("application").info(s"TimeMachineMonitorActor -> response from FeatureSwitchRepository ${res}")
+
+        // TODO: add logic to apply Config reload/invalidate on the actual change!!!!
         if (res.map(_.isEnabled).getOrElse(false)) {
           Logger("application").info("TimeMachineMonitorActor -> attempt to set to True")
           System.setProperty("feature-switch.enable-time-machine", "true")
@@ -60,7 +62,9 @@ class TimeMachineMonitorActor(val config: Configuration,
           val fsTimeMachine = newConfig.getString("enable-time-machine")
           Logger("application").info(s"TimeMachineMonitorActor -> $fsTimeMachine")
         } else {
-          Logger("application").info("TimeMachineMonitorActor -> is False in mongo")
+          System.setProperty("feature-switch.enable-time-machine", "false")
+          ConfigFactory.invalidateCaches()
+          Logger("application").info("TimeMachineMonitorActor -> set TimeMachine to false")
         }
         Future.successful(())
       }

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -57,6 +57,9 @@ class HomeController @Inject()(val homeView: views.html.Home,
                                val appConfig: FrontendAppConfig) extends ClientConfirmedController with I18nSupport with FeatureSwitching {
 
   def show(origin: Option[String] = None): Action[AnyContent] = auth.authenticatedAction(isAgent = false) {
+
+    val date = dateService.getCurrentDate
+    Logger("application").error(s"TimeMachine::CurrentDate => $date")
     implicit user =>
       handleShowRequest(isAgent = false, origin)
   }

--- a/app/models/admin/FeatureSwitchName.scala
+++ b/app/models/admin/FeatureSwitchName.scala
@@ -67,6 +67,8 @@ object FeatureSwitchName {
       JsSuccess(OptOut)
     case name if name == JsString(AdjustPaymentsOnAccount.name) =>
       JsSuccess(AdjustPaymentsOnAccount)
+    case name if name == JsString(TimeMachine.name) =>
+      JsSuccess(TimeMachine)
     case _ => JsError("Invalid feature switch name")
   }
 
@@ -91,7 +93,8 @@ object FeatureSwitchName {
   val allFeatureSwitches: immutable.Set[FeatureSwitchName] =
     Set(ITSASubmissionIntegration, ChargeHistory, PaymentAllocation, CodingOut, NavBarFs,
       ForecastCalculation, CutOverCredits, CreditsRefundsRepay, WhatYouOweCreditAmount, MFACreditsAndDebits,
-      PaymentHistoryRefunds, CalendarQuarterTypes, IncomeSourcesNewJourney, IncomeSources, OptOut, AdjustPaymentsOnAccount)
+      PaymentHistoryRefunds, CalendarQuarterTypes, IncomeSourcesNewJourney,
+      IncomeSources, OptOut, AdjustPaymentsOnAccount, TimeMachine)
 
 
   def get(str: String): Option[FeatureSwitchName] = allFeatureSwitches find (_.name == str)
@@ -175,6 +178,11 @@ case object OptOut extends FeatureSwitchName {
 case object AdjustPaymentsOnAccount extends FeatureSwitchName {
   override val name: String = s"adjust-payments-on-account"
   override val toString: String = "Adjust Payments On Account"
+}
+
+case object TimeMachine extends FeatureSwitchName {
+  override val name: String = s"time-machine"
+  override val toString: String = "Time-Machine"
 }
 
 object FeatureSwitchMongoFormats {

--- a/app/services/DateService.scala
+++ b/app/services/DateService.scala
@@ -17,8 +17,10 @@
 package services
 
 import com.google.inject.ImplementedBy
+import com.typesafe.config.ConfigFactory
 import config.{FrontendAppConfig, TimeMachine}
 import models.incomeSourceDetails.TaxYear
+import play.api.Logger
 
 import java.time.LocalDate
 import java.time.Month.{APRIL, JANUARY}
@@ -31,7 +33,17 @@ class DateService @Inject()(implicit val frontendAppConfig: FrontendAppConfig) e
   override protected def now(): LocalDate = LocalDate.now()
 
   override def getCurrentDate: LocalDate = {
-    if (getTimeMachineConfig.isTimeMachineEnabled) {
+    // Attempt to reload Config everytime
+    // Q1: Is that thread safe?
+    // Q2: Performance ???
+
+    val cfg = ConfigFactory.load(frontendAppConfig.config.underlying)
+    val newConfig = cfg.getConfig("feature-switch")
+    val fsTimeMachine = newConfig.getString("enable-time-machine")
+    Logger("application").info(s"TimeMachine::Config -> ${fsTimeMachine}")
+
+    if ( fsTimeMachine.toBoolean){
+    //if (getTimeMachineConfig.isTimeMachineEnabled) {
       now()
         .plusYears(getTimeMachineConfig.addYears)
         .plusDays(getTimeMachineConfig.addDays)

--- a/app/services/admin/FeatureSwitchService.scala
+++ b/app/services/admin/FeatureSwitchService.scala
@@ -16,11 +16,13 @@
 
 package services.admin
 
+import actors.TimeMachineMonitorActor
 import config.featureswitch.FeatureSwitching
 import config.{AgentItvcErrorHandler, FrontendAppConfig, ItvcErrorHandler}
 import controllers.agent.predicates.ClientConfirmedController
 import models.admin.{FeatureSwitch, FeatureSwitchName}
-import play.api.Logger
+import org.apache.pekko.actor.ActorSystem
+import play.api.{Configuration, Logger}
 import play.api.mvc.MessagesControllerComponents
 import repositories.admin.FeatureSwitchRepository
 import uk.gov.hmrc.auth.core.AuthorisedFunctions
@@ -32,11 +34,15 @@ import scala.concurrent.{ExecutionContext, Future}
 class FeatureSwitchService @Inject()(
                                       val featureSwitchRepository: FeatureSwitchRepository,
                                       val authorisedFunctions: AuthorisedFunctions,
-                                      val appConfig: FrontendAppConfig)
+                                      val appConfig: FrontendAppConfig,
+                                      val config: Configuration,
+                                      system: ActorSystem)
                                     (implicit val ec: ExecutionContext,
                                      mcc: MessagesControllerComponents,
                                      implicit val itvcErrorHandler: ItvcErrorHandler,
                                      implicit val itvcErrorHandlerAgent: AgentItvcErrorHandler) extends ClientConfirmedController with FeatureSwitching {
+
+  val timeMachineActor = system.actorOf(TimeMachineMonitorActor.props(config), "timeMachine-actor")
 
   def get(featureSwitchName: FeatureSwitchName): Future[FeatureSwitch] =
     featureSwitchRepository

--- a/app/services/admin/FeatureSwitchService.scala
+++ b/app/services/admin/FeatureSwitchService.scala
@@ -42,7 +42,7 @@ class FeatureSwitchService @Inject()(
                                      implicit val itvcErrorHandler: ItvcErrorHandler,
                                      implicit val itvcErrorHandlerAgent: AgentItvcErrorHandler) extends ClientConfirmedController with FeatureSwitching {
 
-  val timeMachineActor = system.actorOf(TimeMachineMonitorActor.props(config), "timeMachine-actor")
+  val timeMachineActor = system.actorOf(TimeMachineMonitorActor.props(config, featureSwitchRepository), "timeMachine-actor")
 
   def get(featureSwitchName: FeatureSwitchName): Future[FeatureSwitch] =
     featureSwitchRepository

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -187,7 +187,7 @@ feature-switch {
 #  In the Staging Environment, this will be flipped to true
 #  Therefore changing the state of FS(s) will be easier during demos
 feature-switches {
-  read-from-mongo = false
+  read-from-mongo = true
 }
 
 mongodb {


### PR DESCRIPTION
* Yet another attempt to enable TimeMachine FS at runtime / without restarting application;
* Disadvantages: call to mongoDb every n seconds ( 5 seconds at the moment);
* Threads safety and performance concern around TypeSafe Config as its accessed by different threads;
