### PR TITLE
Auth fix | UnsupportedAffinityGroup being returned instead of InsufficentEnrolments

### DIFF
--- a/app/auth/authV2/actions/AuthoriseAndRetrieve.scala
+++ b/app/auth/authV2/actions/AuthoriseAndRetrieve.scala
@@ -66,7 +66,7 @@ class AuthoriseAndRetrieve @Inject()(val authorisedFunctions: FrontendAuthorised
 
       // Agent identified by ARN - previously parsed from enrolment here:
       // controllers.predicates.IncomeTaxAgentUser.agentReferenceNumber
-      def isAgent(): Predicate = AffinityGroup.Agent and Enrolment("HMRC-AS-AGENT")
+      def isAgent(): Predicate = Enrolment("HMRC-AS-AGENT") and AffinityGroup.Agent
 
       // previously authorised here:
       // auth.BaseFrontendController.AuthenticatedActions.asyncInternal


### PR DESCRIPTION
### Issue

With AffinityGroup first in the agent Predicate, an UnsupportedAffinityGroup exception was returned instead of an InsufficientEnrolments exception when the HMRC-MTD-IT enrolment was missing.

This resulted in user being redirected to the incorrect page when the enrolment is missing (GG, instead of cannot-access-service). This causes [acceptance test fails](https://build.tax.service.gov.uk/job/Payments/job/self-assessment-refund-ui-tests/919/cucumber-html-reports/report-feature_3_3069762375.html) for self-assessment-refund-frontend.

**To reproduce**: 
Direct in to http://localhost:9949/auth-login-stub/gg-sign-in
Enter **Redirect URL**: http://localhost:9081/report-quarterly/income-and-expenses/view/claim-refund?origin=PTA
Enter **NINO**: AY888887A
Enter **Confidence Level**: 250

**Expected result**: http://localhost:9081/report-quarterly/income-and-expenses/view/cannot-access-service
**Actual result**: http://localhost:9553/bas-gateway/sign-in?continue_url=http%3A%2F%2Flocalhost%3A9081%2Freport-quarterly%2Fincome-and-expenses%2Fview&origin=income-tax-view-change-frontend

### Fix

Switched the order of the predicates, now redirects as expected.


