### PR TITLE
Remove logger from ChargeHistoryModel

### DIFF
--- a/app/models/chargeHistory/ChargeHistoryModel.scala
+++ b/app/models/chargeHistory/ChargeHistoryModel.scala
@@ -36,9 +36,7 @@ case class ChargeHistoryModel(taxYear: String,
       reversalReason match {
         case "amended return" => "amend"
         case "Customer Request" => "request"
-        case error =>
-          Logger("application").error(s"Missing or non-matching history reason: $error found")
-          "unrecognisedReason"
+        case error => "unrecognisedReason"
       }
   }
 

--- a/app/models/chargeHistory/ChargeHistoryModel.scala
+++ b/app/models/chargeHistory/ChargeHistoryModel.scala
@@ -16,7 +16,6 @@
 
 package models.chargeHistory
 
-import play.api.Logger
 import play.api.libs.json.{Format, Json}
 import java.time.LocalDate
 


### PR DESCRIPTION
Loggers are not intended to be in Models, case error still returns string.