### PR TITLE
MISUV-9007 Adding scenario based content for optout confirmed page

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -59,7 +59,6 @@ class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, val config
   //SA for Agents Online Service
   lazy val saForAgents: String = "https://www.gov.uk/guidance/self-assessment-for-agents-online-service"
 
-
   //GG Sign In via BAS Gateway
   lazy val signInUrl: String = servicesConfig.getString("base.sign-in")
   lazy val ggSignInUrl: String = servicesConfig.getString("government-gateway.sign-in.url")
@@ -188,5 +187,8 @@ class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, val config
   lazy val timeMachineAddDays: Int = servicesConfig.getInt("time-machine.add-days")
 
   lazy val isSessionDataStorageEnabled: Boolean = servicesConfig.getBoolean("feature-switch.enable-session-data-storage")
+
+  val selfAssessmentTaxReturn = servicesConfig.getString("external-urls.self-assessment-tax-return-link")
+  val compatibleSoftwareLink = servicesConfig.getString("external-urls.compatible-software-link")
 
 }

--- a/app/enums/ChosenTaxYear.scala
+++ b/app/enums/ChosenTaxYear.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package enums
+
+sealed trait ChosenTaxYear
+
+case object PreviousTaxYear extends ChosenTaxYear
+
+case object CurrentTaxYear extends ChosenTaxYear
+
+case object NextTaxYear extends ChosenTaxYear
+
+case object NoChosenTaxYear extends ChosenTaxYear
+
+
+

--- a/app/services/optout/OptOutService.scala
+++ b/app/services/optout/OptOutService.scala
@@ -22,6 +22,7 @@ import auth.MtdItUser
 import cats.data.OptionT
 import connectors.itsastatus.ITSAStatusUpdateConnector
 import connectors.itsastatus.ITSAStatusUpdateConnectorModel.{ITSAStatusUpdateResponse, ITSAStatusUpdateResponseFailure}
+import enums._
 import models.incomeSourceDetails.TaxYear
 import models.itsaStatus.ITSAStatus
 import models.itsaStatus.ITSAStatus.{ITSAStatus, Mandated, Voluntary}
@@ -253,6 +254,20 @@ class OptOutService @Inject()(
         case (false, true) => chosenTaxYear
         case _ => singleTaxYear
       }
+    }
+  }
+
+
+  def determineOptOutIntentYear()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[ChosenTaxYear] = {
+    repository.fetchSavedIntent().map {
+      case Some(chosenYear) if chosenYear == dateService.getCurrentTaxYear.previousYear =>
+        PreviousTaxYear
+      case Some(chosenYear) if chosenYear == dateService.getCurrentTaxYear =>
+        CurrentTaxYear
+      case Some(chosenYear) if chosenYear == dateService.getCurrentTaxYear.nextYear =>
+        NextTaxYear
+      case _ =>
+        NoChosenTaxYear
     }
   }
 

--- a/app/viewUtils/ConfirmedOptOutViewUtils.scala
+++ b/app/viewUtils/ConfirmedOptOutViewUtils.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewUtils
+
+import config.FrontendAppConfig
+import enums.{ChosenTaxYear, CurrentTaxYear, NextTaxYear}
+import models.itsaStatus.ITSAStatus.{Annual, ITSAStatus, Mandated, Voluntary}
+import play.api.i18n.Messages
+import play.twirl.api.{Html, HtmlFormat}
+
+import javax.inject.Inject
+
+class ConfirmedOptOutViewUtils @Inject()(
+                                          link: views.html.components.link,
+                                          h2: views.html.components.h2,
+                                          p: views.html.components.p,
+                                          appConfig: FrontendAppConfig
+                                        ) {
+
+
+  val selfAssessmentTaxReturnLink = appConfig.selfAssessmentTaxReturn
+  val compatibleSoftwareLink = appConfig.compatibleSoftwareLink
+
+  private def submitYourTaxReturnHeading()(implicit messages: Messages): HtmlFormat.Appendable =
+    h2(msg = "optout.confirmedOptOut.submitTax", optId = Some("submit-tax-heading"))
+
+  private def firstParagraph()(implicit messages: Messages): HtmlFormat.Appendable =
+    p(id = Some("now-you-have-opted-out")) {
+      HtmlFormat.fill(
+        Seq(
+          Html(messages("optout.confirmedOptOut.submitTax.confirmed.p1")),
+          link(link = selfAssessmentTaxReturnLink, id = Some("fill-your-tax-return-link"), messageKey = "optout.confirmedOptOut.submitTax.confirmed.p1.link", target = Some("_blank"), additionalOpenTabMessage = Some("."))
+        )
+      )
+    }
+
+  private def secondParagraph()(implicit messages: Messages): HtmlFormat.Appendable =
+    p(id = Some("tax-year-reporting-quarterly")) {
+      HtmlFormat.fill(
+        Seq(
+          Html(messages("optout.confirmedOptOut.submitTax.confirmed.p2")),
+          link(link = compatibleSoftwareLink, id = Some("compatible-software-link"), messageKey = "optout.confirmedOptOut.submitTax.confirmed.p2.link", target = Some("_blank"), additionalOpenTabMessage = Some("."))
+        )
+      )
+    }
+
+  def submitYourTaxReturnContent(
+                                  `itsaStatusCY-1`: ITSAStatus,
+                                  itsaStatusCY: ITSAStatus,
+                                  `itsaStatusCY+1`: ITSAStatus,
+                                  chosenTaxYear: ChosenTaxYear,
+                                  isMultiYear: Boolean,
+                                  isPreviousYearCrystallised: Boolean
+                                )(implicit messages: Messages): Option[Html] = {
+
+    (`itsaStatusCY-1`, itsaStatusCY, `itsaStatusCY+1`, chosenTaxYear) match {
+      case (Voluntary | Mandated, Voluntary | Mandated, Annual, CurrentTaxYear) if isMultiYear =>
+        Some(
+          HtmlFormat.fill(
+            Seq(submitYourTaxReturnHeading, firstParagraph, secondParagraph)
+          )
+        )
+      case (Voluntary | Mandated, Voluntary | Mandated, Voluntary | Mandated, CurrentTaxYear) if isMultiYear && isPreviousYearCrystallised =>
+        Some(
+          HtmlFormat.fill(
+            Seq(submitYourTaxReturnHeading, firstParagraph)
+          )
+        )
+      case (Voluntary | Mandated, Voluntary | Mandated, Voluntary | Mandated, CurrentTaxYear | NextTaxYear) if isMultiYear =>
+        Some(
+          HtmlFormat.fill(
+            Seq(submitYourTaxReturnHeading, firstParagraph, secondParagraph)
+          )
+        )
+      case (Voluntary | Mandated, Annual, Voluntary | Mandated, NextTaxYear) if isMultiYear =>
+        Some(
+          HtmlFormat.fill(
+            Seq(submitYourTaxReturnHeading, firstParagraph, secondParagraph)
+          )
+        )
+      case (Annual, Voluntary | Mandated, Voluntary | Mandated, NextTaxYear) if isMultiYear =>
+        Some(
+          HtmlFormat.fill(
+            Seq(submitYourTaxReturnHeading, firstParagraph, secondParagraph)
+          )
+        )
+      case (Voluntary | Mandated, Voluntary | Mandated, Annual, CurrentTaxYear) if isMultiYear =>
+        Some(
+          HtmlFormat.fill(
+            Seq(submitYourTaxReturnHeading, firstParagraph, secondParagraph)
+          )
+        )
+      case _ =>
+        Some(
+          HtmlFormat.fill(
+            Seq(submitYourTaxReturnHeading, firstParagraph)
+          )
+        )
+    }
+  }
+}

--- a/app/views/optOut/ConfirmedOptOut.scala.html
+++ b/app/views/optOut/ConfirmedOptOut.scala.html
@@ -31,7 +31,12 @@
     govukInsetText : GovukInsetText
 )
 
-@(viewModel: ConfirmedOptOutViewModel, isAgent: Boolean = false, showReportingFrequencyContent: Boolean)(implicit messages: Messages, user: auth.MtdItUser[_])
+@(
+    viewModel: ConfirmedOptOutViewModel,
+    isAgent: Boolean = false,
+    showReportingFrequencyContent: Boolean,
+    submitYourTaxReturnContent: Option[Html]
+)(implicit messages: Messages, user: auth.MtdItUser[_])
 
 
 @panelBody = @{
@@ -93,12 +98,12 @@
 @revisedDeadlinesBlock = {
     <div id="revised-deadlines" class="govuk-!-margin-bottom-7 govuk-!-margin-top-8">
         <h2 id="revised-deadlines-heading" class="govuk-heading-m" >@messages("optout.confirmedOptOut.yourRevisedDeadlines.h2")</h2>
-        <p id="revised-deadlines-p1" class="govuk-body" >@Html(messages("optout.confirmedOptOut.yourRevisedDeadlines.desc1", viewModel.startYear, viewModel.endYear, viewModel.nextYear))</p>
+        <p id="revised-deadlines-p1" class="govuk-body">@Html(messages("optout.confirmedOptOut.yourRevisedDeadlines.desc1", viewModel.startYear, viewModel.endYear, viewModel.nextYear))</p>
         <p id="view-upcoming-updates">
             @link(
                 id = Some("view-upcoming-updates-link"),
                 link = if(isAgent) controllers.routes.NextUpdatesController.showAgent.url else controllers.routes.NextUpdatesController.show().url,
-                messageKey = "optout.confirmedOptOut.viewUpcomingUpdates.text"
+                messageKey = "optout.confirmedOptOut.viewUpcomingDeadlines.text"
             )
         </p>
         <p id="your-reporting-frequency-block" class="govuk-body">
@@ -110,11 +115,13 @@
 }
 
 @submitYourTaxReturnBlock = {
-    <div id="submit-tax" class="govuk-!-margin-bottom-7  govuk-!-margin-top-8">
-        <h2 id="submit-tax-heading" class="govuk-heading-m" >@messages("optout.confirmedOptOut.submitTax")</h2>
-        <p id="submit-tax-p1" class="govuk-body" >@messages("optout.confirmedOptOut.submitTax.desc1")</p>
-        <p id="submit-tax-p2" class="govuk-body" >@messages("optout.confirmedOptOut.submitTax.desc2")</p>
-    </div>
+
+        @submitYourTaxReturnContent.map{ content =>
+            <div id="submit-tax" class="govuk-!-margin-bottom-7  govuk-!-margin-top-8">
+                @content
+            </div>
+        }
+
 }
 
 @reportingUpdatesBlock = {
@@ -138,7 +145,8 @@
                     id = Some("sign-up-criteria-ext"),
                     target = Some("_blank"),
                     link = externalRefLink,
-                    messageKey = "optout.confirmedOptOut.reportQuarterly.desc3.anchor-text"  )
+                    messageKey = "optout.confirmedOptOut.reportQuarterly.desc3.anchor-text"
+                )
 
                 Html(messages("optout.confirmedOptOut.reportQuarterly.desc3", anchor.toString()))
             }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -332,6 +332,11 @@ internalServiceHostPatterns = [ "localhost" ]
 
 accessibility-statement.service-path = "/income-tax-view-change"
 
+external-urls {
+    self-assessment-tax-return-link = "https://www.gov.uk/log-in-file-self-assessment-tax-return"
+    compatible-software-link = "https://www.gov.uk/guidance/find-software-thats-compatible-with-making-tax-digital-for-income-tax"
+}
+
 encryption {
   key = "QmFyMTIzNDVCYXIxMjM0NQ=="
   isEnabled = false

--- a/conf/messages
+++ b/conf/messages
@@ -2137,12 +2137,18 @@ optout.confirmedOptOut.taxYear                                   = You are repor
 optout.confirmedOptOut.one-year                                  = You are reporting annually for the {0} to {1} tax year
 optout.confirmedOptOut.yourRevisedDeadlines.h2                   = Your revised deadlines
 optout.confirmedOptOut.yourRevisedDeadlines.desc1                = Your tax return for the {0} to {1} tax year is due by <b>31 January {2}</b>.
-optout.confirmedOptOut.viewUpcomingUpdates.text                  = View your upcoming updates
+optout.confirmedOptOut.viewUpcomingDeadlines.text                = View your upcoming deadlines
 optout.confirmedOptOut.yourRevisedDeadlines.desc2                = You can decide at any time to opt back in to reporting quarterly for all of your businesses on {0} page.
 optout.confirmedOptOut.yourReportingFrequency.text               = your reporting frequency
+
 optout.confirmedOptOut.submitTax                                 = Submit your tax return
-optout.confirmedOptOut.submitTax.desc1                           = When reporting annually, you can submit your tax return directly through your HMRC online account or software compatible.
-optout.confirmedOptOut.submitTax.desc2                           = However, compatible software is required for any tax years for which you are reporting quarterly.
+
+optout.confirmedOptOut.submitTax.confirmed.p1                    = Now you have opted out, you will need to go back to the way you have previously
+optout.confirmedOptOut.submitTax.confirmed.p1.link               = filed your Self Assessment tax return
+
+optout.confirmedOptOut.submitTax.confirmed.p2                    = For any tax year you are reporting quarterly, you will need
+optout.confirmedOptOut.submitTax.confirmed.p2.link               = software compatible with Making Tax Digital for Income Tax
+
 optout.confirmedOptOut.updatesDue                                = Your next updates due
 optout.confirmedOptOut.updatesDue.desc                           = Check the {0} page for the current tax year’s deadlines. Deadlines for future years will not be visible until they become the current year.
 optout.confirmedOptOut.next-updates                              = next updates

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -2137,12 +2137,17 @@ optout.confirmedOptOut.taxYear                                   = Rydych yn cyf
 optout.confirmedOptOut.one-year                                  = Rydych yn cyflwyno adroddiadau’n flynyddol ar gyfer blwyddyn dreth {0} i {1}
 optout.confirmedOptOut.yourRevisedDeadlines.h2                   = Eich dyddiadau cau sydd wedi’u haddasu
 optout.confirmedOptOut.yourRevisedDeadlines.desc1                = Mae’n rhaid i chi gyflwyno’ch Ffurflen Dreth ar gyfer blwyddyn dreth {0} i {1} erbyn <b>31 Ionawr {2}</b>.
-optout.confirmedOptOut.viewUpcomingUpdates.text                  = Bwrw golwg dros eich diweddariadau sydd ar y gweill
+optout.confirmedOptOut.viewUpcomingDeadlines.text                = Bwrw golwg dros eich dyddiadau cau sydd ar y gweill
 optout.confirmedOptOut.yourRevisedDeadlines.desc2                = Gallwch, ar unrhyw adeg, optio’n ôl i mewn i adrodd yn chwarterol ar gyfer pob un o’ch busnesau. Gallwch wneud hyn drwy fynd i’r dudalen ynghylch {0}
 optout.confirmedOptOut.yourReportingFrequency.text               = amlder eich adroddiadau.
+
 optout.confirmedOptOut.submitTax                                 = Cyflwyno’ch Ffurflen Dreth
-optout.confirmedOptOut.submitTax.desc1                           = Wrth adrodd yn flynyddol, gallwch gyflwyno’ch Ffurflen Dreth yn uniongyrchol drwy’ch cyfrif ar-lein CThEF neu drwy ddefnyddio meddalwedd sy’n cydweddu.
-optout.confirmedOptOut.submitTax.desc2                           = Fodd bynnag, mae’n rhaid i chi ddefnyddio meddalwedd sy’n cydweddu ar gyfer unrhyw flynyddoedd yr ydych yn adrodd amdanynt yn chwarterol.
+optout.confirmedOptOut.submitTax.confirmed.p1                    = Nawr eich bod wedi optio allan, bydd angen i chi fynd yn ôl i’r ffordd rydych wedi
+optout.confirmedOptOut.submitTax.confirmed.p1.link               = cyflwyno’ch Ffurflen Dreth Hunanasesiad yn y gorffennol (yn agor tab newydd)
+
+optout.confirmedOptOut.submitTax.confirmed.p2                    = Os ydych yn adrodd am flwyddyn dreth yn chwarterol, bydd angen i chi ddefnyddio
+optout.confirmedOptOut.submitTax.confirmed.p2.link               =  meddalwedd sy’n cydweddu â’r cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm (yn agor tab newydd)
+
 optout.confirmedOptOut.updatesDue                                = Eich diweddariadau nesaf sy’n ddyledus
 optout.confirmedOptOut.updatesDue.desc                           = Gwiriwch y dudalen {0} ar gyfer dyddiadau cau y flwyddyn dreth bresennol. Ni fydd dyddiadau cau ar gyfer blynyddoedd yn y dyfodol i’w gweld hyd nes eu bod yn newid i’r flwyddyn dreth bresennol.
 optout.confirmedOptOut.next-updates                              = diweddariadau nesaf

--- a/test/viewUtils/ConfirmedOptOutViewUtilsSpec.scala
+++ b/test/viewUtils/ConfirmedOptOutViewUtilsSpec.scala
@@ -73,6 +73,29 @@ class ConfirmedOptOutViewUtilsSpec extends UnitSpec with FeatureSwitching with I
 
     ".submitYourTaxReturnContent()" when {
 
+      "CY-1 == Quarterly, CY == Quarterly, CY+1 == Quarterly - chosen intent is CurrentTaxYear, is a multi year scenario & CY-1 is Crystallised" should {
+
+        "return the correct content" in {
+
+          val actual: Option[Html] =
+            confirmedOptOutViewUtils.submitYourTaxReturnContent(
+              `itsaStatusCY-1` = Voluntary,
+              itsaStatusCY = Voluntary,
+              `itsaStatusCY+1` = Voluntary,
+              chosenTaxYear = CurrentTaxYear,
+              isMultiYear = true,
+              isPreviousYearCrystallised = true
+            )
+
+          val expected =
+            HtmlFormat.fill(
+              Seq(submitYourTaxReturnHeading, firstParagraph)
+            )
+
+          actual shouldBe Some(expected)
+        }
+      }
+
       "CY-1 == Quarterly, CY == Quarterly, CY+1 == Quarterly - chosen intent is CurrentTaxYear and is a multi year scenario" should {
 
         "return the correct content" in {

--- a/test/viewUtils/ConfirmedOptOutViewUtilsSpec.scala
+++ b/test/viewUtils/ConfirmedOptOutViewUtilsSpec.scala
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewUtils
+
+import config.FrontendAppConfig
+import config.featureswitch.FeatureSwitching
+import enums.{CurrentTaxYear, NextTaxYear, NoChosenTaxYear}
+import implicits.ImplicitDateFormatter
+import models.itsaStatus.ITSAStatus.{Annual, Voluntary}
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.{Messages, MessagesApi}
+import play.api.test.FakeRequest
+import play.twirl.api.{Html, HtmlFormat}
+import testUtils.UnitSpec
+import uk.gov.hmrc.play.language.LanguageUtils
+import views.html.components.{h2, link, p}
+
+class ConfirmedOptOutViewUtilsSpec extends UnitSpec with FeatureSwitching with ImplicitDateFormatter with GuiceOneAppPerSuite {
+
+  override implicit val appConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
+  override implicit val languageUtils: LanguageUtils = app.injector.instanceOf[LanguageUtils]
+
+  val linkComponent: link = app.injector.instanceOf[link]
+  val paragraphComponent: p = app.injector.instanceOf[p]
+  val h2Component: h2 = app.injector.instanceOf[h2]
+
+  implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
+
+  val taxReturnLink = "https://www.gov.uk/log-in-file-self-assessment-tax-return"
+  val compatibleSoftwareLink = "https://www.gov.uk/guidance/find-software-thats-compatible-with-making-tax-digital-for-income-tax"
+
+  val confirmedOptOutViewUtils =
+    new ConfirmedOptOutViewUtils(linkComponent, h2Component, paragraphComponent, appConfig)
+
+  val submitYourTaxReturnHeading: HtmlFormat.Appendable =
+    h2Component(msg = "optout.confirmedOptOut.submitTax", optId = Some("submit-tax-heading"))
+
+  val firstParagraph =
+    paragraphComponent(id = Some("now-you-have-opted-out")) {
+      HtmlFormat.fill(
+        Seq(
+          Html(messages("Now you have opted out, you will need to go back to the way you have previously")),
+          linkComponent(link = taxReturnLink, id = Some("fill-your-tax-return-link"), messageKey = "optout.confirmedOptOut.submitTax.confirmed.p1.link", target = Some("_blank"), additionalOpenTabMessage = Some("."))
+        )
+      )
+    }
+
+  val secondParagraph =
+    paragraphComponent(id = Some("tax-year-reporting-quarterly")) {
+      HtmlFormat.fill(
+        Seq(
+          Html(messages("For any tax year you are reporting quarterly, you will need")),
+          linkComponent(link = compatibleSoftwareLink, id = Some("compatible-software-link"), messageKey = "optout.confirmedOptOut.submitTax.confirmed.p2.link", target = Some("_blank"), additionalOpenTabMessage = Some("."))
+        )
+      )
+    }
+
+  "ConfirmOptOutViewUtils" when {
+
+    ".submitYourTaxReturnContent()" when {
+
+      "CY-1 == Quarterly, CY == Quarterly, CY+1 == Quarterly - chosen intent is CurrentTaxYear and is a multi year scenario" should {
+
+        "return the correct content" in {
+
+          val actual: Option[Html] =
+            confirmedOptOutViewUtils.submitYourTaxReturnContent(
+              `itsaStatusCY-1` = Voluntary,
+              itsaStatusCY = Voluntary,
+              `itsaStatusCY+1` = Voluntary,
+              chosenTaxYear = CurrentTaxYear,
+              isMultiYear = true,
+              isPreviousYearCrystallised = false
+            )
+
+          val expected =
+            HtmlFormat.fill(
+              Seq(submitYourTaxReturnHeading, firstParagraph, secondParagraph)
+            )
+
+          actual shouldBe Some(expected)
+        }
+      }
+
+      "CY-1 == Quarterly, CY == Quarterly, CY+1 == Quarterly - chosen intent is NextTaxYear and is a multi year scenario" should {
+
+        "return the correct content" in {
+
+          val actual: Option[Html] =
+            confirmedOptOutViewUtils.submitYourTaxReturnContent(
+              `itsaStatusCY-1` = Voluntary,
+              itsaStatusCY = Voluntary,
+              `itsaStatusCY+1` = Voluntary,
+              chosenTaxYear = NextTaxYear,
+              isMultiYear = true,
+              isPreviousYearCrystallised = false
+            )
+
+          val expected =
+            HtmlFormat.fill(
+              Seq(submitYourTaxReturnHeading, firstParagraph, secondParagraph)
+            )
+
+          actual shouldBe Some(expected)
+        }
+      }
+
+      "CY-1 == Quarterly, CY == Quarterly, CY+1 == Annual - chosen intent is CurrentTaxYear and is a multi year scenario" should {
+
+        "return the correct content" in {
+
+          val actual: Option[Html] =
+            confirmedOptOutViewUtils.submitYourTaxReturnContent(
+              `itsaStatusCY-1` = Voluntary,
+              itsaStatusCY = Voluntary,
+              `itsaStatusCY+1` = Annual,
+              chosenTaxYear = CurrentTaxYear,
+              isMultiYear = true,
+              isPreviousYearCrystallised = false
+            )
+
+          val expected =
+            HtmlFormat.fill(
+              Seq(submitYourTaxReturnHeading, firstParagraph, secondParagraph)
+            )
+
+          actual shouldBe Some(expected)
+        }
+      }
+
+      "CY-1 == Quarterly, CY == Annual, CY+1 == Quarterly - chosen intent is NextTaxYear and is a multi year scenario" should {
+
+        "return the correct content" in {
+
+          val actual: Option[Html] =
+            confirmedOptOutViewUtils.submitYourTaxReturnContent(
+              `itsaStatusCY-1` = Voluntary,
+              itsaStatusCY = Annual,
+              `itsaStatusCY+1` = Voluntary,
+              chosenTaxYear = NextTaxYear,
+              isMultiYear = true,
+              isPreviousYearCrystallised = false
+            )
+          val expected =
+            HtmlFormat.fill(
+              Seq(submitYourTaxReturnHeading, firstParagraph, secondParagraph)
+            )
+
+
+          actual shouldBe Some(expected)
+        }
+      }
+
+      "CY-1 == Quarterly - no chosen intent since it is a single year scenario and tax year is deduced" should {
+
+        "return the correct content" in {
+
+          val actual: Option[Html] =
+            confirmedOptOutViewUtils.submitYourTaxReturnContent(
+              `itsaStatusCY-1` = Voluntary,
+              itsaStatusCY = Annual,
+              `itsaStatusCY+1` = Annual,
+              chosenTaxYear = NoChosenTaxYear,
+              isMultiYear = true,
+              isPreviousYearCrystallised = false
+            )
+          val expected =
+            HtmlFormat.fill(
+              Seq(submitYourTaxReturnHeading, firstParagraph)
+            )
+
+
+          actual shouldBe Some(expected)
+        }
+      }
+
+      "CY == Quarterly - no chosen intent since it is a single year scenario and tax year is deduced" should {
+
+        "return the correct content" in {
+
+          val actual: Option[Html] =
+            confirmedOptOutViewUtils.submitYourTaxReturnContent(
+              `itsaStatusCY-1` = Annual,
+              itsaStatusCY = Voluntary,
+              `itsaStatusCY+1` = Annual,
+              chosenTaxYear = NoChosenTaxYear,
+              isMultiYear = true,
+              isPreviousYearCrystallised = false
+            )
+          val expected =
+            HtmlFormat.fill(
+              Seq(submitYourTaxReturnHeading, firstParagraph)
+            )
+
+
+          actual shouldBe Some(expected)
+        }
+      }
+
+      "CY+1 == Quarterly - no chosen intent since it is a single year scenario and tax year is deduced" should {
+
+        "return the correct content" in {
+
+          val actual: Option[Html] =
+            confirmedOptOutViewUtils.submitYourTaxReturnContent(
+              `itsaStatusCY-1` = Annual,
+              itsaStatusCY = Annual,
+              `itsaStatusCY+1` = Voluntary,
+              chosenTaxYear = NoChosenTaxYear,
+              isMultiYear = true,
+              isPreviousYearCrystallised = false
+            )
+          val expected =
+            HtmlFormat.fill(
+              Seq(submitYourTaxReturnHeading, firstParagraph)
+            )
+
+
+          actual shouldBe Some(expected)
+        }
+      }
+    }
+  }
+}

--- a/test/views/messages/ConfirmedOptOutMessages.scala
+++ b/test/views/messages/ConfirmedOptOutMessages.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.messages
+
+import models.incomeSourceDetails.TaxYear
+import models.itsaStatus.ITSAStatus
+import services.optout.{CurrentOptOutTaxYear, OptOutTaxYear}
+
+object ConfirmedOptOutMessages {
+
+  val taxYear: TaxYear = TaxYear.forYearEnd(2024)
+  val optOutTaxYear: OptOutTaxYear = CurrentOptOutTaxYear(ITSAStatus.Voluntary, taxYear)
+
+  val singleYearReportingUpdatesInset = s"From 6 April ${taxYear.endYear}, you’ll be required to send quarterly updates through software compatible with Making Tax Digital for Income Tax (opens in new tab)"
+  val singleYearReportingUpdatesListP1 = "HMRC lowered the income threshold for Making Tax Digital"
+  val singleYearReportingUpdatesListP2 = "you reported an increase in your qualifying income in last year’s tax return"
+  val singleYearReportingUpdatesP1 = "This could be because:"
+  val singleYearReportingUpdatesHeading = "Reporting quarterly from next tax year onwards"
+  val singleYearSoftwareCompatibleLink = "https://www.gov.uk/guidance/find-software-thats-compatible-with-making-tax-digital-for-income-tax"
+
+
+  val heading: String = "Opt out completed"
+  val title: String =  "Opt out completed - Manage your Income Tax updates - GOV.UK"
+  val panelBodyOneYear: String = s"You are reporting annually for the ${taxYear.startYear} to ${taxYear.endYear} tax year"
+  val panelBodyMultiYear: String = s"You are reporting annually from the ${taxYear.startYear} to ${taxYear.endYear} tax year onwards"
+
+  val submitTaxHeading: String = "Submit your tax return"
+  val submitTaxP1: String = "Now you have opted out, you will need to go back to the way you have previously filed your Self Assessment tax return (opens in new tab)."
+  val submitTaxP1Link: String = "filed your Self Assessment tax return"
+  val submitTaxP2: String = "For any tax year you are reporting quarterly, you will need software compatible with Making Tax Digital for Income Tax (opens in new tab)."
+  val submitTaxP2Link: String = "software compatible with Making Tax Digital for Income Tax"
+
+  val yourRevisedDeadlinesHeading: String = "Your revised deadlines"
+  val yourRevisedDeadlinesContentP1: String = s"Your tax return for the ${taxYear.startYear} to ${taxYear.endYear} tax year is due by 31 January ${taxYear.nextYear.endYear}."
+  val yourRevisedDeadlinesContentP2: String = "You can decide at any time to opt back in to reporting quarterly for all of your businesses on your reporting frequency page."
+  val reportQuarterly: String = "You could be required to report quarterly again in the future if:"
+  val multiYearReportingUpdatesHeading = "Reporting quarterly again in the future"
+  val multiYearReportingUpdatesP1 = "You could be required to report quarterly again in the future if:"
+  val multiYearReportingUpdatesListP1 = "HMRC lowers the income threshold for Making Tax Digital"
+  val multiYearReportingUpdatesListP2 = "you report an increase in your qualifying income in a tax return"
+  val multiYearReportingUpdatesInset = s"For example, if your qualifying income exceeds the threshold in the ${optOutTaxYear.taxYear.startYear} to ${optOutTaxYear.taxYear.endYear} tax year, you would have to report quarterly from 6 April ${optOutTaxYear.taxYear.nextYear.endYear}."
+  val multiYearReportingUpdatesP2 = "If this happens, we will write to you to let you know."
+  val multiYearReportingUpdatesP3 = "You can check the threshold for qualifying income in the criteria for people who will need to sign up for Making Tax Digital (opens in new tab) ."
+  val multiYearReportingUpdatesP3Link = "https://www.gov.uk/guidance/check-if-youre-eligible-for-making-tax-digital-for-income-tax#who-will-need-to-sign-up"
+}

--- a/test/views/optOut/ConfirmedOptOutViewSpec.scala
+++ b/test/views/optOut/ConfirmedOptOutViewSpec.scala
@@ -17,117 +17,98 @@
 package views.optOut
 
 import config.FrontendAppConfig
+import enums.NextTaxYear
 import models.incomeSourceDetails.TaxYear
-import models.itsaStatus.ITSAStatus
+import models.itsaStatus.ITSAStatus.Voluntary
 import models.optout.ConfirmedOptOutViewModel
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import play.api.test.Helpers._
 import services.optout._
 import testUtils.TestSupport
+import viewUtils.ConfirmedOptOutViewUtils
 import views.html.optOut.ConfirmedOptOut
+import views.messages.ConfirmedOptOutMessages
 
 class ConfirmedOptOutViewSpec extends TestSupport {
 
   lazy val mockAppConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
   val confirmedOptOutView: ConfirmedOptOut = app.injector.instanceOf[ConfirmedOptOut]
+  val confirmedOptOutViewUtils: ConfirmedOptOutViewUtils = app.injector.instanceOf[ConfirmedOptOutViewUtils]
+
   val taxYear: TaxYear = TaxYear.forYearEnd(2024)
-  val optOutTaxYear: OptOutTaxYear = CurrentOptOutTaxYear(ITSAStatus.Voluntary, taxYear)
+  val optOutTaxYear: OptOutTaxYear = CurrentOptOutTaxYear(Voluntary, taxYear)
 
-  class Setup(isAgent: Boolean = true,
-              state: OptOutState = OneYearOptOutFollowedByMandated,
-              showReportingFrequencyContent: Boolean) {
+  val submitYourTaxReturnContent = confirmedOptOutViewUtils.submitYourTaxReturnContent(Voluntary, Voluntary, Voluntary, NextTaxYear, isMultiYear = true, isPreviousYearCrystallised = false)
+
+  class Setup(
+               isAgent: Boolean = true,
+               state: OptOutState = OneYearOptOutFollowedByMandated,
+               showReportingFrequencyContent: Boolean
+             ) {
+
     private val viewModel = ConfirmedOptOutViewModel(optOutTaxYear = optOutTaxYear.taxYear, state = Some(state))
-    val pageDocument: Document = Jsoup.parse(contentAsString(confirmedOptOutView(viewModel, isAgent, showReportingFrequencyContent)))
-  }
-
-  object confirmOptOutMessages {
-    val singleYearReportingUpdatesInset = s"From 6 April ${taxYear.endYear}, you’ll be required to send quarterly updates through software compatible with Making Tax Digital for Income Tax (opens in new tab)"
-    val singleYearReportingUpdatesListP1 = "HMRC lowered the income threshold for Making Tax Digital"
-    val singleYearReportingUpdatesListP2 = "you reported an increase in your qualifying income in last year’s tax return"
-    val singleYearReportingUpdatesP1 = "This could be because:"
-    val singleYearReportingUpdatesHeading = "Reporting quarterly from next tax year onwards"
-    val singleYearSoftwareCompatibleLink = "https://www.gov.uk/guidance/find-software-thats-compatible-with-making-tax-digital-for-income-tax"
-
-
-    val heading: String = "Opt out completed"
-    val title: String = messages("htmlTitle", "Opt out completed")
-    val panelBodyOneYear: String = s"You are reporting annually for the ${taxYear.startYear} to ${taxYear.endYear} tax year"
-    val panelBodyMultiYear: String = s"You are reporting annually from the ${taxYear.startYear} to ${taxYear.endYear} tax year onwards"
-    val submitTaxHeading: String = "Submit your tax return"
-    val submitTaxP1: String = "When reporting annually, you can submit your tax return directly through your HMRC online account or software compatible."
-    val submitTaxP2: String = "However, compatible software is required for any tax years for which you are reporting quarterly."
-    val yourRevisedDeadlinesHeading: String = "Your revised deadlines"
-    val yourRevisedDeadlinesContentP1: String = s"Your tax return for the ${taxYear.startYear} to ${taxYear.endYear} tax year is due by 31 January ${taxYear.nextYear.endYear}."
-    val yourRevisedDeadlinesContentP2: String = "You can decide at any time to opt back in to reporting quarterly for all of your businesses on your reporting frequency page."
-    val reportQuarterly: String = "You could be required to report quarterly again in the future if:"
-    val multiYearReportingUpdatesHeading = "Reporting quarterly again in the future"
-    val multiYearReportingUpdatesP1 = "You could be required to report quarterly again in the future if:"
-    val multiYearReportingUpdatesListP1 = "HMRC lowers the income threshold for Making Tax Digital"
-    val multiYearReportingUpdatesListP2 = "you report an increase in your qualifying income in a tax return"
-    val multiYearReportingUpdatesInset = s"For example, if your qualifying income exceeds the threshold in the ${optOutTaxYear.taxYear.startYear} to ${optOutTaxYear.taxYear.endYear} tax year, you would have to report quarterly from 6 April ${optOutTaxYear.taxYear.nextYear.endYear}."
-    val multiYearReportingUpdatesP2 = "If this happens, we will write to you to let you know."
-    val multiYearReportingUpdatesP3 = "You can check the threshold for qualifying income in the criteria for people who will need to sign up for Making Tax Digital (opens in new tab) ."
-    val multiYearReportingUpdatesP3Link = "https://www.gov.uk/guidance/check-if-youre-eligible-for-making-tax-digital-for-income-tax#who-will-need-to-sign-up"
+    val pageDocument: Document = Jsoup.parse(contentAsString(confirmedOptOutView(viewModel, isAgent, showReportingFrequencyContent, submitYourTaxReturnContent)))
   }
 
   "Opt-out confirmed page" should {
 
     "have the correct title" in new Setup(false, showReportingFrequencyContent = false) {
-      pageDocument.title() shouldBe confirmOptOutMessages.title
+      pageDocument.title() shouldBe ConfirmedOptOutMessages.title
     }
 
     "have the correct confirmation panel content" when {
+
       "one year opt out is followed by mandated ITSA Status" in new Setup(isAgent = false, state = OneYearOptOutFollowedByMandated, showReportingFrequencyContent = false) {
         val panel = pageDocument.select(".govuk-panel--confirmation").get(0)
-        panel.child(0).text() shouldBe confirmOptOutMessages.heading
-        panel.child(1).text() shouldBe confirmOptOutMessages.panelBodyOneYear
+        panel.child(0).text() shouldBe ConfirmedOptOutMessages.heading
+        panel.child(1).text() shouldBe ConfirmedOptOutMessages.panelBodyOneYear
       }
 
       "multi year opt out" in new Setup(isAgent = false, state = MultiYearOptOutDefault, showReportingFrequencyContent = false) {
         val panel = pageDocument.select(".govuk-panel--confirmation").get(0)
-        panel.child(0).text() shouldBe confirmOptOutMessages.heading
-        panel.child(1).text() shouldBe confirmOptOutMessages.panelBodyMultiYear
+        panel.child(0).text() shouldBe ConfirmedOptOutMessages.heading
+        panel.child(1).text() shouldBe ConfirmedOptOutMessages.panelBodyMultiYear
       }
     }
 
     "have the correct submit your tax return content" in new Setup(isAgent = false, showReportingFrequencyContent = false) {
       val submitTaxBlock: Element = pageDocument.getElementById("submit-tax")
 
-      submitTaxBlock.getElementById("submit-tax-heading").text() shouldBe confirmOptOutMessages.submitTaxHeading
-      submitTaxBlock.getElementById("submit-tax-p1").text() shouldBe confirmOptOutMessages.submitTaxP1
-      submitTaxBlock.getElementById("submit-tax-p2").text() shouldBe confirmOptOutMessages.submitTaxP2
+      submitTaxBlock.getElementById("submit-tax-heading").text() shouldBe ConfirmedOptOutMessages.submitTaxHeading
+      submitTaxBlock.getElementById("now-you-have-opted-out").text() shouldBe ConfirmedOptOutMessages.submitTaxP1
+      submitTaxBlock.getElementById("tax-year-reporting-quarterly").text() shouldBe ConfirmedOptOutMessages.submitTaxP2
     }
 
     "Individual - revised deadlines content " in new Setup(isAgent = false, showReportingFrequencyContent = false) {
       val revisedDeadlinesBlock: Element = pageDocument.getElementById("revised-deadlines")
-      revisedDeadlinesBlock.getElementById("revised-deadlines-heading").text() shouldBe confirmOptOutMessages.yourRevisedDeadlinesHeading
-      revisedDeadlinesBlock.getElementById("revised-deadlines-p1").text() shouldBe confirmOptOutMessages.yourRevisedDeadlinesContentP1
+      revisedDeadlinesBlock.getElementById("revised-deadlines-heading").text() shouldBe ConfirmedOptOutMessages.yourRevisedDeadlinesHeading
+      revisedDeadlinesBlock.getElementById("revised-deadlines-p1").text() shouldBe ConfirmedOptOutMessages.yourRevisedDeadlinesContentP1
       revisedDeadlinesBlock.getElementById("your-reporting-frequency-block").text shouldBe ""
       revisedDeadlinesBlock.getElementById("view-upcoming-updates-link").attr("href") shouldBe controllers.routes.NextUpdatesController.show().url
     }
 
     "Agent - revised deadlines content" in new Setup(isAgent = true, showReportingFrequencyContent = false) {
       val revisedDeadlinesBlock: Element = pageDocument.getElementById("revised-deadlines")
-      revisedDeadlinesBlock.getElementById("revised-deadlines-heading").text() shouldBe confirmOptOutMessages.yourRevisedDeadlinesHeading
-      revisedDeadlinesBlock.getElementById("revised-deadlines-p1").text() shouldBe confirmOptOutMessages.yourRevisedDeadlinesContentP1
+      revisedDeadlinesBlock.getElementById("revised-deadlines-heading").text() shouldBe ConfirmedOptOutMessages.yourRevisedDeadlinesHeading
+      revisedDeadlinesBlock.getElementById("revised-deadlines-p1").text() shouldBe ConfirmedOptOutMessages.yourRevisedDeadlinesContentP1
       revisedDeadlinesBlock.getElementById("your-reporting-frequency-block").text() shouldBe ""
       revisedDeadlinesBlock.getElementById("view-upcoming-updates-link").attr("href") shouldBe controllers.routes.NextUpdatesController.showAgent.url
     }
 
     "Individual - revised deadlines with reporting frequency content" in new Setup(isAgent = false, showReportingFrequencyContent = true) {
       val revisedDeadlinesBlock: Element = pageDocument.getElementById("revised-deadlines")
-      revisedDeadlinesBlock.getElementById("revised-deadlines-heading").text() shouldBe confirmOptOutMessages.yourRevisedDeadlinesHeading
-      revisedDeadlinesBlock.getElementById("revised-deadlines-p1").text() shouldBe confirmOptOutMessages.yourRevisedDeadlinesContentP1
-      revisedDeadlinesBlock.getElementById("your-reporting-frequency-block").text() shouldBe confirmOptOutMessages.yourRevisedDeadlinesContentP2
+      revisedDeadlinesBlock.getElementById("revised-deadlines-heading").text() shouldBe ConfirmedOptOutMessages.yourRevisedDeadlinesHeading
+      revisedDeadlinesBlock.getElementById("revised-deadlines-p1").text() shouldBe ConfirmedOptOutMessages.yourRevisedDeadlinesContentP1
+      revisedDeadlinesBlock.getElementById("your-reporting-frequency-block").text() shouldBe ConfirmedOptOutMessages.yourRevisedDeadlinesContentP2
       revisedDeadlinesBlock.getElementById("view-upcoming-updates-link").attr("href") shouldBe controllers.routes.NextUpdatesController.show().url
     }
 
     "Agent - revised deadlines with reporting frequency content" in new Setup(isAgent = true, showReportingFrequencyContent = true) {
       val revisedDeadlinesBlock: Element = pageDocument.getElementById("revised-deadlines")
-      revisedDeadlinesBlock.getElementById("revised-deadlines-heading").text() shouldBe confirmOptOutMessages.yourRevisedDeadlinesHeading
-      revisedDeadlinesBlock.getElementById("revised-deadlines-p1").text() shouldBe confirmOptOutMessages.yourRevisedDeadlinesContentP1
-      revisedDeadlinesBlock.getElementById("your-reporting-frequency-block").text() shouldBe confirmOptOutMessages.yourRevisedDeadlinesContentP2
+      revisedDeadlinesBlock.getElementById("revised-deadlines-heading").text() shouldBe ConfirmedOptOutMessages.yourRevisedDeadlinesHeading
+      revisedDeadlinesBlock.getElementById("revised-deadlines-p1").text() shouldBe ConfirmedOptOutMessages.yourRevisedDeadlinesContentP1
+      revisedDeadlinesBlock.getElementById("your-reporting-frequency-block").text() shouldBe ConfirmedOptOutMessages.yourRevisedDeadlinesContentP2
       revisedDeadlinesBlock.getElementById("view-upcoming-updates-link").attr("href") shouldBe controllers.routes.NextUpdatesController.showAgent.url
     }
 
@@ -135,25 +116,25 @@ class ConfirmedOptOutViewSpec extends TestSupport {
 
       "one year opt out is followed by mandated ITSA Status" in new Setup(isAgent = false, state = OneYearOptOutFollowedByMandated, showReportingFrequencyContent = false) {
         val reportingUpdateBlock: Element = pageDocument.getElementById("reporting-updates")
-        reportingUpdateBlock.child(0).text() shouldBe confirmOptOutMessages.singleYearReportingUpdatesHeading
-        reportingUpdateBlock.child(1).text() shouldBe confirmOptOutMessages.singleYearReportingUpdatesInset
-        reportingUpdateBlock.child(2).text() shouldBe confirmOptOutMessages.singleYearReportingUpdatesP1
-        reportingUpdateBlock.child(3).child(0).text() shouldBe confirmOptOutMessages.singleYearReportingUpdatesListP1
-        reportingUpdateBlock.child(3).child(1).text() shouldBe confirmOptOutMessages.singleYearReportingUpdatesListP2
-        reportingUpdateBlock.getElementById("software-compatible-ext").attr("href") shouldBe confirmOptOutMessages.singleYearSoftwareCompatibleLink
-        reportingUpdateBlock.getElementById("sign-up-criteria-ext").attr("href") shouldBe confirmOptOutMessages.multiYearReportingUpdatesP3Link
+        reportingUpdateBlock.child(0).text() shouldBe ConfirmedOptOutMessages.singleYearReportingUpdatesHeading
+        reportingUpdateBlock.child(1).text() shouldBe ConfirmedOptOutMessages.singleYearReportingUpdatesInset
+        reportingUpdateBlock.child(2).text() shouldBe ConfirmedOptOutMessages.singleYearReportingUpdatesP1
+        reportingUpdateBlock.child(3).child(0).text() shouldBe ConfirmedOptOutMessages.singleYearReportingUpdatesListP1
+        reportingUpdateBlock.child(3).child(1).text() shouldBe ConfirmedOptOutMessages.singleYearReportingUpdatesListP2
+        reportingUpdateBlock.getElementById("software-compatible-ext").attr("href") shouldBe ConfirmedOptOutMessages.singleYearSoftwareCompatibleLink
+        reportingUpdateBlock.getElementById("sign-up-criteria-ext").attr("href") shouldBe ConfirmedOptOutMessages.multiYearReportingUpdatesP3Link
       }
 
       "multi year opt out" in new Setup(isAgent = false, state = MultiYearOptOutDefault, showReportingFrequencyContent = false) {
         val reportingUpdateBlock: Element = pageDocument.getElementById("reporting-updates")
-        reportingUpdateBlock.child(0).text() shouldBe confirmOptOutMessages.multiYearReportingUpdatesHeading
-        reportingUpdateBlock.child(1).text() shouldBe confirmOptOutMessages.multiYearReportingUpdatesP1
-        reportingUpdateBlock.child(2).child(0).text() shouldBe confirmOptOutMessages.multiYearReportingUpdatesListP1
-        reportingUpdateBlock.child(2).child(1).text() shouldBe confirmOptOutMessages.multiYearReportingUpdatesListP2
-        reportingUpdateBlock.child(3).text() shouldBe confirmOptOutMessages.multiYearReportingUpdatesInset
-        reportingUpdateBlock.child(4).text() shouldBe confirmOptOutMessages.multiYearReportingUpdatesP2
-        reportingUpdateBlock.child(5).text() shouldBe confirmOptOutMessages.multiYearReportingUpdatesP3
-        reportingUpdateBlock.getElementById("sign-up-criteria-ext").attr("href") shouldBe confirmOptOutMessages.multiYearReportingUpdatesP3Link
+        reportingUpdateBlock.child(0).text() shouldBe ConfirmedOptOutMessages.multiYearReportingUpdatesHeading
+        reportingUpdateBlock.child(1).text() shouldBe ConfirmedOptOutMessages.multiYearReportingUpdatesP1
+        reportingUpdateBlock.child(2).child(0).text() shouldBe ConfirmedOptOutMessages.multiYearReportingUpdatesListP1
+        reportingUpdateBlock.child(2).child(1).text() shouldBe ConfirmedOptOutMessages.multiYearReportingUpdatesListP2
+        reportingUpdateBlock.child(3).text() shouldBe ConfirmedOptOutMessages.multiYearReportingUpdatesInset
+        reportingUpdateBlock.child(4).text() shouldBe ConfirmedOptOutMessages.multiYearReportingUpdatesP2
+        reportingUpdateBlock.child(5).text() shouldBe ConfirmedOptOutMessages.multiYearReportingUpdatesP3
+        reportingUpdateBlock.getElementById("sign-up-criteria-ext").attr("href") shouldBe ConfirmedOptOutMessages.multiYearReportingUpdatesP3Link
 
       }
     }


### PR DESCRIPTION
Requirements and scenarios covered in the ticket is a bit weird, basically we showed content for the submit your tax return with no logic originally.

However, we are now according to the ticket displaying logic based on itsa statuses & CY & CY+1 choices.

The scenarios covered in the ticket miss out single tax year choice scenarios and possible CY-1 choices. This has been raised with Bethrand and also other combinations of itsa statuses.

After speaking with Bethrand it is likely we ultimately only really care about the user's chosen intent tax year and not the combination of itsa statuses. But atm not sure so coded out the ticket logic. A comment has been raised to raise a ticket for other scenarios.

**Update:** 
Have a feeling we may need to for now add content for the previous years and some combinations not mentioned in the ticket. Added some logic to display content for various CY-1 scenarios and only for a multi year if the user chooses the most recent/in the future year possible it will display the 2nd paragraph.

