### PR TITLE
MISUV-8687 Create new Reporting Frequency View

### DIFF
--- a/app/models/ReportingFrequencyViewModel.scala
+++ b/app/models/ReportingFrequencyViewModel.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import models.incomeSourceDetails.TaxYear
+
+case class ReportingFrequencyViewModel(
+                                        isAgent: Boolean,
+                                        currentTaxYear: TaxYear,
+                                        nextTaxYear: TaxYear,
+                                        optOutJourneyUrl: Option[String]
+                                      )

--- a/app/models/admin/FeatureSwitchName.scala
+++ b/app/models/admin/FeatureSwitchName.scala
@@ -96,7 +96,6 @@ object FeatureSwitchName {
       NavBarFs,
       CreditsRefundsRepay,
       PaymentHistoryRefunds,
-
       IncomeSourcesNewJourney,
       IncomeSources,
       OptOut,

--- a/app/models/admin/FeatureSwitchName.scala
+++ b/app/models/admin/FeatureSwitchName.scala
@@ -96,6 +96,7 @@ object FeatureSwitchName {
       NavBarFs,
       CreditsRefundsRepay,
       PaymentHistoryRefunds,
+
       IncomeSourcesNewJourney,
       IncomeSources,
       OptOut,

--- a/app/services/optout/OptOutService.scala
+++ b/app/services/optout/OptOutService.scala
@@ -137,7 +137,7 @@ class OptOutService @Inject()(itsaStatusUpdateConnector: ITSAStatusUpdateConnect
       _ <- repository.initialiseOptOutJourney(proposition)
     } yield (nextUpdatesQuarterlyReportingContentChecks(proposition), nextUpdatesOptOutViewModel(proposition))
   }
-
+  
   private def nextUpdatesQuarterlyReportingContentChecks(oop: OptOutProposition) = {
     val currentYearStatus = oop.currentTaxYear.status
     val previousYearStatus = oop.previousTaxYear.status

--- a/app/views/ReportingFrequencyView.scala.html
+++ b/app/views/ReportingFrequencyView.scala.html
@@ -1,0 +1,68 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import models.optin.OptInCompletedViewModel
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.components._
+@import views.html.layouts.unifiedLayout
+@import models.ReportingFrequencyViewModel
+
+@this(
+    mainTemplate: unifiedLayout,
+    h1: h1,
+    h2: h2,
+    p: p,
+    linkComponent: linkComponent,
+    bulletList: bulletPointList,
+    govukTable: GovukTable,
+    govukInsetText : GovukInsetText
+)
+
+@(viewModel: ReportingFrequencyViewModel)(implicit messages: Messages, user: auth.MtdItUser[_])
+
+@manageReportingFrequency = {
+
+    @h2(msg = "reporting.frequency.h2", optId = Some("manage-reporting-frequency-heading"))
+
+    @p(id=Some("change-reporting-frequency")){
+        @messages("reporting.frequency.manageReportingFrequency.p1")
+    }
+
+    @p(id=Some("what-you-can-do")){
+        @messages("reporting.frequency.manageReportingFrequency.p2")
+    }
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>
+            @linkComponent(controllers.optIn.routes.BeforeYouStartController.show(viewModel.isAgent).url, message = messages("reporting.frequency.manageReportingFrequency.b1.link", viewModel.currentTaxYear.startYear.toString, viewModel.currentTaxYear.endYear.toString))
+        </li>
+        @viewModel.optOutJourneyUrl.map{ url =>
+            <li>
+                @linkComponent(url, message = messages("reporting.frequency.manageReportingFrequency.b2.link", viewModel.nextTaxYear.startYear.toString, viewModel.nextTaxYear.endYear.toString))
+            </li>
+        }
+    </ul>
+}
+
+@mainTemplate(
+    pageTitle = messages("reporting.frequency.title"),
+    isAgent = viewModel.isAgent,
+    btaNavPartial = user.btaNavPartial
+) {
+
+    @h1(msg = "reporting.frequency.h1", id = Some("reporting-frequency-heading"))
+    @manageReportingFrequency
+}

--- a/app/views/components/linkComponent.scala.html
+++ b/app/views/components/linkComponent.scala.html
@@ -1,0 +1,36 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(
+    url: String,
+    classes: String = "",
+    message: String,
+    id: Option[String] = None,
+    target: Option[String] = None,
+    ariaLabel: Option[String] = None,
+    role: Option[String] = None,
+    rel: Option[String] = None,
+    additionalOpenTabMessage: Option[String] = None
+)(implicit messages: Messages)
+
+<a href="@url" class="govuk-link govuk-body @classes" @id.map(id => s"id=$id") @if(rel.isDefined){rel="@rel.map(c=>s"$c")"} @target.map(target => s"target=$target") @role.map(role => s"role=$role")>
+    @message
+    @if(target == Some("_blank")){
+        @messages("pagehelp.opensInNewTabText")@additionalOpenTabMessage.map(message => message)
+    }
+</a>

--- a/conf/messages
+++ b/conf/messages
@@ -2347,3 +2347,20 @@ optIn.confirmTaxYear.cancel                         = Cancel
 
 optIn.confirmNextTaxYear.heading                    = Confirm and opt in from {0} to {1} tax year onwards
 optIn.confirmNextTaxYear.desc                       = If you opt in for the next tax year, from {0} you will need to submit your quarterly updates through compatible software.
+
+
+# Reporting Frequency Page
+
+reporting.frequency.title = Your reporting frequency
+
+reporting.frequency.h1 = Your reporting frequency
+reporting.frequency.h2 = Manage your reporting frequency for all your businesses
+
+reporting.frequency.manageReportingFrequency.p1 = If you are reporting annually or voluntarily reporting quarterly, you may be able to change your reporting frequency for specific tax years.
+reporting.frequency.manageReportingFrequency.p2 = This is what you can do for all your businesses:
+reporting.frequency.manageReportingFrequency.b1.link = Opt in to quarterly reporting for the {0} to {1} tax year
+reporting.frequency.manageReportingFrequency.b2.link = Opt out of quarterly reporting and report annually from the {0} to {1} tax year onwards
+
+
+
+

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -2282,3 +2282,13 @@ optIn.confirmTaxYear.cancel                         = Canslo
 
 optIn.confirmNextTaxYear.heading                    = Cadarnhau ac optio i mewn ar gyfer blwyddyn dreth {0} i {1} ymlaen
 optIn.confirmNextTaxYear.desc                       = Os byddwch yn optio i mewn ar gyfer y flwyddyn dreth nesaf, o {0} ymlaen, bydd angen i chi gyflwyno’ch adroddiadau chwarterol drwy ddefnyddio meddalwedd sy’n cydweddu.
+
+# Reporting Frequency Page
+
+reporting.frequency.h2 = Rheoli amlder eich adroddiadau ar gyfer eich holl fusnesau
+
+reporting.frequency.manageReportingFrequency.p1 = Os ydych yn adrodd yn flynyddol, neu’n adrodd yn chwarterol yn wirfoddol, mae’n bosibl y byddwch yn gallu newid amlder eich adroddiadau ar gyfer blynyddoedd treth penodol.
+reporting.frequency.manageReportingFrequency.p2 = Yr hyn y gallwch ei wneud ar gyfer eich holl fusnesau:
+reporting.frequency.manageReportingFrequency.b1.link = Optio i mewn i adrodd yn chwarterol ar gyfer blwyddyn dreth {0} i {1}
+reporting.frequency.manageReportingFrequency.b2.link = Optio allan o adrodd yn chwarterol, a mynd ati i adrodd yn flynyddol o flwyddyn dreth {0} i {1} ymlaen
+

--- a/it/test/controllers/NextUpdatesControllerISpec.scala
+++ b/it/test/controllers/NextUpdatesControllerISpec.scala
@@ -182,6 +182,7 @@ class NextUpdatesControllerISpec extends ComponentSpecBase {
       }
 
       "the user has a Opt Out Feature Switch Enabled" in {
+        
         enable(OptOut)
 
         val currentTaxYear = dateService.getCurrentTaxYearEnd

--- a/it/test/controllers/ReportingFrequencyControllerISpec.scala
+++ b/it/test/controllers/ReportingFrequencyControllerISpec.scala
@@ -19,9 +19,9 @@ package controllers
 import com.github.tomakehurst.wiremock.client.WireMock
 import config.FrontendAppConfig
 import config.featureswitch.FeatureSwitching
-import helpers.servicemocks.{AuthStub, IncomeTaxViewChangeStub}
+import helpers.servicemocks.{AuthStub, ITSAStatusDetailsStub, IncomeTaxViewChangeStub}
 import models.admin.FeatureSwitchName.allFeatureSwitches
-import models.admin.ReportingFrequencyPage
+import models.admin.{OptOut, ReportingFrequencyPage}
 import org.jsoup.Jsoup
 import play.api.http.HeaderNames
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK}
@@ -61,11 +61,13 @@ class ReportingFrequencyControllerISpec extends ControllerISpecBase with Feature
 
         "return the ReportingFrequency page, OK - 200" in {
 
-          AuthStub.stubAuthorised()
-          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponseWoMigration)
-
           allFeatureSwitches.foreach(switch => disable(switch))
           enable(ReportingFrequencyPage)
+          enable(OptOut)
+
+          AuthStub.stubAuthorised()
+          IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, businessAndPropertyResponseWoMigration)
+          ITSAStatusDetailsStub.stubGetITSAStatusFutureYearsDetails(dateService.getCurrentTaxYearEnd)
 
           val res =
             httpClient

--- a/it/test/controllers/ReportingFrequencyControllerISpec.scala
+++ b/it/test/controllers/ReportingFrequencyControllerISpec.scala
@@ -74,8 +74,7 @@ class ReportingFrequencyControllerISpec extends ControllerISpecBase with Feature
               .execute[HttpResponse]
 
           res.futureValue.status shouldBe OK
-          //        Jsoup.parse(res.futureValue.body).title shouldBe "New page title"  //TODO: change the test to look for the title of the new page when implemented
-          res.futureValue.body shouldBe "Reporting Frequency Page - Placeholder"
+          Jsoup.parse(res.futureValue.body).title shouldBe "Your reporting frequency - Manage your Income Tax updates - GOV.UK"
         }
       }
     }

--- a/it/test/testConstants/IncomeSourceIntegrationTestConstants.scala
+++ b/it/test/testConstants/IncomeSourceIntegrationTestConstants.scala
@@ -153,8 +153,8 @@ object IncomeSourceIntegrationTestConstants {
   )
 
   val multipleBusinessesResponse: IncomeSourceDetailsResponse = IncomeSourceDetailsModel(
-    testNino,
-    testMtdItId,
+    nino = testNino,
+    mtdbsa = testMtdItId,
     businesses = List(
       business1,
       business2

--- a/test/testUtils/TestSupport.scala
+++ b/test/testUtils/TestSupport.scala
@@ -85,6 +85,7 @@ trait TestSupport extends UnitSpec with GuiceOneAppPerSuite with BeforeAndAfterA
 
   // Set fixed date for DateService
   lazy val fixedDate: LocalDate = LocalDate.of(2023, 12, 15)
+  
   implicit val dateService: DateService = new DateService {
 
     override def getCurrentDate: LocalDate = fixedDate

--- a/test/views/ReportingFrequencyViewSpec.scala
+++ b/test/views/ReportingFrequencyViewSpec.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import models.ReportingFrequencyViewModel
+import models.incomeSourceDetails.TaxYear
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.test.Helpers._
+import testUtils.TestSupport
+import views.html.ReportingFrequencyView
+import views.messages.ReportingFrequencyViewMessages._
+
+
+class ReportingFrequencyViewSpec extends TestSupport {
+
+  val view: ReportingFrequencyView = app.injector.instanceOf[ReportingFrequencyView]
+
+  def beforeYouStartUrl(isAgent: Boolean): String = controllers.optIn.routes.BeforeYouStartController.show(isAgent).url
+
+  def optOutChooseTaxYearUrl(isAgent: Boolean): String = controllers.optOut.routes.OptOutChooseTaxYearController.show(isAgent).url
+
+  def confirmOptOutUrl(isAgent: Boolean): String = controllers.optOut.routes.ConfirmOptOutController.show(isAgent).url
+
+  def bullet(i: Int): String = s"#main-content > div > div > div > ul > li:nth-child($i) > a"
+
+  object Selectors {
+    val h1 = "reporting-frequency-heading"
+    val h2 = "manage-reporting-frequency-heading"
+    val p1 = "change-reporting-frequency"
+    val p2 = "what-you-can-do"
+  }
+
+  "ReportingFrequencyView" when {
+
+    "the user is an Agent" should {
+
+      "return the correct content" in {
+
+        val isAgentFlag = true
+
+        val reportingFrequencyViewModel: ReportingFrequencyViewModel =
+          ReportingFrequencyViewModel(
+            isAgent = isAgentFlag,
+            TaxYear(2024, 2025),
+            TaxYear(2025, 2026),
+            Some(optOutChooseTaxYearUrl(isAgentFlag))
+          )
+
+        val pageDocument: Document =
+          Jsoup.parse(
+            contentAsString(
+              view.apply(
+                viewModel = reportingFrequencyViewModel
+              )
+            )
+          )
+
+        def testContentByIds(idsAndContent: Seq[(String, String)]): Unit =
+          idsAndContent.foreach {
+            case (selectors, content) =>
+              pageDocument.getElementById(selectors).text() shouldBe content
+          }
+
+        val expectedContent: Seq[(String, String)] =
+          Seq(
+            Selectors.h1 -> h1Content,
+            Selectors.h2 -> h2Content,
+            Selectors.p1 -> p1Content,
+            Selectors.p2 -> p2Content,
+          )
+
+        pageDocument.title() shouldBe agentTitle
+
+        testContentByIds(expectedContent)
+
+        pageDocument.select(bullet(1)).text() shouldBe bullet1Content
+
+        pageDocument.select(bullet(1)).attr("href") shouldBe beforeYouStartUrl(isAgentFlag)
+
+        pageDocument.select(bullet(2)).text() shouldBe bullet2Content
+
+        pageDocument.select(bullet(2)).attr("href") shouldBe optOutChooseTaxYearUrl(isAgentFlag)
+      }
+    }
+
+    "the user is Non-Agent" should {
+
+      "return the correct content" in {
+
+        val isAgentFlag = false
+
+        val reportingFrequencyViewModel: ReportingFrequencyViewModel =
+          ReportingFrequencyViewModel(
+            isAgent = isAgentFlag,
+            TaxYear(2024, 2025),
+            TaxYear(2025, 2026),
+            Some(confirmOptOutUrl(isAgentFlag))
+          )
+
+        val pageDocument: Document =
+          Jsoup.parse(
+            contentAsString(
+              view.apply(
+                viewModel = reportingFrequencyViewModel
+              )
+            )
+          )
+
+        def testContentByIds(idsAndContent: Seq[(String, String)]): Unit =
+          idsAndContent.foreach {
+            case (selectors, content) =>
+              pageDocument.getElementById(selectors).text() shouldBe content
+          }
+
+        val expectedContent: Seq[(String, String)] =
+          Seq(
+            Selectors.h1 -> h1Content,
+            Selectors.h2 -> h2Content,
+            Selectors.p1 -> p1Content,
+            Selectors.p2 -> p2Content,
+          )
+
+        pageDocument.title() shouldBe title
+
+        testContentByIds(expectedContent)
+
+        pageDocument.select(bullet(1)).text() shouldBe bullet1Content
+
+        pageDocument.select(bullet(1)).attr("href") shouldBe beforeYouStartUrl(isAgentFlag)
+
+        pageDocument.select(bullet(2)).text() shouldBe bullet2Content
+
+        pageDocument.select(bullet(2)).attr("href") shouldBe confirmOptOutUrl(isAgentFlag)
+      }
+    }
+  }
+}

--- a/test/views/messages/ReportingFrequencyViewMessages.scala
+++ b/test/views/messages/ReportingFrequencyViewMessages.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.messages
+
+object ReportingFrequencyViewMessages {
+
+  val title = "Your reporting frequency - Manage your Income Tax updates - GOV.UK"
+  val agentTitle = "Your reporting frequency - Manage your client’s Income Tax updates - GOV.UK"
+  val h1Content = "Your reporting frequency"
+  val h2Content = "Manage your reporting frequency for all your businesses"
+  val p1Content = "If you are reporting annually or voluntarily reporting quarterly, you may be able to change your reporting frequency for specific tax years."
+  val p2Content = "This is what you can do for all your businesses:"
+  val bullet1Content = "Opt in to quarterly reporting for the 2024 to 2025 tax year"
+  val bullet2Content = "Opt out of quarterly reporting and report annually from the 2025 to 2026 tax year onwards"
+
+}


### PR DESCRIPTION
opt out does not have a journey start page. 

The logic for the links are off but we have tickets to update the link logic and have dynamic changing links for the page based on the user statuses and journey eligibility.

For now placing some logic as a placeholder and for demoing the page.