### PR TITLE
MISUV-8145 | Merge Agent and Individual Auth

### DIFF
--- a/app/auth/MtdItUser.scala
+++ b/app/auth/MtdItUser.scala
@@ -21,10 +21,7 @@ import models.incomeSourceDetails.IncomeSourceDetailsModel
 import play.api.mvc.{Request, WrappedRequest}
 import play.twirl.api.Html
 import uk.gov.hmrc.auth.core.AffinityGroup
-import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Individual}
 import uk.gov.hmrc.auth.core.retrieve.Name
-
-import javax.inject.Inject
 
 abstract class MtdItUserBase[A](implicit request: Request[A]) extends WrappedRequest[A](request) {
   def mtditid: String

--- a/app/auth/authV2/AuthActions.scala
+++ b/app/auth/authV2/AuthActions.scala
@@ -37,7 +37,7 @@ class AuthActions @Inject()(val checkSessionTimeout: SessionTimeoutPredicateV2,
                            (implicit val appConfig: FrontendAppConfig,
                                      val ec: ExecutionContext)  extends  FeatureSwitching {
 
-  def authAction[A](): ActionBuilder[MtdItUser, AnyContent] = {
+  def individualOrAgentWithClient[A]: ActionBuilder[MtdItUser, AnyContent] = {
 
       (   checkSessionTimeout andThen
 

--- a/app/auth/authV2/AuthActions.scala
+++ b/app/auth/authV2/AuthActions.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth.authV2
+
+import auth.MtdItUser
+import auth.authV2.actions._
+import config.FrontendAppConfig
+import config.featureswitch.FeatureSwitching
+import controllers.predicates._
+import play.api.mvc._
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class AuthActions @Inject()(val checkSessionTimeout: SessionTimeoutPredicateV2,
+                            val authoriseAndRetrieve: AuthoriseAndRetrieve,
+                            val agentHasClientDetails: AgentHasClientDetails,
+                            val asMtdUser: AsMtdUser,
+                            val retrieveBtaNavBar: NavBarPredicate,
+                            val retrieveNinoWithIncomeSources: IncomeSourceDetailsPredicate,
+                            val featureSwitchPredicate: FeatureSwitchPredicateV2)
+                           (implicit val appConfig: FrontendAppConfig,
+                                     val ec: ExecutionContext)  extends  FeatureSwitching {
+
+  def authAction[A](): ActionBuilder[MtdItUser, AnyContent] = {
+
+      (   checkSessionTimeout andThen
+
+          authoriseAndRetrieve andThen
+
+          agentHasClientDetails andThen
+
+          // get MtdItUser from EnroledUser by requiring mtdId
+
+          asMtdUser andThen
+
+          // are income sources required on most pages? could this step
+          // be removed from here and added where required?
+
+          retrieveNinoWithIncomeSources andThen
+
+          featureSwitchPredicate andThen
+
+          retrieveBtaNavBar )
+  }
+
+}
+

--- a/app/auth/authV2/AuthActions.scala
+++ b/app/auth/authV2/AuthActions.scala
@@ -31,7 +31,7 @@ class AuthActions @Inject()(val checkSessionTimeout: SessionTimeoutPredicateV2,
                             val authoriseAndRetrieve: AuthoriseAndRetrieve,
                             val agentHasClientDetails: AgentHasClientDetails,
                             val asMtdUser: AsMtdUser,
-                            val retrieveBtaNavBar: NavBarPredicate,
+                            val retrieveBtaNavBar: NavBarPredicateV2,
                             val retrieveNinoWithIncomeSources: IncomeSourceDetailsPredicate,
                             val featureSwitchPredicate: FeatureSwitchPredicateV2)
                            (implicit val appConfig: FrontendAppConfig,

--- a/app/auth/authV2/AuthExceptions.scala
+++ b/app/auth/authV2/AuthExceptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,15 @@
  * limitations under the License.
  */
 
-package controllers.predicates.agent
+package auth.authV2
 
-object Constants {
+import uk.gov.hmrc.auth.core.AuthorisationException
 
-  val agentServiceEnrolmentName = "HMRC-AS-AGENT"
-  val agentServiceIdentifierKey = "AgentReferenceNumber"
+object AuthExceptions {
 
-  val ninoEnrolmentName = "HMRC-NI"
-  val ninoEnrolmentIdentifierKey = "NINO"
-
-  val saEnrolmentName = "IR-SA"
-  val saEnrolmentIdentifierKey = "UTR"
-
-  val mtdEnrolmentName = "HMRC-MTD-IT"
-  val mtdEnrolmentIdentifierKey = "MTDITID"
-
+  case class MissingMtdId(r:String = "Could not retrieve MTD ID from request")
+    extends AuthorisationException(r)
+  case class MissingAgentReferenceNumber(r:String = "Agent Reference Number was not found in user's enrolments")
+    extends AuthorisationException(r)
 
 }

--- a/app/auth/authV2/EnroledUser.scala
+++ b/app/auth/authV2/EnroledUser.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth.authV2
+
+import controllers.predicates.agent.Constants
+import play.api.mvc.{Request, WrappedRequest}
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve.{Credentials, Name}
+
+// During the auth process, an MTD ID may not be present (e.g. an agent without a confirmed client)
+// Existing User classes require MTD ID. Instead, defer creation of User object until after
+// auth.
+case class EnroledUser[A](enrolments: Enrolments,
+                          userName: Option[Name],
+                          affinityGroup: Option[AffinityGroup],
+                          confidenceLevel: ConfidenceLevel,
+                          credentials: Option[Credentials])(implicit request: Request[A]) extends WrappedRequest[A](request){
+
+  private def getValueFromEnrolment(enrolment: String, identifier: String): Option[String] =
+    enrolments.getEnrolment(enrolment)
+      .flatMap(_.getIdentifier(identifier)).map(_.value)
+
+  lazy val credId: Option[String] =
+    credentials.map(credential => credential.providerId)
+
+  lazy val mtdId: Option[String] =
+    getValueFromEnrolment(Constants.mtdEnrolmentName, Constants.mtdEnrolmentIdentifierKey)
+
+  lazy val nino: Option[String] =
+    getValueFromEnrolment(Constants.ninoEnrolmentName, Constants.ninoEnrolmentIdentifierKey)
+
+  lazy val saId: Option[String] =
+    getValueFromEnrolment(Constants.saEnrolmentName, Constants.saEnrolmentIdentifierKey)
+
+  lazy val arn: Option[String] =
+    getValueFromEnrolment(Constants.agentServiceEnrolmentName, Constants.agentServiceIdentifierKey)
+
+}

--- a/app/auth/authV2/actions/AgentHasClientDetails.scala
+++ b/app/auth/authV2/actions/AgentHasClientDetails.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth.authV2.actions
+
+import auth.authV2.AuthExceptions._
+import auth.authV2.EnroledUser
+import controllers.agent.routes
+import controllers.agent.sessionUtils.SessionKeys
+import play.api.mvc.Results.Redirect
+import play.api.mvc.{ActionRefiner, Result}
+import uk.gov.hmrc.auth.core.AffinityGroup.Agent
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class AgentHasClientDetails @Inject()(implicit val executionContext: ExecutionContext) extends ActionRefiner[EnroledUser, EnroledUser] {
+
+  lazy val noClientDetailsRoute: Result = Redirect(routes.EnterClientsUTRController.show)
+
+  override protected def refine[A](request: EnroledUser[A]): Future[Either[Result, EnroledUser[A]]] = {
+
+    val hasConfirmedClient: Boolean = request.session.get(SessionKeys.confirmedClient).nonEmpty
+
+    val hasClientDetails: Boolean = {
+      request.session.get(SessionKeys.clientMTDID).nonEmpty &&
+      request.session.get(SessionKeys.clientFirstName).nonEmpty &&
+      request.session.get(SessionKeys.clientLastName).nonEmpty &&
+      request.session.get(SessionKeys.clientUTR).nonEmpty
+    }
+
+    // This check might not be necessary now we authorise on the Agent enrolment?
+    val hasArn: Boolean = request.arn.nonEmpty
+
+    if (!request.affinityGroup.contains(Agent)) {
+      Future.successful(Right(request))
+    } else if (hasArn && hasConfirmedClient && hasClientDetails) {
+      Future.successful(Right(request))
+    } else if (!hasArn) {
+        throw new MissingAgentReferenceNumber
+    } else Future.successful(Left(noClientDetailsRoute))
+  }
+}

--- a/app/auth/authV2/actions/AgentHasClientDetails.scala
+++ b/app/auth/authV2/actions/AgentHasClientDetails.scala
@@ -51,6 +51,8 @@ class AgentHasClientDetails @Inject()(implicit val executionContext: ExecutionCo
       Future.successful(Right(request))
     } else if (!hasArn) {
         throw new MissingAgentReferenceNumber
-    } else Future.successful(Left(noClientDetailsRoute))
+    } else {
+      Future.successful(Left(noClientDetailsRoute))
+    }
   }
 }

--- a/app/auth/authV2/actions/AsMtdUser.scala
+++ b/app/auth/authV2/actions/AsMtdUser.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth.authV2.actions
+
+import auth.MtdItUserOptionNino
+import auth.authV2.AuthExceptions._
+import auth.authV2.EnroledUser
+import controllers.agent.routes
+import play.api.mvc.Results.Redirect
+import play.api.mvc.{ActionRefiner, Result}
+import uk.gov.hmrc.auth.core.AffinityGroup.Agent
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class AsMtdUser @Inject()
+  (implicit val executionContext: ExecutionContext) extends ActionRefiner[EnroledUser, MtdItUserOptionNino] {
+
+  lazy val noClientDetailsRoute: Result = Redirect(routes.EnterClientsUTRController.show)
+
+  override protected def refine[A](request: EnroledUser[A]): Future[Either[Result, MtdItUserOptionNino[A]]] = {
+
+    implicit val r = request
+
+    Future.successful(
+      request.mtdId
+        .map(id => MtdItUserOptionNino(
+          mtditid = id,
+          nino = request.nino,
+          userName = request.userName,
+          saUtr = request.saId,
+          credId = request.credId,
+          userType = request.affinityGroup,
+          arn = request.arn))
+        .map(Right(_))
+        .getOrElse(
+          request.affinityGroup match {
+            case Some(Agent) => Left(noClientDetailsRoute)
+            case _ => throw new MissingMtdId
+          }
+        ))
+  }
+}

--- a/app/auth/authV2/actions/AsMtdUser.scala
+++ b/app/auth/authV2/actions/AsMtdUser.scala
@@ -20,6 +20,7 @@ import auth.MtdItUserOptionNino
 import auth.authV2.AuthExceptions._
 import auth.authV2.EnroledUser
 import controllers.agent.routes
+import controllers.agent.sessionUtils.SessionKeys
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{ActionRefiner, Result}
 import uk.gov.hmrc.auth.core.AffinityGroup.Agent
@@ -36,9 +37,13 @@ class AsMtdUser @Inject()
 
     implicit val r = request
 
+    val optMtdId = request.affinityGroup match {
+      case Some(Agent) => request.session.get(SessionKeys.clientMTDID)
+      case _ => request.mtdId
+    }
+
     Future.successful(
-      request.mtdId
-        .map(id => MtdItUserOptionNino(
+      optMtdId.map(id => MtdItUserOptionNino(
           mtditid = id,
           nino = request.nino,
           userName = request.userName,

--- a/app/auth/authV2/actions/AuthoriseAndRetrieve.scala
+++ b/app/auth/authV2/actions/AuthoriseAndRetrieve.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth.authV2.actions
+
+import audit.AuditingService
+import audit.models.IvUpliftRequiredAuditModel
+import auth._
+import auth.authV2.EnroledUser
+import config.FrontendAppConfig
+import config.featureswitch.FeatureSwitching
+import controllers.agent.sessionUtils.SessionKeys
+import models.OriginEnum
+import play.api.mvc.Results.Redirect
+import play.api.mvc._
+import play.api.{Configuration, Environment, Logger}
+import uk.gov.hmrc.auth.core.AffinityGroup.{Individual, Organisation}
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
+import uk.gov.hmrc.auth.core.retrieve.{Credentials, Name, ~}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.config.AuthRedirects
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+
+import java.net.URLEncoder
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class AuthoriseAndRetrieve @Inject()(val authorisedFunctions: FrontendAuthorisedFunctions,
+                           val appConfig: FrontendAppConfig,
+                           override val config: Configuration,
+                           override val env: Environment,
+                           mcc: MessagesControllerComponents,
+                           val auditingService: AuditingService)
+  extends  AuthRedirects with ActionRefiner[Request, EnroledUser] with FeatureSwitching {
+
+  val requireClientSelected: Boolean = true
+
+  implicit val executionContext: ExecutionContext = mcc.executionContext
+  val requiredConfidenceLevel: Int = appConfig.requiredConfidenceLevel
+
+  override protected def refine[A](request: Request[A]): Future[Either[Result, EnroledUser[A]]] = {
+
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter
+      .fromRequestAndSession(request, request.session)
+
+    implicit val req: Request[A] = request
+
+    // Has agent affinity group, HMRC-AS-AGENT enrolment, if has client then also
+    // has HMRC-MTD-IT enrolment with client's ID
+    def isAgent(clientMtdId: Option[String]): Predicate = {
+
+      // Agent identified by ARN - previously parsed from enrolment here:
+      // controllers.predicates.IncomeTaxAgentUser.agentReferenceNumber
+      def isAgent(): Predicate = AffinityGroup.Agent and Enrolment("HMRC-AS-AGENT")
+
+      // previously authorised here:
+      // auth.BaseFrontendController.AuthenticatedActions.asyncInternal
+      def hasClient(id:String) = Enrolment(appConfig.mtdItEnrolmentKey)
+        .withIdentifier(appConfig.mtdItIdentifierKey, id)
+        .withDelegatedAuthRule("mtd-it-auth")
+
+      clientMtdId match {
+        case Some(mtdId) => isAgent() and hasClient(mtdId)
+        case _ => isAgent()
+      }
+    }
+
+    // if user is not agent, authorise on HMRC-MTD-IT enrolment and Individual /
+    // Organisation affinity group
+    val isIndividual: Predicate = Enrolment(appConfig.mtdItEnrolmentKey) and (AffinityGroup.Organisation or AffinityGroup.Individual)
+
+    val requiredClientId: Option[String] = request.session.get(SessionKeys.clientMTDID).filter(_ => requireClientSelected)
+
+    authorisedFunctions.authorised( isIndividual or isAgent(requiredClientId) )
+      .retrieve(allEnrolments and name and credentials and affinityGroup and confidenceLevel) {
+            redirectIfInsufficientConfidence() orElse constructEnroledUser()
+      }(hc, executionContext) recoverWith logAndRedirect
+  }
+
+  // this URL is incorrect in live - the completion and failure URLs must be URL encoded
+  val ivUpliftRedirectUrl: String = {
+    val host = if (appConfig.relativeIVUpliftParams) "" else appConfig.itvcFrontendEnvironment
+    val completionUrl: String = s"$host${controllers.routes.UpliftSuccessController.success(OriginEnum.PTA.toString).url}"
+    val failureUrl: String = s"$host${controllers.errors.routes.UpliftFailedController.show.url}"
+    s"${appConfig.ivUrl}/uplift?origin=ITVC&confidenceLevel=$requiredConfidenceLevel&completionURL=${URLEncoder.encode(completionUrl, "UTF-8")}&failureURL=${URLEncoder.encode(failureUrl, "UTF-8")}"
+  }
+
+  type AuthRetrievals =
+    Enrolments ~ Option[Name] ~ Option[Credentials] ~ Option[AffinityGroup]  ~ ConfidenceLevel
+
+    private def logAndRedirect[A]: PartialFunction[Throwable, Future[Either[Result, EnroledUser[A]]]] = {
+      case insufficientEnrolments: InsufficientEnrolments =>
+        Logger("application").info(s"[AuthenticationPredicate][async] Insufficient enrolments: ${insufficientEnrolments.msg}" )
+        Future.successful(Left(Redirect(controllers.errors.routes.NotEnrolledController.show)))
+      case _: BearerTokenExpired =>
+        Logger("application").info("[AuthenticationPredicate][async] Bearer Token Timed Out.")
+        Future.successful(Left(Redirect(controllers.timeout.routes.SessionTimeoutController.timeout)))
+      case authorisationException: AuthorisationException =>
+        Logger("application").info(s"[AuthenticationPredicate][async] Unauthorised request: ${authorisationException.reason}. Redirect to Sign In.")
+        Future.successful(Left(Redirect(controllers.routes.SignInController.signIn)))
+      // No catch all block at end - bubble up to global error handler
+      // See investigation: https://github.com/hmrc/income-tax-view-change-frontend/pull/2432
+    }
+
+  private def redirectIfInsufficientConfidence[A]()(
+    implicit request: Request[A],
+    hc: HeaderCarrier): PartialFunction[AuthRetrievals, Future[Either[Result, EnroledUser[A]]]] = {
+
+    case _ ~ _ ~ _ ~ Some(ag@(Organisation | Individual)) ~ confidenceLevel
+      if confidenceLevel.level < requiredConfidenceLevel =>
+      auditingService.audit(IvUpliftRequiredAuditModel(ag.toString, confidenceLevel.level, requiredConfidenceLevel), Some(request.path))
+      Future.successful(Left(Redirect(ivUpliftRedirectUrl)))
+
+    // No support in original code for agent to uplift confidence?
+    case _ ~ _ ~ _ ~ _ ~ confidenceLevel
+      if confidenceLevel.level < requiredConfidenceLevel =>
+      throw UnsupportedAuthProvider()
+  }
+
+  private def constructEnroledUser[A]()(
+    implicit request: Request[A]): PartialFunction[AuthRetrievals, Future[Either[Result, EnroledUser[A]]]] = {
+      case enrolments ~ userName ~ credentials ~ affinityGroup ~ confidenceLevel =>
+        Future.successful(
+          Right(EnroledUser(
+            enrolments = enrolments,
+            userName = userName,
+            affinityGroup = affinityGroup,
+            confidenceLevel =confidenceLevel,
+            credentials = credentials)))
+  }
+}

--- a/app/auth/authV2/actions/FeatureSwitchPredicateV2.scala
+++ b/app/auth/authV2/actions/FeatureSwitchPredicateV2.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth.authV2.actions
+
+import auth.MtdItUser
+import config.FrontendAppConfig
+import controllers.predicates.SaveOriginAndRedirect
+import play.api.i18n.MessagesApi
+import play.api.mvc._
+import services.admin.FeatureSwitchService
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class FeatureSwitchPredicateV2 @Inject()(val featureSwitchService: FeatureSwitchService)
+                                        (implicit val appConfig: FrontendAppConfig,
+                                       val executionContext: ExecutionContext,
+                                       val messagesApi: MessagesApi) extends ActionRefiner[MtdItUser, MtdItUser] with SaveOriginAndRedirect {
+
+  override def refine[A](request: MtdItUser[A]): Future[Either[Result, MtdItUser[A]]] = {
+    featureSwitchService.getAll.flatMap(fs => {
+      val newRequest = request
+        .copy(featureSwitches = fs)(request)
+      Future.successful(Right(newRequest))
+    })
+  }
+}
+

--- a/app/auth/authV2/actions/NavBarPredicateV2.scala
+++ b/app/auth/authV2/actions/NavBarPredicateV2.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth.authV2.actions
+
+import auth.MtdItUser
+import config.{FrontendAppConfig, ItvcErrorHandler}
+import controllers.bta.BtaNavBarController
+import controllers.predicates.SaveOriginAndRedirect
+import forms.utils.SessionKeys
+import models.OriginEnum
+import models.OriginEnum.{BTA, PTA}
+import models.admin.NavBarFs
+import play.api.i18n.MessagesApi
+import play.api.mvc.Results.Redirect
+import play.api.mvc._
+import play.twirl.api.Html
+import uk.gov.hmrc.auth.core.AffinityGroup.Agent
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+import views.html.navBar.PtaPartial
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class NavBarPredicateV2 @Inject()(val btaNavBarController: BtaNavBarController,
+                                  val ptaPartial: PtaPartial,
+                                  val itvcErrorHandler: ItvcErrorHandler)
+                                 (implicit val appConfig: FrontendAppConfig,
+                                val executionContext: ExecutionContext,
+                                val messagesApi: MessagesApi
+                               ) extends ActionRefiner[MtdItUser, MtdItUser] with SaveOriginAndRedirect {
+
+  override def refine[A](request: MtdItUser[A]): Future[Either[Result, MtdItUser[A]]] = {
+
+    val header: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
+    implicit val hc: HeaderCarrier = header.copy(extraHeaders = header.headers(Seq(play.api.http.HeaderNames.COOKIE)))
+    if (!isEnabled(NavBarFs)(request) || request.userType.contains(Agent)) {
+      Future.successful(Right(request))
+    } else {
+      request.getQueryString(SessionKeys.origin).fold[Future[Either[Result, MtdItUser[A]]]](ifEmpty = retrieveCacheAndHandleNavBar(request))(_ => {
+        saveOriginAndReturnToHomeWithoutQueryParams(request, !isEnabled(NavBarFs)(request)).map(Left(_))
+      })
+    }
+  }
+
+  def retrieveCacheAndHandleNavBar[A](request: MtdItUser[A])(implicit hc: HeaderCarrier): Future[Either[Result, MtdItUser[A]]] = {
+    request.session.get(SessionKeys.origin) match {
+      case Some(origin) if OriginEnum(origin) == Some(PTA) =>
+        Future.successful(Right(returnMtdItUserWithNavbar(request, ptaPartial()(request, request.messages, appConfig))))
+      case Some(origin) if OriginEnum(origin) == Some(BTA) =>
+        handleBtaNavBar(request)
+      case _ =>
+        Future.successful(Left(Redirect(appConfig.taxAccountRouterUrl)))
+    }
+  }
+
+  def returnMtdItUserWithNavbar[A](request: MtdItUser[A], partial: Html): MtdItUser[A] = {
+    MtdItUser[A](mtditid = request.mtditid, nino = request.nino, userName = request.userName,
+      incomeSources = request.incomeSources, btaNavPartial = Some(partial), saUtr = request.saUtr, credId = request.credId,
+      userType = request.userType, arn = request.arn, featureSwitches = request.featureSwitches)(request)
+  }
+
+  def handleBtaNavBar[A](request: MtdItUser[A])(implicit hc: HeaderCarrier): Future[Either[Result, MtdItUser[A]]] = {
+    btaNavBarController.btaNavBarPartial(request) map {
+      case Some(partial) => Right(returnMtdItUserWithNavbar(request, partial))
+      case _ => Left(itvcErrorHandler.showInternalServerError()(request))
+    }
+  }
+}

--- a/app/auth/authV2/actions/SessionTimeoutPredicateV2.scala
+++ b/app/auth/authV2/actions/SessionTimeoutPredicateV2.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth.authV2.actions
+
+import play.api.Logger
+import play.api.mvc.Results.Redirect
+import play.api.mvc._
+import uk.gov.hmrc.http.SessionKeys
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SessionTimeoutPredicateV2 @Inject()(val parser: BodyParsers.Default)(implicit val executionContext: ExecutionContext)
+  extends ActionRefiner[Request, Request] with ActionBuilder[Request, AnyContent] {
+
+  override protected def refine[A](request: Request[A]): Future[Either[Result, Request[A]]] = {
+
+    val updatedHeaders = request.session.get("Gov-Test-Scenario") match {
+      case Some(data) => request.headers.add(("Gov-Test-Scenario", data))
+      case _ => request.headers
+    }
+
+    (request.session.get(SessionKeys.lastRequestTimestamp), request.session.get(SessionKeys.authToken)) match {
+      case (Some(_), None) =>
+        // Auth session has been wiped by Frontend Bootstrap Filter, hence timed out.
+        Logger("application").warn("Session Time Out.")
+        Future.successful(Left(Redirect(controllers.timeout.routes.SessionTimeoutController.timeout)))
+      case (_, _) =>
+        val mtdItUserWithUpdatedHeaders = request.withHeaders(updatedHeaders)
+        Future.successful(Right(mtdItUserWithUpdatedHeaders))
+    }
+  }
+
+}

--- a/app/controllers/CreditAndRefundController.scala
+++ b/app/controllers/CreditAndRefundController.scala
@@ -59,7 +59,7 @@ class CreditAndRefundController @Inject()(val authActions: AuthActions,
   extends FrontendBaseController with FeatureSwitching with I18nSupport {
 
   def show(origin: Option[String] = None): Action[AnyContent] =
-    authActions.authAction().async {
+    authActions.individualOrAgentWithClient async {
       implicit user =>
         handleRequest(
           backUrl = controllers.routes.HomeController.show(origin).url,
@@ -88,7 +88,7 @@ class CreditAndRefundController @Inject()(val authActions: AuthActions,
   }
 
   def showAgent(): Action[AnyContent] = {
-    authActions.authAction().async {
+    authActions.individualOrAgentWithClient async {
       implicit mtdItUser =>
         handleRequest(
           backUrl = controllers.routes.HomeController.showAgent.url,
@@ -99,7 +99,7 @@ class CreditAndRefundController @Inject()(val authActions: AuthActions,
   }
 
   def startRefund(): Action[AnyContent] =
-    authActions.authAction().async {
+    authActions.individualOrAgentWithClient async {
       implicit user =>
         user.userType match {
           case _ if !isEnabled(CreditsRefundsRepay) =>

--- a/app/controllers/agent/predicates/ClientConfirmedController.scala
+++ b/app/controllers/agent/predicates/ClientConfirmedController.scala
@@ -28,7 +28,7 @@ import play.api.mvc.{AnyContent, MessagesControllerComponents, Request, Result}
 import services.IncomeSourceDetailsService
 import uk.gov.hmrc.auth.core.AffinityGroup.Agent
 import uk.gov.hmrc.auth.core.retrieve.Name
-import uk.gov.hmrc.http.{HeaderCarrier, HeaderNames, InternalServerException}
+import uk.gov.hmrc.http.{HeaderCarrier, InternalServerException}
 
 import scala.concurrent.Future
 

--- a/app/controllers/predicates/IncomeSourceDetailsPredicate.scala
+++ b/app/controllers/predicates/IncomeSourceDetailsPredicate.scala
@@ -16,17 +16,14 @@
 
 package controllers.predicates
 
-import auth.{MtdItUser, MtdItUserOptionNino, MtdItUserWithNino}
+import auth.{MtdItUser, MtdItUserOptionNino}
 import config.ItvcErrorHandler
 import controllers.BaseController
-import models.core.{NinoResponseError, NinoResponseSuccess}
 import models.incomeSourceDetails.IncomeSourceDetailsModel
-import play.api.Logger
 import play.api.mvc.{ActionRefiner, MessagesControllerComponents, Result}
 import services.IncomeSourceDetailsService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
-import uk.gov.hmrc.http.HeaderNames
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -46,7 +43,7 @@ class IncomeSourceDetailsPredicate @Inject()(val incomeSourceDetailsService: Inc
     // no caching for now
     incomeSourceDetailsService.getIncomeSourceDetails() map {
       case response: IncomeSourceDetailsModel =>
-        Right(MtdItUser(request.mtditid, response.nino, request.userName, response, None, request.saUtr, request.credId, request.userType, None))
+        Right(MtdItUser(request.mtditid, response.nino, request.userName, response, None, request.saUtr, request.credId, request.userType, request.arn))
       case _ => Left(itvcErrorHandler.showInternalServerError())
     }
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -215,6 +215,11 @@ enrolments {
     key = "IR-SA"
     identifier = "UTR"
   }
+
+  arn {
+    key = "HMRC-AS-AGENT"
+    identifier = "AgentReferenceNumber"
+  }
 }
 
 base {

--- a/it/test/controllers/CreditAndRefundControllerISpec.scala
+++ b/it/test/controllers/CreditAndRefundControllerISpec.scala
@@ -270,6 +270,8 @@ class CreditAndRefundControllerISpec extends ComponentSpecBase {
       enable(CutOverCredits)
       enable(MFACreditsAndDebits)
 
+
+
       val mtdUser = if(isAgent) {
         MtdItUser(testMtditid, testNino, None,
           multipleBusinessesAndPropertyResponse, None, Some("1234567890"),

--- a/it/test/controllers/CreditAndRefundControllerISpec.scala
+++ b/it/test/controllers/CreditAndRefundControllerISpec.scala
@@ -273,9 +273,9 @@ class CreditAndRefundControllerISpec extends ComponentSpecBase {
 
 
       val mtdUser = if(isAgent) {
-        MtdItUser(testMtditid, testNino, None,
-          multipleBusinessesAndPropertyResponse, None, Some("1234567890"),
-          None, Some(Agent), Some("1"))(FakeRequest())
+        MtdItUser(testMtditid, testNino, userName = None,
+          incomeSources = multipleBusinessesAndPropertyResponse, btaNavPartial = None, saUtr = Some("1234567890"),
+          credId = None, userType = Some(Agent), arn = Some("1"))(FakeRequest())
       } else {
         MtdItUser(
           testMtditid, testNino, None,

--- a/it/test/helpers/servicemocks/AuthStub.scala
+++ b/it/test/helpers/servicemocks/AuthStub.scala
@@ -144,6 +144,15 @@ object AuthStub extends ComponentSpecBase {
             )
           ),
           Json.obj(
+            "key" -> s"$testSaUtrEnrolmentKey",
+            "identifiers" -> Json.arr(
+              Json.obj(
+                "key" -> s"$testSaUtrEnrolmentIdentifier",
+                "value" -> s"$testSaUtr"
+              )
+            )
+          ),
+          Json.obj(
             "key" -> "HMRC-MTD-IT",
             "identifiers" -> Json.arr(
               Json.obj(

--- a/test/auth/authV2/AuthActionsSpec.scala
+++ b/test/auth/authV2/AuthActionsSpec.scala
@@ -16,12 +16,12 @@
 
 package auth.authV2
 
-import auth.{FrontendAuthorisedFunctions, MtdItUser}
 import auth.authV2.AuthExceptions.{MissingAgentReferenceNumber, MissingMtdId}
 import auth.authV2.actions._
+import auth.{FrontendAuthorisedFunctions, MtdItUser}
 import config.FrontendAuthConnector
 import controllers.agent.sessionUtils.SessionKeys
-import controllers.predicates.{IncomeSourceDetailsPredicate, NavBarPredicate}
+import controllers.predicates.IncomeSourceDetailsPredicate
 import models.incomeSourceDetails.{IncomeSourceDetailsError, IncomeSourceDetailsModel, IncomeSourceDetailsResponse}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
@@ -237,14 +237,6 @@ class AuthActionsSpec extends TestSupport with ScalaFutures {
         result.header.headers(Location) shouldBe "/report-quarterly/income-and-expenses/view/agents/client-utr"
       }
 
-      "redirect to /agents/client-utr to when client id is missing from enrolments (HMRC-MTD-ID)" in new ResultFixture(
-        retrievals = agentRetrievalData.copy(enrolments = Enrolments(Set(agentEnrolment, saEnrolment))),
-        request = validAgentRequest) {
-
-        result.header.status shouldBe SEE_OTHER
-        result.header.headers(Location) shouldBe "/report-quarterly/income-and-expenses/view/agents/client-utr"
-      }
-
       "redirect to /agents/client-utr when client id is missing from session" in new ResultFixture(
         retrievals = agentRetrievalData,
         request = agentRequestMissingClientMtdId) {
@@ -330,7 +322,7 @@ class AuthActionsSpec extends TestSupport with ScalaFutures {
     app.injector.instanceOf[AuthoriseAndRetrieve],
     app.injector.instanceOf[AgentHasClientDetails],
     app.injector.instanceOf[AsMtdUser],
-    app.injector.instanceOf[NavBarPredicate],
+    app.injector.instanceOf[NavBarPredicateV2],
     app.injector.instanceOf[IncomeSourceDetailsPredicate],
     app.injector.instanceOf[FeatureSwitchPredicateV2]
   )(appConfig, ec)

--- a/test/auth/authV2/AuthActionsSpec.scala
+++ b/test/auth/authV2/AuthActionsSpec.scala
@@ -1,0 +1,394 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth.authV2
+
+import auth.{FrontendAuthorisedFunctions, MtdItUser}
+import auth.authV2.AuthExceptions.{MissingAgentReferenceNumber, MissingMtdId}
+import auth.authV2.actions._
+import config.FrontendAuthConnector
+import controllers.agent.sessionUtils.SessionKeys
+import controllers.predicates.{IncomeSourceDetailsPredicate, NavBarPredicate}
+import models.incomeSourceDetails.{IncomeSourceDetailsError, IncomeSourceDetailsModel, IncomeSourceDetailsResponse}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.when
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.exceptions.TestFailedException
+import org.scalatestplus.mockito.MockitoSugar.mock
+import play.api
+import play.api.Application
+import play.api.http.Status.{INTERNAL_SERVER_ERROR, NOT_FOUND, OK, SEE_OTHER}
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.Results.Ok
+import play.api.mvc.{AnyContent, Result}
+import play.api.test.FakeRequest
+import services.IncomeSourceDetailsService
+import sttp.model.HeaderNames.Location
+import testUtils.TestSupport
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve.{Credentials, Name, ~}
+
+import java.net.URLEncoder
+import scala.concurrent.Future
+
+class AuthActionsSpec extends TestSupport with ScalaFutures {
+
+  val nino              = "AA111111A"
+  val saUtr             = "123456789"
+  val mtdId             = "abcde"
+  val arn               = "12345"
+
+  val agentEnrolment            = Enrolment("HMRC-AS-AGENT",  Seq(EnrolmentIdentifier("AgentReferenceNumber", arn)), "Activated", None)
+  val ninoEnrolment             = Enrolment("HMRC-NI",        Seq(EnrolmentIdentifier("NINO", nino)),                "Activated", None)
+  val saEnrolment               = Enrolment("IR-SA",          Seq(EnrolmentIdentifier("UTR", saUtr)),                "Activated", None)
+  val credentials               = Credentials("foo", "bar")
+  val defaultIncomeSourcesData  = IncomeSourceDetailsModel(nino, saUtr, Some("2012"), Nil, Nil)
+
+  def mtdIdAgentPredicate(mtdId: String) = Enrolment("HMRC-MTD-IT").withIdentifier("MTDITID", mtdId).withDelegatedAuthRule("mtd-it-auth")
+  def mtdIdIndividualPredicate(mtdId: String) = Enrolment("HMRC-MTD-IT").withIdentifier("MTDITID", mtdId)
+
+  val individualRetrievalData = RetrievalData(
+    enrolments = Enrolments(Set(ninoEnrolment, mtdIdIndividualPredicate(mtdId), saEnrolment)),
+    name = None,
+    credentials = Some(credentials),
+    affinityGroup = Some(AffinityGroup.Individual),
+    confidenceLevel = ConfidenceLevel.L250
+  )
+
+  val agentRetrievalData = RetrievalData(
+    enrolments = Enrolments(Set(agentEnrolment, mtdIdAgentPredicate(mtdId), saEnrolment)),
+    name = None,
+    credentials = Some(credentials),
+    affinityGroup = Some(AffinityGroup.Agent),
+    confidenceLevel = ConfidenceLevel.L250
+  )
+
+  "invokeBlock" when {
+
+    "user is an individual" when {
+
+      "execute block when timestamp and auth token, origin, HMRC-MTD-ID enrolment and successful income sources response" in new ResultFixture(
+        retrievals = individualRetrievalData,
+        request = fakeRequestWithActiveSession.withSession(("origin", "PTA")),
+        block = {
+          (user: MtdItUser[_]) =>  {
+            user.nino shouldBe nino
+            user.arn shouldBe None
+            user.mtditid shouldBe mtdId
+            user.saUtr shouldBe Some(saUtr)
+            user.credId shouldBe Some(credentials.providerId)
+            Future.successful(Ok("!"))
+          }
+        }
+      ) {
+        result.header.status shouldBe OK
+      }
+
+      "throw exception if no HMRC-MTD-ID in enrolments" in new ExceptionFixture(
+        retrievals = individualRetrievalData.copy(enrolments = Enrolments(Set.empty)),
+        request = fakeRequestWithActiveSession.withSession(("origin", "PTA")),
+        expectedError = new MissingMtdId) { }
+
+      s"show internal error when $INTERNAL_SERVER_ERROR returned from income sources" in new ResultFixture(
+        retrievals = individualRetrievalData,
+        incomeSources = IncomeSourceDetailsError(INTERNAL_SERVER_ERROR, "Internal server error")
+      ) {
+        result.header.status shouldBe INTERNAL_SERVER_ERROR
+      }
+
+      s"show internal error when $NOT_FOUND returned from income sources" in new ResultFixture(
+        retrievals = individualRetrievalData,
+        incomeSources = IncomeSourceDetailsError(NOT_FOUND, "Record not found")
+      ) {
+        result.header.status shouldBe INTERNAL_SERVER_ERROR
+      }
+
+      s"redirect to /uplift with confidence level < ${appConfig.requiredConfidenceLevel}, " in new ResultFixture(
+        retrievals = individualRetrievalData.copy(confidenceLevel = ConfidenceLevel.L50 )) {
+
+        val completionUrl = URLEncoder.encode("http://localhost:9081/report-quarterly/income-and-expenses/view/uplift-success?origin=PTA", "UTF-8")
+        val failureUrl = URLEncoder.encode("http://localhost:9081/report-quarterly/income-and-expenses/view/cannot-view-page", "UTF-8")
+        val upliftUrl = s"http://localhost:9948/iv-stub/uplift?origin=ITVC&confidenceLevel=${appConfig.requiredConfidenceLevel}&completionURL=$completionUrl&failureURL=$failureUrl"
+
+        result.header.status shouldBe SEE_OTHER
+        result.header.headers(Location) shouldBe upliftUrl
+      }
+
+      s"redirect to /cannot-access-service when required enrolments not found" in new AuthThrowsExceptionFixture(
+        retrievals = individualRetrievalData,
+        authorisationException = new InsufficientEnrolments("Enrolment not found")
+      ) {
+        result.header.status shouldBe SEE_OTHER
+        result.header.headers(Location) shouldBe "/report-quarterly/income-and-expenses/view/cannot-access-service"
+      }
+
+      s"redirect to /session-timeout when BearerToken has expired" in new AuthThrowsExceptionFixture(
+        retrievals = individualRetrievalData,
+        authorisationException = new BearerTokenExpired("Bearer token expired")
+      ) {
+        result.header.status shouldBe SEE_OTHER
+        result.header.headers(Location) shouldBe "/report-quarterly/income-and-expenses/view/session-timeout"
+      }
+
+      "redirect to /session-timeout with a timestamp and no auth token" in new ResultFixture(
+        retrievals = individualRetrievalData,
+        request = fakeRequestWithTimeoutSession.withSession(("origin", "PTA"))
+      ) {
+        print(result)
+        result.header.status shouldBe SEE_OTHER
+        result.header.headers(Location).contains("/report-quarterly/income-and-expenses/view/session-timeout") shouldBe true
+      }
+
+      s"redirect to /sign-in when any other error is returned" in new AuthThrowsExceptionFixture(
+        retrievals = individualRetrievalData,
+        authorisationException = new UnsupportedAffinityGroup("Affinity group not supported")
+      ) {
+        result.header.status shouldBe SEE_OTHER
+        result.header.headers(Location) shouldBe "/report-quarterly/income-and-expenses/view/sign-in"
+      }
+    }
+
+    "user is an agent" when {
+
+      val sessionData = Map(
+        (SessionKeys.confirmedClient, ""),
+        (SessionKeys.clientMTDID, mtdId),
+        (SessionKeys.clientFirstName, "Brian"),
+        (SessionKeys.clientLastName, "Brianson"),
+        (SessionKeys.clientUTR, saUtr),
+        ("origin", "PTA")
+      )
+
+      val validAgentRequest = fakeRequestWithActiveSession.withSession({sessionData.toList}:_*)
+
+      val timeoutAgentRequest = fakeRequestWithTimeoutSession.withSession({sessionData.toList}:_*)
+
+      val agentRequestMissingClientMtdId = fakeRequestWithActiveSession
+        .withSession({sessionData.filterNot(_._1 == SessionKeys.clientMTDID).toList}:_*)
+
+      val agentRequestMissingConfirmedClient = fakeRequestWithActiveSession
+        .withSession({sessionData.filterNot(_._1 == SessionKeys.confirmedClient).toList}: _*)
+
+      "execute block when has timestamp and auth token, origin, agent enrolment, client data and successful income sources response" in new ResultFixture(
+        retrievals = agentRetrievalData,
+        request = validAgentRequest,
+        block = {
+          (user: MtdItUser[_]) => {
+            user.nino shouldBe nino
+            user.arn shouldBe Some(arn)
+            user.mtditid shouldBe mtdId
+            user.saUtr shouldBe Some(saUtr)
+            Future.successful(Ok("!"))
+        }}
+      ) {
+        result.header.status shouldBe OK
+      }
+
+
+
+      s"throw exception when confidence level < ${appConfig.requiredConfidenceLevel}" in new ResultFixture(
+        retrievals = agentRetrievalData.copy(confidenceLevel = ConfidenceLevel.L50 ),
+        request = validAgentRequest) {
+
+        // does not re-direct to uplift for agent
+        // agent throws exception if insufficient confidence, which then redirects to sign-in
+
+        result.header.status shouldBe SEE_OTHER
+        result.header.headers(Location) shouldBe "/report-quarterly/income-and-expenses/view/sign-in"
+      }
+
+      s"show internal error when $INTERNAL_SERVER_ERROR returned from income sources" in new ResultFixture(
+        retrievals = agentRetrievalData,
+        incomeSources = IncomeSourceDetailsError(INTERNAL_SERVER_ERROR, "Internal server error"),
+        request = validAgentRequest
+      ) {
+        result.header.status shouldBe INTERNAL_SERVER_ERROR
+      }
+
+      s"show internal error when $NOT_FOUND returned from income sources" in new ResultFixture(
+        retrievals = agentRetrievalData,
+        incomeSources = IncomeSourceDetailsError(NOT_FOUND, "Record not found"),
+        request = validAgentRequest
+      ) {
+        result.header.status shouldBe INTERNAL_SERVER_ERROR
+      }
+
+      // agent reference number is missing / present
+
+      "throw exception when agent reference number is missing" in new ExceptionFixture(
+        retrievals = agentRetrievalData.copy(enrolments = Enrolments(Set.empty)),
+        request = validAgentRequest,
+        expectedError = new MissingAgentReferenceNumber
+      ) {  }
+
+      "redirect to /agents/client-utr when confirmed client is missing" in new ResultFixture(
+        retrievals = agentRetrievalData,
+        request = agentRequestMissingConfirmedClient) {
+        result.header.status shouldBe SEE_OTHER
+        result.header.headers(Location) shouldBe "/report-quarterly/income-and-expenses/view/agents/client-utr"
+      }
+
+      "redirect to /agents/client-utr to when client id is missing from enrolments (HMRC-MTD-ID)" in new ResultFixture(
+        retrievals = agentRetrievalData.copy(enrolments = Enrolments(Set(agentEnrolment, saEnrolment))),
+        request = validAgentRequest) {
+
+        result.header.status shouldBe SEE_OTHER
+        result.header.headers(Location) shouldBe "/report-quarterly/income-and-expenses/view/agents/client-utr"
+      }
+
+      "redirect to /agents/client-utr when client id is missing from session" in new ResultFixture(
+        retrievals = agentRetrievalData,
+        request = agentRequestMissingClientMtdId) {
+        result.header.status shouldBe SEE_OTHER
+        result.header.headers(Location) shouldBe "/report-quarterly/income-and-expenses/view/agents/client-utr"
+      }
+
+      s"redirect to /cannot-access-service when required enrolments not found" in new AuthThrowsExceptionFixture(
+        retrievals = agentRetrievalData,
+        request = validAgentRequest,
+        authorisationException = new InsufficientEnrolments("Enrolment not found")
+      ) {
+        result.header.status shouldBe SEE_OTHER
+        result.header.headers(Location) shouldBe "/report-quarterly/income-and-expenses/view/cannot-access-service"
+      }
+
+      "redirect to /session-timeout with a timestamp and no auth token" in new ResultFixture(
+        retrievals = agentRetrievalData,
+        request = timeoutAgentRequest
+      ) {
+        print(result)
+        result.header.status shouldBe SEE_OTHER
+        result.header.headers(Location).contains("/report-quarterly/income-and-expenses/view/session-timeout") shouldBe true
+      }
+
+      s"redirect to /session-timeout when BearerToken has expired" in new AuthThrowsExceptionFixture(
+        retrievals = agentRetrievalData,
+        request = validAgentRequest,
+        authorisationException = new BearerTokenExpired("Bearer token expired")
+      ) {
+        result.header.status shouldBe SEE_OTHER
+        result.header.headers(Location) shouldBe "/report-quarterly/income-and-expenses/view/session-timeout"
+      }
+
+      s"redirect to /sign-in when any other error is returned" in new AuthThrowsExceptionFixture(
+        retrievals = agentRetrievalData,
+        request = validAgentRequest,
+        authorisationException = new UnsupportedAffinityGroup("Affinity group not supported")
+      ) {
+        result.header.status shouldBe SEE_OTHER
+        result.header.headers(Location) shouldBe "/report-quarterly/income-and-expenses/view/sign-in"
+      }
+    }
+  }
+
+  lazy val mockAuthConnector = mock[FrontendAuthConnector]
+  lazy val mockIncomeSourceDetailsService = mock[IncomeSourceDetailsService]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    Mockito.reset(mockAuthConnector)
+    Mockito.reset(mockIncomeSourceDetailsService)
+  }
+
+  override def fakeApplication(): Application = {
+
+    val frontendAuthFunctions = new FrontendAuthorisedFunctions(mockAuthConnector)
+
+    new GuiceApplicationBuilder()
+      .overrides(
+        api.inject.bind[IncomeSourceDetailsService].toInstance(mockIncomeSourceDetailsService),
+//        api.inject.bind[AuthorisedFunctions].toInstance(frontendAuthFunctions),
+        api.inject.bind[FrontendAuthorisedFunctions].toInstance(frontendAuthFunctions),
+//        api.inject.bind[AuthConnector].toInstance(mockAuthConnector)
+      )
+      .build()
+  }
+
+  implicit class Ops[A](a: A) {
+    def ~[B](b: B): A ~ B = new ~(a, b)
+  }
+
+  type AuthRetrievals =
+    Enrolments ~ Option[Name] ~ Option[Credentials] ~ Option[AffinityGroup]  ~ ConfidenceLevel
+
+  case class RetrievalData(enrolments: Enrolments,
+                           name: Option[Name],
+                           credentials: Option[Credentials],
+                           affinityGroup: Option[AffinityGroup],
+                           confidenceLevel: ConfidenceLevel)
+
+  val authActions = new AuthActions(
+    app.injector.instanceOf[SessionTimeoutPredicateV2],
+    app.injector.instanceOf[AuthoriseAndRetrieve],
+    app.injector.instanceOf[AgentHasClientDetails],
+    app.injector.instanceOf[AsMtdUser],
+    app.injector.instanceOf[NavBarPredicate],
+    app.injector.instanceOf[IncomeSourceDetailsPredicate],
+    app.injector.instanceOf[FeatureSwitchPredicateV2]
+  )(appConfig, ec)
+
+  abstract class Fixture(retrievals: RetrievalData,
+                         request: FakeRequest[AnyContent] = FakeRequest(),
+                         incomeSources: IncomeSourceDetailsResponse = defaultIncomeSourcesData,
+                         block: MtdItUser[_] => Future[Result] = (_) => Future.successful(Ok("OK!"))) {
+
+    when(mockIncomeSourceDetailsService.getIncomeSourceDetails()(any(), any()))
+      .thenReturn(Future.successful(incomeSources))
+
+    when(mockAuthConnector.authorise[AuthRetrievals](any(), any())(any(), any())).thenReturn(
+      Future.successful[AuthRetrievals](
+        retrievals.enrolments ~ retrievals.name ~ retrievals.credentials ~ retrievals.affinityGroup ~ retrievals.confidenceLevel
+      )
+    )
+  }
+
+
+
+  class AuthThrowsExceptionFixture(retrievals: RetrievalData,
+                      request: FakeRequest[AnyContent] = FakeRequest(),
+                      incomeSources: IncomeSourceDetailsResponse = defaultIncomeSourcesData,
+                      block: MtdItUser[_] => Future[Result] = (_) => Future.successful(Ok("OK!")),
+                      authorisationException: AuthorisationException)
+    extends Fixture(retrievals, request, incomeSources, block) {
+
+    when(mockAuthConnector.authorise[AuthRetrievals](any(), any())(any(), any())).thenReturn(Future.failed( authorisationException ))
+
+    val result = authActions.authAction().async(block).apply(request).futureValue
+  }
+  class ResultFixture(retrievals: RetrievalData,
+                      request: FakeRequest[AnyContent] = FakeRequest(),
+                      incomeSources: IncomeSourceDetailsResponse = defaultIncomeSourcesData,
+                      block: MtdItUser[_] => Future[Result] = (_) => Future.successful(Ok("OK!")))
+    extends Fixture(retrievals, request, incomeSources, block) {
+
+    val result = authActions.authAction().async(block).apply(request).futureValue
+  }
+
+  class ExceptionFixture(retrievals: RetrievalData,
+                         request: FakeRequest[AnyContent] = FakeRequest(),
+                         incomeSources: IncomeSourceDetailsResponse = defaultIncomeSourcesData,
+                         block: MtdItUser[_] => Future[Result] = (_) => Future.successful(Ok("OK!")),
+                         expectedError: Throwable)
+    extends Fixture(retrievals, request, incomeSources, block) {
+
+    val failedException: TestFailedException = intercept[TestFailedException] {
+      authActions.authAction().async(block).apply(request).futureValue
+    }
+
+    failedException.getCause.getClass shouldBe expectedError.getClass
+  }
+}

--- a/test/mocks/auth/MockAuthActions.scala
+++ b/test/mocks/auth/MockAuthActions.scala
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mocks.auth
 
 import audit.mocks.MockAuditingService
 import auth.authV2.AuthActions
 import auth.authV2.actions._
 import config.ItvcErrorHandler
-import controllers.predicates.{IncomeSourceDetailsPredicate, NavBarPredicate}
+import controllers.predicates.IncomeSourceDetailsPredicate
 import mocks.services.MockIncomeSourceDetailsService
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -38,7 +54,7 @@ trait MockAuthActions extends TestSupport with MockIncomeSourceDetailsService wi
     authoriseAndRetrieve,
     app.injector.instanceOf[AgentHasClientDetails],
     app.injector.instanceOf[AsMtdUser],
-    app.injector.instanceOf[NavBarPredicate],
+    app.injector.instanceOf[NavBarPredicateV2],
     incomeSourceDetailsPredicate,
     app.injector.instanceOf[FeatureSwitchPredicateV2]
   )(appConfig, ec)

--- a/test/mocks/auth/MockAuthActions.scala
+++ b/test/mocks/auth/MockAuthActions.scala
@@ -1,0 +1,69 @@
+package mocks.auth
+
+import audit.mocks.MockAuditingService
+import auth.authV2.AuthActions
+import auth.authV2.actions._
+import config.ItvcErrorHandler
+import controllers.predicates.{IncomeSourceDetailsPredicate, NavBarPredicate}
+import mocks.services.MockIncomeSourceDetailsService
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import play.api.test.Helpers.stubMessagesControllerComponents
+import testUtils.TestSupport
+import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
+import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
+import uk.gov.hmrc.auth.core.{AuthorisationException, InvalidBearerToken}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockAuthActions extends TestSupport with MockIncomeSourceDetailsService with MockFrontendAuthorisedFunctions  with MockAuditingService{
+
+  private val authoriseAndRetrieve = new AuthoriseAndRetrieve(
+    authorisedFunctions = mockAuthService,
+    appConfig = appConfig,
+    config = conf,
+    env = environment,
+    mcc = stubMessagesControllerComponents(),
+    auditingService = mockAuditingService
+  )
+
+  private val incomeSourceDetailsPredicate = new IncomeSourceDetailsPredicate(
+    mockIncomeSourceDetailsService,
+    app.injector.instanceOf[ItvcErrorHandler]
+  )(ec, stubMessagesControllerComponents())
+
+  val mockAuthActions = new AuthActions(
+    app.injector.instanceOf[SessionTimeoutPredicateV2],
+    authoriseAndRetrieve,
+    app.injector.instanceOf[AgentHasClientDetails],
+    app.injector.instanceOf[AsMtdUser],
+    app.injector.instanceOf[NavBarPredicate],
+    incomeSourceDetailsPredicate,
+    app.injector.instanceOf[FeatureSwitchPredicateV2]
+  )(appConfig, ec)
+
+  override def setupMockAuthRetrievalSuccess[X, Y](retrievalValue: X ~ Y): Unit = {
+    when(mockAuthService.authorised(any()))
+      .thenReturn(
+        new mockAuthService.AuthorisedFunction(EmptyPredicate) {
+          override def retrieve[A](retrieval: Retrieval[A]) = new mockAuthService.AuthorisedFunctionWithResult[A](EmptyPredicate, retrieval) {
+            override def apply[B](body: A => Future[B])(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[B] = body.apply(retrievalValue.asInstanceOf[A])
+          }
+        })
+  }
+
+  override def setupMockAgentAuthorisationException(exception: AuthorisationException = new InvalidBearerToken, withClientPredicate: Boolean = true): Unit = {
+
+      when(mockAuthService.authorised(any()))
+      .thenReturn(
+        new mockAuthService.AuthorisedFunction(EmptyPredicate) {
+          override def apply[A](body: => Future[A])(implicit hc: HeaderCarrier, executionContext: ExecutionContext) = Future.failed(exception)
+
+          override def retrieve[A](retrieval: Retrieval[A]) = new mockAuthService.AuthorisedFunctionWithResult[A](EmptyPredicate, retrieval) {
+            override def apply[B](body: A => Future[B])(implicit hc: HeaderCarrier, executionContext: ExecutionContext): Future[B] = Future.failed(exception)
+          }
+        })
+  }
+
+}

--- a/test/mocks/auth/MockFrontendAuthorisedFunctions.scala
+++ b/test/mocks/auth/MockFrontendAuthorisedFunctions.scala
@@ -49,6 +49,8 @@ trait MockFrontendAuthorisedFunctions extends BeforeAndAfterEach {
     else setupMockAuthRetrievalSuccess(testIndividualAuthSuccessWithSaUtrResponse())
   }
 
+
+
   def setupMockAuthRetrievalSuccess[X, Y](retrievalValue: X ~ Y): Unit = {
     when(mockAuthService.authorised(Enrolment("HMRC-MTD-IT")))
       .thenReturn(

--- a/test/testConstants/BaseTestConstants.scala
+++ b/test/testConstants/BaseTestConstants.scala
@@ -142,6 +142,7 @@ object BaseTestConstants extends UnitSpec with GuiceOneAppPerSuite {
 
   def testAuthAgentSuccessWithSaUtrResponse(confidenceLevel: ConfidenceLevel = testConfidenceLevel,
                                        affinityGroup: AffinityGroup = AffinityGroup.Agent) = new ~(new ~(new ~(new ~(Enrolments(Set(
+    arnEnrolment,
     Enrolment("HMRC-MTD-IT", Seq(EnrolmentIdentifier("MTDITID", testMtditid)), "activated"),
     Enrolment("HMRC-NI", Seq(EnrolmentIdentifier("NINO", testNino)), "activated"),
     Enrolment("IR-SA", Seq(EnrolmentIdentifier("UTR", "1234567890")), "activated")
@@ -150,7 +151,7 @@ object BaseTestConstants extends UnitSpec with GuiceOneAppPerSuite {
 
   val arnEnrolment: Enrolment = Enrolment(
     "HMRC-AS-AGENT",
-    Seq(EnrolmentIdentifier("ARN", testArn)),
+    Seq(EnrolmentIdentifier("AgentReferenceNumber", testArn)),
     "Activated"
   )
 


### PR DESCRIPTION
Simplified the logic for Auth (e.g. authorising on` HMRC-AS-AGENT` enrolment to ensure ARN, rather than empty enrolment and manually checking).

Used composite predicates (`uk.gov.hmrc.auth.core.authorise.Predicate`) to check for Agent / Individual on same auth call.

Split up some of the logic into different actions to add comprehensibility.

More abstract "user" type introduced - EnroledUser. Would aid in supporting agents without confirmed clients, but needs more work in that direction.

IV-uplift URL in production is incorrect - it looks like the service base url appears twice, and the URLs passed as parameters need to be URL encoded (corrected here).

Identifier key for `testConstants.BaseTestConstants#arnEnrolment` ("ARN") looks to be incorrect. ARN is parsed from enrolments here: `controllers.predicates.IncomeTaxAgentUser#agentReferenceNumber`, where "AgentReferenceNumber" is used. Updated here, but no impact in the tests...