### PR TITLE
Fixed bug with class 2 Nics

### DIFF
--- a/app/models/financialDetails/DocumentDetail.scala
+++ b/app/models/financialDetails/DocumentDetail.scala
@@ -106,7 +106,7 @@ case class DocumentDetail(taxYear: Int,
       case _ => false
     }
 
-  def isNotCodingOutDocumentDetail: Boolean = !isClass2Nic && !isPayeSelfAssessment && !isCancelledPayeSelfAssessment
+  def isNotCodingOutDocumentDetail: Boolean = !isPayeSelfAssessment && !isCancelledPayeSelfAssessment
 
   def isClass2Nic: Boolean = documentText match {
     case Some(documentText) if documentText == CODING_OUT_CLASS2_NICS.name => true

--- a/app/models/financialDetails/DocumentDetail.scala
+++ b/app/models/financialDetails/DocumentDetail.scala
@@ -100,10 +100,9 @@ case class DocumentDetail(taxYear: Int,
   }
 
   def isCodingOutDocumentDetail: Boolean =
-    (isPayeSelfAssessment, isCancelledPayeSelfAssessment, isClass2Nic) match {
-      case (true, _, _) => true
-      case (_, true, _) => true
-      case (_, _, true) => true
+    (isPayeSelfAssessment, isCancelledPayeSelfAssessment) match {
+      case (true, _) => true
+      case (_, true) => true
       case _ => false
     }
 

--- a/test/services/FinancialDetailsServiceSpec.scala
+++ b/test/services/FinancialDetailsServiceSpec.scala
@@ -406,14 +406,17 @@ class FinancialDetailsServiceSpec extends TestSupport with MockFinancialDetailsC
             interestOutstandingAmount = Some(0), documentDescription = Some("TRM New Charge"), documentText = Some(CODING_OUT_ACCEPTED)),
           documentDetailModel(transactionId = "transid3", outstandingAmount = 0).copy(
             interestOutstandingAmount = Some(0), documentDescription = Some("TRM Amend Charge"), documentText = Some(CODING_OUT_CANCELLED)),
+          documentDetailModel(transactionId = "transid4", outstandingAmount = 0).copy(
+            interestOutstandingAmount = Some(0), documentDescription = Some("TRM New Charge"), documentText = Some(CODING_OUT_CLASS2_NICS))
         ), financialDetails = List(
           fullFinancialDetailModel,
           fullFinancialDetailModel,
         ))
         val financialDetail = getFinancialDetailSuccess(documentDetails = List(
           fullDocumentDetailModel.copy(outstandingAmount = 300.00),
-          fullDocumentDetailModel.copy(outstandingAmount = 400.00)
+          fullDocumentDetailModel.copy(outstandingAmount = 400.00),
         ), financialDetails = List(
+          fullFinancialDetailModel,
           fullFinancialDetailModel,
           fullFinancialDetailModel
         ))
@@ -423,8 +426,20 @@ class FinancialDetailsServiceSpec extends TestSupport with MockFinancialDetailsC
 
         val result = TestFinancialDetailsService.getAllUnpaidFinancialDetails()(mtdUser(2), headerCarrier, ec)
 
+        val expectedFinancialDetailCodingOut = getFinancialDetailSuccess(documentDetails = List(
+          documentDetailModel(transactionId = "transid1", outstandingAmount = 200.00).copy(
+            interestOutstandingAmount = Some(0), documentDescription = Some("TRM New Charge"), documentText = Some(CODING_OUT_CLASS2_NICS)),
+          documentDetailModel(taxYear = 2021, transactionId = "transid2", outstandingAmount = 0).copy(
+            interestOutstandingAmount = Some(0), documentDescription = Some("TRM New Charge"), documentText = Some(CODING_OUT_ACCEPTED)),
+          documentDetailModel(transactionId = "transid3", outstandingAmount = 0).copy(
+            interestOutstandingAmount = Some(0), documentDescription = Some("TRM Amend Charge"), documentText = Some(CODING_OUT_CANCELLED)),
+        ), financialDetails = List(
+          fullFinancialDetailModel,
+          fullFinancialDetailModel,
+        ))
+
         result.futureValue shouldBe List(
-          financialDetailCodingOut,
+          expectedFinancialDetailCodingOut,
           financialDetail
         )
       }


### PR DESCRIPTION
Class 2 Nics was being shown even with 0 outstanding amount, as it was being treated as a coded out charge, but Class 2 Nics can't be coded out