### PR TITLE
MISUV-8098-logger-level-change 

### DIFF
--- a/app/connectors/BusinessDetailsConnector.scala
+++ b/app/connectors/BusinessDetailsConnector.scala
@@ -24,7 +24,7 @@ import models.core.{NinoResponse, NinoResponseError, NinoResponseSuccess}
 import models.incomeSourceDetails.{IncomeSourceDetailsError, IncomeSourceDetailsModel, IncomeSourceDetailsResponse}
 import play.api.Logger
 import play.api.http.Status
-import play.api.http.Status.OK
+import play.api.http.Status.{NOT_FOUND, OK}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 import utils.Headers.checkAndAddTestHeader
 
@@ -66,8 +66,8 @@ class BusinessDetailsConnector @Inject()(val http: HttpClient,
             valid => valid
           )
         case status =>
-          if (status == 404) {
-            Logger("application").error(s"RESPONSE status: ${response.status}, body: ${response.body}")
+          if (status == NOT_FOUND) {
+            Logger("application").warn(s"RESPONSE status: ${response.status}, body: ${response.body}")
           } else if (status >= 500) {
             Logger("application").error(s"RESPONSE status: ${response.status}, body: ${response.body}")
           } else {


### PR DESCRIPTION
Good day all prospective reviewers!!! The main goal of this PR was to change the logging level for a valid scenario from error to warning. This means that it will no longer clog up our Kibana logs with IRRELEVANT error logs! I also took the liberty to remove the use of a magic number in this here production code (404 -> NOT_FOUND). Hopefully, this would make the code more readable to anyone reading it.

I hope this change pleases you. Feel free to leave any comments below and I shall endeavour to address them at my earliest convenience. 

Good day.

Best regards,
Simon