### PR TITLE
[MISUV-9594] Adding guidance link to supporting agents front page

### DIFF
--- a/app/views/agent/SupportingAgentHome.scala.html
+++ b/app/views/agent/SupportingAgentHome.scala.html
@@ -101,8 +101,8 @@
         "home.agent.supporting.cannotAccess.returns",
         "home.agent.supporting.cannotAccess.nextChargesDue"
     )
-    @p(id = Some("changeClientLink")) {
-        <a class="govuk-link" target="_blank" href="#">@messages("home.agent.supporting.readMore")</a>
+    @p(id = Some("readMoreAboutDifferencesLink")) {
+        <a class="govuk-link" target="_blank" href="@messages("home.agent.supporting.readMore.link")">@messages("home.agent.supporting.readMore")</a>
     }
 }
 

--- a/app/views/agent/SupportingAgentHome.scala.html
+++ b/app/views/agent/SupportingAgentHome.scala.html
@@ -101,7 +101,7 @@
         "home.agent.supporting.cannotAccess.returns",
         "home.agent.supporting.cannotAccess.nextChargesDue"
     )
-    @p(id = Some("readMoreAboutDifferencesLink")) {
+    @p(id = Some("read-more-about-differences-link")) {
         <a class="govuk-link" target="_blank" href="@messages("home.agent.supporting.readMore.link")">@messages("home.agent.supporting.readMore")</a>
     }
 }

--- a/conf/messages
+++ b/conf/messages
@@ -179,6 +179,7 @@ home.agent.supporting.cannotAccess.payments                     = payments, cred
 home.agent.supporting.cannotAccess.returns                      = returns
 home.agent.supporting.cannotAccess.nextChargesDue               = next charges due
 home.agent.supporting.readMore                                  = Read more about the difference between main and supporting agents on GOV.UK (opens in new tab).
+home.agent.supporting.readMore.link                             = https://www.gov.uk/guidance/choose-agents-for-making-tax-digital-for-income-tax
 
 home.penaltiesAndAppeals.heading                                = Penalties and appeals
 home.penaltiesAndAppeals.view                                   = Check Self Assessment penalties and appeals

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -179,6 +179,7 @@ home.agent.supporting.cannotAccess.payments                     = taliadau, cred
 home.agent.supporting.cannotAccess.returns                      = Ffurflenni Treth
 home.agent.supporting.cannotAccess.nextChargesDue               = y ffioedd sy’n ddyledus nesaf
 home.agent.supporting.readMore                                  = Darllenwch ragor am y gwahaniaeth rhwng prif asiantau ac asiantau ategol ar GOV.UK (yn agor tab newydd).
+home.agent.supporting.readMore.link                             = https://www.gov.uk/guidance/choose-agents-for-making-tax-digital-for-income-tax.cy
 
 home.penaltiesAndAppeals.heading                                = Cosbau ac apeliadau
 home.penaltiesAndAppeals.view                                   = Gwirio cosbau ac apeliadau Hunanasesiad

--- a/test/views/agent/SupportingAgentHomePageViewSpec.scala
+++ b/test/views/agent/SupportingAgentHomePageViewSpec.scala
@@ -200,7 +200,7 @@ class SupportingAgentHomePageViewSpec extends TestSupport with FeatureSwitching 
 
       s"have a read more about differences between agents and supporting agents link" in new TestSetup {
 
-        val link: Option[Elements] = getElementById("readMoreAboutDifferencesLink").map(_.select("a"))
+        val link: Option[Elements] = getElementById("read-more-about-differences-link").map(_.select("a"))
         link.map(_.attr("href")) shouldBe Some("https://www.gov.uk/guidance/choose-agents-for-making-tax-digital-for-income-tax")
         link.map(_.text) shouldBe Some("Read more about the difference between main and supporting agents on GOV.UK (opens in new tab).")
       }

--- a/test/views/agent/SupportingAgentHomePageViewSpec.scala
+++ b/test/views/agent/SupportingAgentHomePageViewSpec.scala
@@ -197,6 +197,13 @@ class SupportingAgentHomePageViewSpec extends TestSupport with FeatureSwitching 
         link.map(_.attr("href")) shouldBe Some("/report-quarterly/income-and-expenses/view/agents/remove-client-sessions")
         link.map(_.text) shouldBe Some(messages("home.agent.changeClientLink"))
       }
+
+      s"have a read more about differences between agents and supporting agents link" in new TestSetup {
+
+        val link: Option[Elements] = getElementById("readMoreAboutDifferencesLink").map(_.select("a"))
+        link.map(_.attr("href")) shouldBe Some("https://www.gov.uk/guidance/choose-agents-for-making-tax-digital-for-income-tax")
+        link.map(_.text) shouldBe Some("Read more about the difference between main and supporting agents on GOV.UK (opens in new tab).")
+      }
     }
 
     "the feature switches are disabled" should {


### PR DESCRIPTION
The link itself isn't live yet so clicking it currently just leads to a 404.