### PR TITLE
MISUV-8943 Add routing to opt out cancelled for multi year and update logic for determining tax year

### DIFF
--- a/app/controllers/incomeSources/add/IncomeSourceReportingMethodController.scala
+++ b/app/controllers/incomeSources/add/IncomeSourceReportingMethodController.scala
@@ -158,7 +158,7 @@ class IncomeSourceReportingMethodController @Inject()(val authActions: AuthActio
       case Some(LatencyDetails(_, _, _, taxYear2, _)) if taxYear2.toInt < currentTaxYear =>
         Future.successful(None)
       case Some(LatencyDetails(_, taxYear1, taxYear1LatencyIndicator, taxYear2, taxYear2LatencyIndicator)) =>
-        calculationListService.isTaxYearCrystallised(taxYear1.toInt).flatMap {
+        calculationListService.determineTaxYearCrystallised(taxYear1.toInt).flatMap {
           case true =>
             Future.successful {
               Some(IncomeSourceReportingMethodViewModel(latencyYear1 = None, latencyYear2 = Some(LatencyYear(taxYear2, taxYear2LatencyIndicator))))

--- a/app/controllers/incomeSources/manage/ManageIncomeSourceDetailsController.scala
+++ b/app/controllers/incomeSources/manage/ManageIncomeSourceDetailsController.scala
@@ -181,8 +181,8 @@ class ManageIncomeSourceDetailsController @Inject()(val view: ManageIncomeSource
     latencyDetails match {
       case Some(x) =>
         for {
-          isTY1Crystallised <- calculationListService.isTaxYearCrystallised(x.taxYear1.toInt)
-          isTY2Crystallised <- calculationListService.isTaxYearCrystallised(x.taxYear2.toInt)
+          isTY1Crystallised <- calculationListService.determineTaxYearCrystallised(x.taxYear1.toInt)
+          isTY2Crystallised <- calculationListService.determineTaxYearCrystallised(x.taxYear2.toInt)
         } yield {
           Some(List(isTY1Crystallised, isTY2Crystallised))
         }

--- a/app/controllers/manageBusinesses/add/IncomeSourceReportingMethodController.scala
+++ b/app/controllers/manageBusinesses/add/IncomeSourceReportingMethodController.scala
@@ -169,7 +169,7 @@ class IncomeSourceReportingMethodController @Inject()(val authActions: AuthActio
       case Some(LatencyDetails(_, _, _, taxYear2, _)) if taxYear2.toInt < currentTaxYear =>
         Future.successful(None)
       case Some(LatencyDetails(_, taxYear1, taxYear1LatencyIndicator, taxYear2, taxYear2LatencyIndicator)) =>
-        calculationListService.isTaxYearCrystallised(taxYear1.toInt).flatMap {
+        calculationListService.determineTaxYearCrystallised(taxYear1.toInt).flatMap {
           case true =>
             Future.successful {
               Some(IncomeSourceReportingMethodViewModel(latencyYear1 = None, latencyYear2 = Some(LatencyYear(taxYear2, taxYear2LatencyIndicator))))

--- a/app/controllers/manageBusinesses/manage/ManageIncomeSourceDetailsController.scala
+++ b/app/controllers/manageBusinesses/manage/ManageIncomeSourceDetailsController.scala
@@ -209,8 +209,8 @@ class ManageIncomeSourceDetailsController @Inject()(val view: ManageIncomeSource
     latencyDetails match {
       case Some(x) =>
         for {
-          isTY1Crystallised <- calculationListService.isTaxYearCrystallised(x.taxYear1.toInt)
-          isTY2Crystallised <- calculationListService.isTaxYearCrystallised(x.taxYear2.toInt)
+          isTY1Crystallised <- calculationListService.determineTaxYearCrystallised(x.taxYear1.toInt)
+          isTY2Crystallised <- calculationListService.determineTaxYearCrystallised(x.taxYear2.toInt)
         } yield {
           Some(List(isTY1Crystallised, isTY2Crystallised))
         }

--- a/app/services/CalculationListService.scala
+++ b/app/services/CalculationListService.scala
@@ -63,10 +63,10 @@ class CalculationListService @Inject()(calculationListConnector: CalculationList
   }
 
   def isTaxYearCrystallised(taxYear: TaxYear)(implicit user: MtdItUser[_], hc: HeaderCarrier): Future[Boolean] = {
-    isTaxYearCrystallised(taxYear.endYear)
+    determineTaxYearCrystallised(taxYear.endYear)
   }
 
-  def isTaxYearCrystallised(taxYear: Int)(implicit user: MtdItUser[_], hc: HeaderCarrier): Future[Boolean] = {
+  def determineTaxYearCrystallised(taxYear: Int)(implicit user: MtdItUser[_], hc: HeaderCarrier): Future[Boolean] = {
 
     val currentTaxYearEnd = dateService.getCurrentTaxYearEnd
     val futureTaxYear = taxYear >= currentTaxYearEnd

--- a/app/views/optOut/OptOutCancelledView.scala.html
+++ b/app/views/optOut/OptOutCancelledView.scala.html
@@ -32,7 +32,7 @@
 )
 
 
-@(isAgent:Boolean, currentTaxYearStart: String, currentTaxYearEnd: String)(implicit messages: Messages, user: auth.MtdItUser[_])
+@(isAgent:Boolean, taxYearOpt: Option[TaxYear])(implicit messages: Messages, user: auth.MtdItUser[_])
 
 @nextUpdatesUrl = @{
     if(isAgent) {
@@ -61,8 +61,10 @@
 
     @h1(id = Some("opt-out-cancelled"), msg = messages("optout.cancelled.h1"), classes = "govuk-heading-l")
 
-    @p(id=Some("continue-to-report-quarterly")) {
-        @messages("optout.cancelled.p1", currentTaxYearStart, currentTaxYearEnd)
+    @taxYearOpt.map { taxYear =>
+        @p(id=Some("continue-to-report-quarterly")) {
+            @messages("optout.cancelled.p1", taxYear.startYear.toString, taxYear.endYear.toString)
+        }
     }
 
     <ul class="govuk-list govuk-list--bullet">

--- a/it/test/controllers/optOut/OptOutCancelledControllerISpec.scala
+++ b/it/test/controllers/optOut/OptOutCancelledControllerISpec.scala
@@ -42,11 +42,17 @@ class OptOutCancelledControllerISpec extends ControllerISpecHelper with FeatureS
   mtdAllRoles.foreach { case mtdUserRole =>
     val path = getPath(mtdUserRole)
     val additionalCookies = getAdditionalCookies(mtdUserRole)
+
     s"GET $path" when {
+
       s"a user is a $mtdUserRole" that {
+
         "is authenticated, with a valid enrolment" should {
+
           "render the choose tax year page" when {
+
             "only single tax year is voluntary, CY-1 = Mandated, CY = Voluntary, CY+1 = Mandated" in {
+
               val previousTaxYear = dateService.getCurrentTaxYearEnd - 1
               stubAuthorised(mtdUserRole)
 
@@ -68,11 +74,9 @@ class OptOutCancelledControllerISpec extends ControllerISpecHelper with FeatureS
                 pageTitle(mtdUserRole, "optout.cancelled.title")
               )
             }
-          }
-
-          "render the error page" when {
 
             "no tax year is voluntary, CY-1 = Mandated, CY = Mandated, CY+1 = Mandated" in {
+
               val previousTaxYear = dateService.getCurrentTaxYearEnd - 1
 
               stubAuthorised(mtdUserRole)
@@ -90,8 +94,8 @@ class OptOutCancelledControllerISpec extends ControllerISpecHelper with FeatureS
               val result = buildGETMTDClient(path, additionalCookies).futureValue
 
               result should have(
-                httpStatus(INTERNAL_SERVER_ERROR),
-                pageTitleCustom("Sorry, there is a problem with the service - GOV.UK")
+                httpStatus(OK),
+                pageTitle(mtdUserRole, "optout.cancelled.title")
               )
             }
 
@@ -114,10 +118,9 @@ class OptOutCancelledControllerISpec extends ControllerISpecHelper with FeatureS
               val result = buildGETMTDClient(path, additionalCookies).futureValue
 
               result should have(
-                httpStatus(INTERNAL_SERVER_ERROR),
-                pageTitleCustom("Sorry, there is a problem with the service - GOV.UK")
+                httpStatus(OK),
+                pageTitle(mtdUserRole, "optout.cancelled.title")
               )
-
             }
           }
         }

--- a/it/test/controllers/optOut/OptOutCancelledControllerISpec.scala
+++ b/it/test/controllers/optOut/OptOutCancelledControllerISpec.scala
@@ -22,7 +22,7 @@ import controllers.ControllerISpecHelper
 import enums.{MTDIndividual, MTDUserRole}
 import helpers.servicemocks.{CalculationListStub, ITSAStatusDetailsStub, IncomeTaxViewChangeStub}
 import models.itsaStatus.ITSAStatus
-import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK}
+import play.api.http.Status.{OK}
 import testConstants.BaseIntegrationTestConstants.{testMtditid, testNino}
 import testConstants.CalculationListIntegrationTestConstants
 import testConstants.IncomeSourceIntegrationTestConstants.businessAndPropertyResponseWoMigration

--- a/test/controllers/incomeSources/add/IncomeSourceReportingMethodControllerSpec.scala
+++ b/test/controllers/incomeSources/add/IncomeSourceReportingMethodControllerSpec.scala
@@ -131,13 +131,13 @@ class IncomeSourceReportingMethodControllerSpec extends MockAuthActions
 
   def setupMockIsTaxYearCrystallisedCall(scenario: Scenario): OngoingStubbing[Future[Boolean]] = scenario match {
     case FIRST_YEAR_CRYSTALLISED =>
-      when(mockCalculationListService.isTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2022))(any, any)).thenReturn(Future(true))
+      when(mockCalculationListService.determineTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2022))(any, any)).thenReturn(Future(true))
     case CURRENT_TAX_YEAR_IN_LATENCY_YEARS =>
-      when(mockCalculationListService.isTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2022))(any, any)).thenReturn(Future(false))
+      when(mockCalculationListService.determineTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2022))(any, any)).thenReturn(Future(false))
     case CURRENT_TAX_YEAR_2024_IN_LATENCY_YEARS =>
-      when(mockCalculationListService.isTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2023))(any, any)).thenReturn(Future(false))
+      when(mockCalculationListService.determineTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2023))(any, any)).thenReturn(Future(false))
     case _ =>
-      when(mockCalculationListService.isTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2023))(any, any)).thenReturn(Future(false))
+      when(mockCalculationListService.determineTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2023))(any, any)).thenReturn(Future(false))
   }
 
   def setupMockUpdateIncomeSourceCall(numberOfSuccessResponses: Int): Unit = {

--- a/test/controllers/manageBusinesses/add/IncomeSourceReportingMethodControllerSpec.scala
+++ b/test/controllers/manageBusinesses/add/IncomeSourceReportingMethodControllerSpec.scala
@@ -130,13 +130,13 @@ class IncomeSourceReportingMethodControllerSpec extends MockAuthActions with Moc
 
   def setupMockIsTaxYearCrystallisedCall(scenario: Scenario): OngoingStubbing[Future[Boolean]] = scenario match {
     case FIRST_YEAR_CRYSTALLISED =>
-      when(mockCalculationListService.isTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2022))(any, any)).thenReturn(Future(true))
+      when(mockCalculationListService.determineTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2022))(any, any)).thenReturn(Future(true))
     case CURRENT_TAX_YEAR_IN_LATENCY_YEARS =>
-      when(mockCalculationListService.isTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2022))(any, any)).thenReturn(Future(false))
+      when(mockCalculationListService.determineTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2022))(any, any)).thenReturn(Future(false))
     case CURRENT_TAX_YEAR_2024_IN_LATENCY_YEARS =>
-      when(mockCalculationListService.isTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2023))(any, any)).thenReturn(Future(false))
+      when(mockCalculationListService.determineTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2023))(any, any)).thenReturn(Future(false))
     case _ =>
-      when(mockCalculationListService.isTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2023))(any, any)).thenReturn(Future(false))
+      when(mockCalculationListService.determineTaxYearCrystallised(ArgumentMatchers.eq(TAX_YEAR_2023))(any, any)).thenReturn(Future(false))
   }
 
   def setupMockUpdateIncomeSourceCall(numberOfSuccessResponses: Int): Unit = {

--- a/test/mocks/services/MockCalculationListService.scala
+++ b/test/mocks/services/MockCalculationListService.scala
@@ -35,7 +35,7 @@ trait MockCalculationListService extends UnitSpec with BeforeAndAfterEach {
     reset(mockCalculationListService)
   }
   def setupMockTaxYearNotCrystallised(): Unit =
-    when(mockCalculationListService.isTaxYearCrystallised(ArgumentMatchers.anyInt())(any(), any()))
+    when(mockCalculationListService.determineTaxYearCrystallised(ArgumentMatchers.anyInt())(any(), any()))
       .thenReturn(Future.successful(false))
 
   def setupMockIsTaxYearCrystallisedCall(taxYear: TaxYear)(out: Future[Boolean]): Unit = {
@@ -44,14 +44,14 @@ trait MockCalculationListService extends UnitSpec with BeforeAndAfterEach {
       .thenReturn(out)
   }
   def setupMockTaxYearCrystallised(): Unit =
-    when(mockCalculationListService.isTaxYearCrystallised(ArgumentMatchers.anyInt())(any(), any()))
+    when(mockCalculationListService.determineTaxYearCrystallised(ArgumentMatchers.anyInt())(any(), any()))
       .thenReturn(Future.successful(true))
 
   def setupMockTaxYearCrystallised(year: Int): Unit =
-    when(mockCalculationListService.isTaxYearCrystallised(ArgumentMatchers.eq(year))(any(), any()))
+    when(mockCalculationListService.determineTaxYearCrystallised(ArgumentMatchers.eq(year))(any(), any()))
       .thenReturn(Future.successful(true))
 
   def setupMockTaxYearNotCrystallised(year: Int): Unit =
-    when(mockCalculationListService.isTaxYearCrystallised(ArgumentMatchers.eq(year))(any(), any()))
+    when(mockCalculationListService.determineTaxYearCrystallised(ArgumentMatchers.eq(year))(any(), any()))
       .thenReturn(Future.successful(false))
 }

--- a/test/services/CalculationListServiceSpec.scala
+++ b/test/services/CalculationListServiceSpec.scala
@@ -77,25 +77,25 @@ class CalculationListServiceSpec extends TestSupport with MockCalculationListCon
       val taxYearEnd = "2023"
       "returns Some(true)" in {
         setupGetLegacyCalculationList(testNino, taxYearEnd)(CalculationListTestConstants.calculationListFull)
-        TestCalculationListService.isTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe true
+        TestCalculationListService.determineTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe true
       }
       "returns Some(false)" in {
         setupGetLegacyCalculationList(testNino, taxYearEnd)(CalculationListTestConstants.calculationListFalseFull)
-        TestCalculationListService.isTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
+        TestCalculationListService.determineTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
       }
       "returns None" in {
         setupGetLegacyCalculationList(testNino, taxYearEnd)(CalculationListTestConstants.calculationListMin)
-        TestCalculationListService.isTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
+        TestCalculationListService.determineTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
       }
       "returns Some(false) given 404 response from 1404" in {
         val error = CalculationListErrorModel(NOT_FOUND, "not found")
         setupGetLegacyCalculationList(testNino, taxYearEnd)(error)
-        TestCalculationListService.isTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
+        TestCalculationListService.determineTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
       }
       "returns InternalServerException" in {
         val error = CalculationListErrorModel(IM_A_TEAPOT, "I'm a teapot")
         setupGetLegacyCalculationList(testNino, taxYearEnd)(error)
-        TestCalculationListService.isTaxYearCrystallised(taxYearEnd.toInt).failed.futureValue.getMessage shouldBe error.message
+        TestCalculationListService.determineTaxYearCrystallised(taxYearEnd.toInt).failed.futureValue.getMessage shouldBe error.message
       }
     }
 
@@ -104,37 +104,37 @@ class CalculationListServiceSpec extends TestSupport with MockCalculationListCon
       val testTaxYearRange = "23-24"
       "returns Some(true)" in {
         setupGetCalculationList(testNino, testTaxYearRange)(CalculationListTestConstants.calculationListFull)
-        TestCalculationListService.isTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe true
+        TestCalculationListService.determineTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe true
       }
       "returns Some(false)" in {
         setupGetCalculationList(testNino, testTaxYearRange)(CalculationListTestConstants.calculationListFalseFull)
-        TestCalculationListService.isTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
+        TestCalculationListService.determineTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
       }
       "returns None" in {
         setupGetCalculationList(testNino, testTaxYearRange)(CalculationListTestConstants.calculationListMin)
-        TestCalculationListService.isTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
+        TestCalculationListService.determineTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
       }
       "returns Some(false) given 404 response from 1896" in {
         val error = CalculationListErrorModel(NOT_FOUND, "not found")
         setupGetCalculationList(testNino, testTaxYearRange)(error)
-        TestCalculationListService.isTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
+        TestCalculationListService.determineTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
       }
       "returns InternalServerException" in {
         val error = CalculationListErrorModel(IM_A_TEAPOT, "I'm a teapot")
         setupGetCalculationList(testNino, testTaxYearRange)(error)
-        TestCalculationListService.isTaxYearCrystallised(taxYearEnd.toInt).failed.futureValue.getMessage shouldBe error.message
+        TestCalculationListService.determineTaxYearCrystallised(taxYearEnd.toInt).failed.futureValue.getMessage shouldBe error.message
       }
     }
     "for year 2024-25" should {
       "returns Some(false)" in {
         val taxYearEnd = "2025"
-        TestCalculationListService.isTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
+        TestCalculationListService.determineTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
       }
     }
     "for year 2025-26" should {
       "returns Some(false)" in {
         val taxYearEnd = "2026"
-        TestCalculationListService.isTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
+        TestCalculationListService.determineTaxYearCrystallised(taxYearEnd.toInt).futureValue shouldBe false
       }
     }
   }

--- a/test/views/optOut/OptOutCancelledViewSpec.scala
+++ b/test/views/optOut/OptOutCancelledViewSpec.scala
@@ -73,8 +73,7 @@ class OptOutCancelledViewSpec extends TestSupport {
             contentAsString(
               view.apply(
                 isAgent = isAgentFlag,
-                currentTaxYearStart = dateService.getCurrentTaxYear.startYear.toString,
-                currentTaxYearEnd = dateService.getCurrentTaxYear.endYear.toString,
+                taxYearOpt = Some(dateService.getCurrentTaxYear)
               )
             )
           )
@@ -122,8 +121,7 @@ class OptOutCancelledViewSpec extends TestSupport {
             contentAsString(
               view.apply(
                 isAgent = isAgentFlag,
-                currentTaxYearStart = dateService.getCurrentTaxYear.startYear.toString,
-                currentTaxYearEnd = dateService.getCurrentTaxYear.endYear.toString,
+                taxYearOpt = Some(dateService.getCurrentTaxYear)
               )
             )
           )


### PR DESCRIPTION
Added routing, had to adjust the logic to handle multi years  and moved it to the service out of the controller, hopefully making it easier to test and then cleaned up the tests. Page also handles when a tax year intent is not chosen, since there is cancel link for a multi year scenario. It allows the user to cancel before a year is chosen but the current view has content which depends on a chose tax year. Thus made the paragraph optional. Might need to check with design.