### PR TITLE
Misuv 9397: API 1553 Refactoring / simplify FinancialDetailsResponseModel / drop documentDetailsFilter method

### DIFF
--- a/app/controllers/ChargeSummaryController.scala
+++ b/app/controllers/ChargeSummaryController.scala
@@ -149,14 +149,16 @@ class ChargeSummaryController @Inject()(val authActions: AuthActions,
     chargeHistoryService.chargeHistoryResponse(isInterestCharge, documentDetailWithDueDate.documentDetail.isPayeSelfAssessment,
       chargeReference, isEnabled(ChargeHistory)).map {
       case Right(chargeHistory) =>
-        auditChargeSummary(chargeItem, paymentBreakdown, chargeHistory, paymentAllocations,
-          isInterestCharge, isMFADebit, taxYear)
+        auditChargeSummary(chargeItem, paymentBreakdown,
+          chargeHistory, paymentAllocations, isInterestCharge, isMFADebit, taxYear)
 
         val chargeItems : List[ChargeItem] = chargeDetailsforTaxYear.asChargeItems
         val (poaOneChargeUrl, poaTwoChargeUrl) = {
           for {
-            poaOneChargeItem <- chargeItems.filter(x => x.transactionType == PoaOneDebit || x.transactionType == PoaOneReconciliationDebit)
-            poaTwoChargeItem <- chargeItems.filter(x => x.transactionType == PoaTwoDebit || x.transactionType == PoaTwoReconciliationDebit)
+            poaOneChargeItem <- chargeItems
+              .filter(c => List(PoaOneDebit, PoaOneReconciliationDebit).contains(c.transactionType))
+            poaTwoChargeItem <- chargeItems
+              .filter(c => List(PoaTwoDebit, PoaTwoReconciliationDebit).contains(c.transactionType))
           } yield {
             if (isAgent)
               (

--- a/app/controllers/ChargeSummaryController.scala
+++ b/app/controllers/ChargeSummaryController.scala
@@ -28,6 +28,7 @@ import forms.utils.SessionKeys.gatewayPage
 import models.admin._
 import models.chargeHistory._
 import models.chargeSummary.{ChargeSummaryViewModel, PaymentHistoryAllocations}
+import models.financialDetails.ChargeType.poaOneReconciliationDebit
 import models.financialDetails._
 import play.api.Logger
 import play.api.i18n.I18nSupport
@@ -151,22 +152,23 @@ class ChargeSummaryController @Inject()(val authActions: AuthActions,
         auditChargeSummary(chargeItem, paymentBreakdown, chargeHistory, paymentAllocations,
           isInterestCharge, isMFADebit, taxYear)
 
-
-        val (poaOneChargeUrl, poaTwoChargeUrl) =
-          (for {
-            poaOneTaxYearTo     <- chargeDetailsforTaxYear.documentDetailsFilter(isPoaOne).map(_.taxYear)
-            poaOneTransactionId <- chargeDetailsforTaxYear.documentDetailsFilter(isPoaOne).map(_.transactionId)
-            poaTwoTaxYearTo     <- chargeDetailsforTaxYear.documentDetailsFilter(isPoaTwo).map(_.taxYear)
-            poaTwoTransactionId <- chargeDetailsforTaxYear.documentDetailsFilter(isPoaTwo).map(_.transactionId)
-          } yield
+        val chargeItems : List[ChargeItem] = chargeDetailsforTaxYear.asChargeItems
+        val (poaOneChargeUrl, poaTwoChargeUrl) = {
+          for {
+            poaOneChargeItem <- chargeItems.filter(x => x.transactionType == PoaOneDebit || x.transactionType == PoaOneReconciliationDebit)
+            poaTwoChargeItem <- chargeItems.filter(x => x.transactionType == PoaTwoDebit || x.transactionType == PoaTwoReconciliationDebit)
+          } yield {
             if (isAgent)
-              (routes.ChargeSummaryController.showAgent(poaOneTaxYearTo, poaOneTransactionId).url,
-                routes.ChargeSummaryController.showAgent(poaTwoTaxYearTo, poaTwoTransactionId).url)
+              (
+                routes.ChargeSummaryController.showAgent(poaOneChargeItem.taxYear.endYear, poaOneChargeItem.transactionId).url,
+                routes.ChargeSummaryController.showAgent(poaTwoChargeItem.taxYear.endYear, poaTwoChargeItem.transactionId).url
+              )
             else
-              (routes.ChargeSummaryController.show(poaOneTaxYearTo, poaOneTransactionId).url,
-                routes.ChargeSummaryController.show(poaTwoTaxYearTo, poaTwoTransactionId).url)
-            ).getOrElse(("", ""))
-
+              (routes.ChargeSummaryController.show(poaOneChargeItem.taxYear.endYear, poaOneChargeItem.transactionId).url,
+                routes.ChargeSummaryController.show(poaTwoChargeItem.taxYear.endYear, poaTwoChargeItem.transactionId).url
+              )
+          }
+        }.headOption.getOrElse( ("", ""))
         val whatYouOweUrl = {
           if (isAgent) controllers.routes.WhatYouOweController.showAgent.url
           else controllers.routes.WhatYouOweController.show(origin).url

--- a/app/models/financialDetails/FinancialDetailsResponseModel.scala
+++ b/app/models/financialDetails/FinancialDetailsResponseModel.scala
@@ -31,6 +31,8 @@ import scala.util.{Failure, Success, Try}
 
 sealed trait FinancialDetailsResponseModel
 
+// TODO-[1]: make balanceDetails private val -> apply re-design and fix test failures where needed
+// TODO-[2]: make financialDetails private val -> ~
 case class FinancialDetailsModel(balanceDetails: BalanceDetails,
                                  private val documentDetails: List[DocumentDetail],
                                  financialDetails: List[FinancialDetail]) extends FinancialDetailsResponseModel {
@@ -52,12 +54,14 @@ case class FinancialDetailsModel(balanceDetails: BalanceDetails,
     }
   }
 
+  // TODO: to be removed as we should rely on the chargeType available in ChargeItem type;
   def isMFADebit(documentId: String): Boolean = {
     financialDetails.exists { fd =>
       fd.transactionId.contains(documentId) && MfaDebitUtils.isMFADebitMainType(fd.mainType)
     }
   }
 
+  // TODO: we need to identify this on the chargeItem level -> mark as deprecated
   def isReviewAndReconcilePoaOneDebit(documentId: String, reviewAndReconcileIsEnabled: Boolean): Boolean = {
     reviewAndReconcileIsEnabled &&
       financialDetails.exists { fd =>
@@ -65,6 +69,7 @@ case class FinancialDetailsModel(balanceDetails: BalanceDetails,
       }
   }
 
+  // TODO: we need to identify this on the chargeItem level -> mark as deprecated
   def isReviewAndReconcilePoaTwoDebit(documentId: String, reviewAndReconcileIsEnabled: Boolean): Boolean = {
     reviewAndReconcileIsEnabled &&
       financialDetails.exists { fd =>

--- a/app/models/financialDetails/FinancialDetailsResponseModel.scala
+++ b/app/models/financialDetails/FinancialDetailsResponseModel.scala
@@ -181,10 +181,6 @@ case class FinancialDetailsModel(balanceDetails: BalanceDetails,
     documentDetails.exists(_.transactionId == id)
   }
 
-  def documentDetailsFilter(predicate: DocumentDetail => Boolean): Option[DocumentDetail] = {
-    this.documentDetails.find(predicate)
-  }
-
   def documentDetailsFilterByTaxYear(taxYear: Int): List[DocumentDetail] = {
     this.documentDetails.filter(_.taxYear == taxYear)
   }

--- a/app/services/CreditHistoryService.scala
+++ b/app/services/CreditHistoryService.scala
@@ -40,7 +40,7 @@ class CreditHistoryService @Inject()(financialDetailsConnector: FinancialDetails
                                  (implicit hc: HeaderCarrier, user: MtdItUser[_]): Future[Either[CreditHistoryError.type, List[CreditDetailModel]]] = {
     financialDetailsConnector.getFinancialDetails(taxYear, nino).flatMap {
       case financialDetailsModel: FinancialDetailsModel =>
-        val fdRes = financialDetailsModel.getPairedDocumentDetails.flatMap {
+        val fdRes = financialDetailsModel.asChargeItems.flatMap {
           // Apply rewiring to use ChargeItem instead of DocumentDetails here
           case (chargeItem: ChargeItem) =>
             (chargeItem.transactionType, chargeItem.credit.isDefined) match {

--- a/app/services/WhatYouOweService.scala
+++ b/app/services/WhatYouOweService.scala
@@ -71,7 +71,7 @@ class WhatYouOweService @Inject()(val financialDetailsService: FinancialDetailsS
         val balanceDetails = financialDetailsModelList.headOption
           .map(_.balanceDetails).getOrElse(BalanceDetails(0.00, 0.00, 0.00, None, None, None, None, None))
         val codedOutChargeItem = {
-          financialDetailsModelList.flatMap(_.toChargeItem())
+          financialDetailsModelList.flatMap(_.toChargeItem)
             .filter(_.subTransactionType.contains(Accepted))
             .find(_.taxYear.endYear == (dateService.getCurrentTaxYearEnd - 1))
         }

--- a/app/services/claimToAdjustPoa/ClaimToAdjustService.scala
+++ b/app/services/claimToAdjustPoa/ClaimToAdjustService.scala
@@ -57,7 +57,7 @@ class ClaimToAdjustService @Inject()(val financialDetailsConnector: FinancialDet
         paymentOnAccountViewModelMaybe <- EitherT(
           Future.successful(financialDetailsMaybe
             .map { financialDetails =>
-              val charges = sortByTaxYearC(financialDetails.toChargeItem())
+              val charges = sortByTaxYearC(financialDetails.toChargeItem)
               getPaymentOnAccountModel(charges)
             } match {
               case Some(x) => x
@@ -130,7 +130,7 @@ class ClaimToAdjustService @Inject()(val financialDetailsConnector: FinancialDet
       case Some(taxYear: TaxYear) =>
         financialDetailsConnector.getFinancialDetails(taxYear.endYear, nino.value).map {
           case financialDetails: FinancialDetailsModel =>
-            val charges = sortByTaxYearC(financialDetails.toChargeItem())
+            val charges = sortByTaxYearC(financialDetails.toChargeItem)
             getPaymentOnAccountModel(charges) match {
               case Right(x) =>
                 Right(FinancialDetailsAndPoaModel(Some(financialDetails), x))

--- a/it/test/controllers/TaxYearSummaryControllerISpec.scala
+++ b/it/test/controllers/TaxYearSummaryControllerISpec.scala
@@ -224,7 +224,7 @@ class TaxYearSummaryControllerISpec extends TaxSummaryISpecHelper {
 
                 AuditStub.verifyAuditEvent(TaxYearSummaryResponseAuditModel(testUser(mtdUserRole, singleBusinessResponse),
                   messagesAPI, TaxYearSummaryViewModel(Some(CalculationSummary(liabilityCalculationModelSuccessfulExpected)),
-                    financialDetailsDunningLockSuccess.toChargeItem().map(TaxYearSummaryChargeItem.fromChargeItem),
+                    financialDetailsDunningLockSuccess.toChargeItem.map(TaxYearSummaryChargeItem.fromChargeItem),
                     allObligations, reviewAndReconcileEnabled = true, showForecastData = true, ctaViewModel = emptyCTAModel)))
               }
 

--- a/it/test/controllers/WhatYouOweControllerISpec.scala
+++ b/it/test/controllers/WhatYouOweControllerISpec.scala
@@ -195,7 +195,7 @@ class WhatYouOweControllerISpec extends ControllerISpecHelper with ChargeConstan
                   val documentDetailsForTestTaxYear = financialDetailsModel.documentDetailsFilterByTaxYear(testTaxYear)
 
                   val financialDetails = financialDetailsModel.copy(documentDetails = documentDetailsForTestTaxYear)
-                  val chargeItems = financialDetails.toChargeItem()
+                  val chargeItems = financialDetails.toChargeItem
 
                   WhatYouOweChargesList(
                     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None, None),
@@ -291,7 +291,7 @@ class WhatYouOweControllerISpec extends ControllerISpecHelper with ChargeConstan
                 val whatYouOweChargesList = {
                   val documentDetailsForTestTaxYear = financialDetailsModel.documentDetailsFilterByTaxYear(testTaxYear)
                   val financialDetails = financialDetailsModel.copy(documentDetails = documentDetailsForTestTaxYear)
-                  val chargeItems = financialDetails.toChargeItem()
+                  val chargeItems = financialDetails.toChargeItem
 
                   WhatYouOweChargesList(
                     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None, None),
@@ -329,7 +329,7 @@ class WhatYouOweControllerISpec extends ControllerISpecHelper with ChargeConstan
                   val documentDetailsForTestTaxYear = financialDetailsModel.documentDetailsFilterByTaxYear(testTaxYear)
 
                   val financialDetails = financialDetailsModel.copy(documentDetails = documentDetailsForTestTaxYear)
-                  val chargeItems = financialDetails.toChargeItem()
+                  val chargeItems = financialDetails.toChargeItem
 
 
                   WhatYouOweChargesList(
@@ -366,7 +366,7 @@ class WhatYouOweControllerISpec extends ControllerISpecHelper with ChargeConstan
                 val whatYouOweChargesList = {
                   val documentDetailsForTestTaxYear = financialDetailsModel.documentDetailsFilterByTaxYear(testTaxYear)
                   val financialDetails = financialDetailsModel.copy(documentDetails = documentDetailsForTestTaxYear)
-                  val chargeItems = financialDetails.toChargeItem()
+                  val chargeItems = financialDetails.toChargeItem
 
                   WhatYouOweChargesList(
                     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None, None),

--- a/it/test/controllers/YourSelfAssessmentChargesControllerISpec.scala
+++ b/it/test/controllers/YourSelfAssessmentChargesControllerISpec.scala
@@ -194,7 +194,7 @@ class YourSelfAssessmentChargesControllerISpec extends ControllerISpecHelper wit
                   val documentDetailsForTestTaxYear = financialDetailsModel.documentDetailsFilterByTaxYear(testTaxYear)
 
                   val financialDetails = financialDetailsModel.copy(documentDetails = documentDetailsForTestTaxYear)
-                  val chargeItems = financialDetails.toChargeItem()
+                  val chargeItems = financialDetails.toChargeItem
 
                   WhatYouOweChargesList(
                     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None, None),
@@ -289,7 +289,7 @@ class YourSelfAssessmentChargesControllerISpec extends ControllerISpecHelper wit
                 val whatYouOweChargesList = {
                   val documentDetailsForTestTaxYear = financialDetailsModel.documentDetailsFilterByTaxYear(testTaxYear)
                   val financialDetails = financialDetailsModel.copy(documentDetails = documentDetailsForTestTaxYear)
-                  val chargeItems = financialDetails.toChargeItem()
+                  val chargeItems = financialDetails.toChargeItem
 
                   WhatYouOweChargesList(
                     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None, None),
@@ -327,7 +327,7 @@ class YourSelfAssessmentChargesControllerISpec extends ControllerISpecHelper wit
                   val documentDetailsForTestTaxYear = financialDetailsModel.documentDetailsFilterByTaxYear(testTaxYear)
 
                   val financialDetails = financialDetailsModel.copy(documentDetails = documentDetailsForTestTaxYear)
-                  val chargeItems = financialDetails.toChargeItem()
+                  val chargeItems = financialDetails.toChargeItem
 
 
                   WhatYouOweChargesList(
@@ -364,7 +364,7 @@ class YourSelfAssessmentChargesControllerISpec extends ControllerISpecHelper wit
                 val whatYouOweChargesList = {
                   val documentDetailsForTestTaxYear = financialDetailsModel.documentDetailsFilterByTaxYear(testTaxYear)
                   val financialDetails = financialDetailsModel.copy(documentDetails = documentDetailsForTestTaxYear)
-                  val chargeItems = financialDetails.toChargeItem()
+                  val chargeItems = financialDetails.toChargeItem
 
                   WhatYouOweChargesList(
                     balanceDetails = BalanceDetails(1.00, 2.00, 3.00, None, None, None, None, None),

--- a/test/controllers/ChargeSummaryControllerSpec.scala
+++ b/test/controllers/ChargeSummaryControllerSpec.scala
@@ -70,9 +70,9 @@ class ChargeSummaryControllerSpec extends ChargeSummaryControllerHelper {
 
                 val result: Future[Result] = action(id1040000123)(fakeRequest)
                 val chargeSummaryUrl = if(isAgent) {
-                  routes.ChargeSummaryController.showAgent(testTaxYear, id1040000125).url
+                  routes.ChargeSummaryController.showAgent(testTaxYear, id1040000123).url
                 } else {
-                  routes.ChargeSummaryController.show(testTaxYear, id1040000125).url
+                  routes.ChargeSummaryController.show(testTaxYear, id1040000123).url
                 }
 
                 status(result) shouldBe Status.OK
@@ -102,9 +102,9 @@ class ChargeSummaryControllerSpec extends ChargeSummaryControllerHelper {
                 status(result) shouldBe Status.OK
                 val document = JsoupParse(result).toHtmlDocument
                 val chargeSummaryUrl = if(isAgent) {
-                  routes.ChargeSummaryController.showAgent(testTaxYear, id1040000126).url
+                  routes.ChargeSummaryController.showAgent(testTaxYear, id1040000124).url
                 } else {
-                  routes.ChargeSummaryController.show(testTaxYear, id1040000126).url
+                  routes.ChargeSummaryController.show(testTaxYear, id1040000124).url
                 }
 
                 document.select("h1").text() shouldBe successHeadingForRAR2(startYear.toString, endYear.toString)


### PR DESCRIPTION
In this PR one small change applied in FinancialDetailsResponseModel:
* next method removed as not required => documentDetailsFilter
* other changes as a result of this refactoring;
* Rename next method getPairedDocumentDetails => asChargeItems