### PR TITLE
MISUV-9760: Update MTD Usage Label and Rendering Logic Based on Latency Indicators in View and Manage page

### DIFF
--- a/app/models/incomeSourceDetails/viewmodels/ManageIncomeSourceDetailsViewModel.scala
+++ b/app/models/incomeSourceDetails/viewmodels/ManageIncomeSourceDetailsViewModel.scala
@@ -32,9 +32,7 @@ case class ManageIncomeSourceDetailsViewModel(incomeSourceId: IncomeSourceId,
                                               latencyYearsCrystallised: LatencyYearsCrystallised,
                                               latencyDetails: Option[LatencyDetails],
                                               incomeSourceType: IncomeSourceType,
-                                              quarterReportingType: Option[QuarterReportingType],
-                                              useMTDForTaxYear1: Option[Boolean] = None,
-                                              useMTDForTaxYear2: Option[Boolean] = None
+                                              quarterReportingType: Option[QuarterReportingType]
                                              ) {
 
   def latencyValueAsKey(latencyIndicator: String): String = {

--- a/app/views/manageBusinesses/manage/ManageIncomeSourceDetails.scala.html
+++ b/app/views/manageBusinesses/manage/ManageIncomeSourceDetails.scala.html
@@ -143,55 +143,94 @@
 
 @getMTDUsageRows = @{
 
-    def getActionRow(useMTD: Boolean, taxYear: String, rowIndex: Int) = {
-        val taxYearFormatted = s"${taxYear.toInt - 1}-$taxYear"
-        val changeTo = if (useMTD) "annual" else "quarterly"
-        val actionTextKey =
-            if (useMTD)
-                "incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.optOut"
-            else
-                "incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.signup"
-
-        val changeLink =
-            if (isAgent)
-                controllers.manageBusinesses.manage.routes.ConfirmReportingMethodSharedController
-                .showAgent(taxYearFormatted, changeTo, viewModel.incomeSourceType).url
-            else
-                controllers.manageBusinesses.manage.routes.ConfirmReportingMethodSharedController
-                .show(taxYearFormatted, changeTo, viewModel.incomeSourceType).url
-
-        val linkId = if (useMTD) s"opt-out-link-$rowIndex" else s"sign-up-link-$rowIndex"
-
-        SummaryListRow(
-            key = Key(Text(
-                messages(
-                    "incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.mtdUsage",
-                    (taxYear.toInt - 1).toString,
-                    taxYear
-                )
-            )),
-            value = Value(Text(
-                if (useMTD)
-                    messages("incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.mtdUsage.yes")
-                else
-                    messages("incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.mtdUsage.no")
-            )),
-            actions = Some(Actions(
-                items = Seq(
-                    ActionItem(
-                        href = changeLink,
-                        content = Text(messages(actionTextKey)),
-                        attributes = Map("id" -> linkId)
+    val taxYearRows = Seq(
+        if (!viewModel.latencyYearsCrystallised.firstYear.get) {
+            Some(SummaryListRow(
+                key = Key(
+                    content = Text(
+                        messages(
+                            "incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.mtdUsage",
+                            (viewModel.latencyDetails.get.taxYear1.toInt - 1).toString,
+                            viewModel.latencyDetails.get.taxYear1
+                        )
                     )
-                )
+                ),
+                value = Value(
+                    content = Text(
+                        if (viewModel.latencyDetails.get.latencyIndicator1 == "Q")
+                            messages("incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.mtdUsage.yes")
+                        else
+                            messages("incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.mtdUsage.no")
+                    )
+                ),
+                actions = if (viewModel.latencyYearsQuarterly.firstYear.get) Some(Actions(
+                    items = Seq(
+                        ActionItem(
+                            href = changeReportingMethodUrl(
+                                taxYearValue(viewModel.latencyDetails.get.taxYear1),
+                                changeToValue(viewModel.latencyDetails.get.latencyIndicator1)
+                            ),
+                            content = Text(
+                                messages(
+                                    if (viewModel.latencyDetails.get.latencyIndicator1 == "Q")
+                                        "incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.optOut"
+                                    else
+                                        "incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.signup"
+                                )
+                            ),
+                            attributes = Map(
+                                "id" -> (if (viewModel.latencyDetails.get.latencyIndicator1 == "Q") "opt-out-link-1" else "sign-up-link-1")
+                            )
+                        )
+                    )
+                )) else None
             ))
-        )
-    }
+        } else None,
 
-    Seq(
-        viewModel.useMTDForTaxYear1.map(getActionRow(_, viewModel.latencyDetails.get.taxYear1, 1)),
-        viewModel.useMTDForTaxYear2.map(getActionRow(_, viewModel.latencyDetails.get.taxYear2, 2))
-    ).flatten
+        if (!viewModel.latencyYearsCrystallised.secondYear.get) {
+            Some(SummaryListRow(
+                key = Key(
+                    content = Text(
+                        messages(
+                            "incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.mtdUsage",
+                            (viewModel.latencyDetails.get.taxYear2.toInt - 1).toString,
+                            viewModel.latencyDetails.get.taxYear2
+                        )
+                    )
+                ),
+                value = Value(
+                    content = Text(
+                        if (viewModel.latencyDetails.get.latencyIndicator2 == "Q")
+                            messages("incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.mtdUsage.yes")
+                        else
+                            messages("incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.mtdUsage.no")
+                    )
+                ),
+                actions = if (viewModel.latencyYearsQuarterly.secondYear.get) Some(Actions(
+                    items = Seq(
+                        ActionItem(
+                            href = changeReportingMethodUrl(
+                                taxYearValue(viewModel.latencyDetails.get.taxYear2),
+                                changeToValue(viewModel.latencyDetails.get.latencyIndicator2)
+                            ),
+                            content = Text(
+                                messages(
+                                    if (viewModel.latencyDetails.get.latencyIndicator2 == "Q")
+                                        "incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.optOut"
+                                    else
+                                        "incomeSources.manage.business-manage-details.OptInOptOutContentUpdateR17.signup"
+                                )
+                            ),
+                            attributes = Map(
+                                "id" -> (if (viewModel.latencyDetails.get.latencyIndicator2 == "Q") "opt-out-link-2" else "sign-up-link-2")
+                            )
+                        )
+                    )
+                )) else None
+            ))
+        } else None
+    )
+    taxYearRows.flatten
 }
 
     @getTaxYears = @{
@@ -384,7 +423,7 @@
                 ++ (getQuarterlyType)
                 ++(
                     if (viewModel.latencyDetails.isDefined) {
-                        if (showOptInOptOutContentUpdateR17 &&(viewModel.useMTDForTaxYear1.isDefined || viewModel.useMTDForTaxYear2.isDefined)) {
+                        if (showOptInOptOutContentUpdateR17) {
                             getMTDUsageRows
                         } else {
                             getTaxYears

--- a/app/views/manageBusinesses/manage/ManageIncomeSourceDetails.scala.html
+++ b/app/views/manageBusinesses/manage/ManageIncomeSourceDetails.scala.html
@@ -381,9 +381,7 @@
                         )
                     } else Seq.empty
                 )
-                ++ (
-                    if (showOptInOptOutContentUpdateR17) Seq.empty else getQuarterlyType
-                )
+                ++ (getQuarterlyType)
                 ++(
                     if (viewModel.latencyDetails.isDefined) {
                         if (showOptInOptOutContentUpdateR17 &&(viewModel.useMTDForTaxYear1.isDefined || viewModel.useMTDForTaxYear2.isDefined)) {

--- a/conf/messages
+++ b/conf/messages
@@ -2103,7 +2103,7 @@ incomeSources.add.manageObligations.heading                           =   What y
 
 
 # manage journey manage income source
-incomeSources.manage.quarterly-period                                 =   Quarterly period
+incomeSources.manage.quarterly-period                                 =   Update period
 incomeSources.manage.quarterly-period.standard                        =   Standard
 incomeSources.manage.quarterly-period.calendar                        =   Calendar
 incomeSources.manage.quarterly-period.standard.summary                =   What is a standard quarterly period?

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -2107,7 +2107,7 @@ incomeSources.add.manageObligations.heading                           =   Yr hyn
 
 
 # manage journey manage income source
-incomeSources.manage.quarterly-period                                 =   Cyfnod chwarterol
+incomeSources.manage.quarterly-period                                 =   Cyfnod diweddaru
 incomeSources.manage.quarterly-period.standard                        =   Safonol
 incomeSources.manage.quarterly-period.calendar                        =   Calendr
 incomeSources.manage.quarterly-period.standard.summary                =   Beth yw cyfnod chwarterol safonol?

--- a/it/test/controllers/manageBusinesses/manage/ManageIncomeSourceDetailsSelfEmploymentControllerISpec.scala
+++ b/it/test/controllers/manageBusinesses/manage/ManageIncomeSourceDetailsSelfEmploymentControllerISpec.scala
@@ -213,6 +213,8 @@ class ManageIncomeSourceDetailsSelfEmploymentControllerISpec extends ManageIncom
             disable(NavBarFs)
             stubAuthorised(mtdUserRole)
             IncomeTaxViewChangeStub.stubGetIncomeSourceDetailsResponse(testMtditid)(OK, singleBusinessResponseInLatencyPeriod2(latencyDetails2))
+            ITSAStatusDetailsStub.stubGetITSAStatusDetails("MTD Mandated", "2022-23")
+            ITSAStatusDetailsStub.stubGetITSAStatusDetails("MTD Mandated", "2023-24")
             CalculationListStub.stubGetLegacyCalculationList(testNino, "2023")(CalculationListIntegrationTestConstants.successResponseNonCrystallised.toString())
             CalculationListStub.stubGetCalculationList(testNino, testTaxYearRange)(CalculationListIntegrationTestConstants.successResponseNonCrystallised.toString())
 

--- a/test/controllers/manageBusinesses/manage/ManageIncomeSourceDetailsSelfEmploymentSpec.scala
+++ b/test/controllers/manageBusinesses/manage/ManageIncomeSourceDetailsSelfEmploymentSpec.scala
@@ -255,7 +255,7 @@ class ManageIncomeSourceDetailsSelfEmploymentISpec extends ManageIncomeSourceDet
             setupMockCreateSession(true)
 
             setupMockGetCurrentTaxYearEnd(2023)
-            setupMockHasMandatedOrVoluntaryStatusForLatencyYears(true, false)
+            setupMockHasMandatedOrVoluntaryStatusForLatencyYears(true, true)
             setupMockTaxYearNotCrystallised(2023)
             setupMockTaxYearNotCrystallised(2024)
 
@@ -286,12 +286,12 @@ class ManageIncomeSourceDetailsSelfEmploymentISpec extends ManageIncomeSourceDet
             )
 
             val summaryValues = getManageDetailsSummaryValues(document).eachText()
-            summaryValues should contain("Yes")
             summaryValues should contain("No")
+            summaryValues should contain("Yes")
 
             val actions = document.select(".govuk-summary-list__actions a").eachText()
-            actions should contain("Opt out")
             actions should contain("Sign up")
+            actions should contain("Opt out")
           }
 
         }

--- a/test/controllers/manageBusinesses/manage/ManageIncomeSourceDetailsUkPropertySpec.scala
+++ b/test/controllers/manageBusinesses/manage/ManageIncomeSourceDetailsUkPropertySpec.scala
@@ -120,7 +120,7 @@ class ManageIncomeSourceDetailsUkPropertyISpec extends ManageIncomeSourceDetails
               setupMockSuccess(mtdUserRole)
               setupMockCreateSession(true)
               setupMockGetCurrentTaxYearEnd(2023)
-              setupMockHasMandatedOrVoluntaryStatusForLatencyYears(true, false)
+              setupMockHasMandatedOrVoluntaryStatusForLatencyYears(true, true)
               setupMockTaxYearNotCrystallised(2023)
               setupMockTaxYearNotCrystallised(2024)
               mockUkPlusForeignPlusSoleTraderWithLatency()

--- a/test/views/manageBusinesses/manage/ManageIncomeSourceDetailsViewSpec.scala
+++ b/test/views/manageBusinesses/manage/ManageIncomeSourceDetailsViewSpec.scala
@@ -774,15 +774,16 @@ class ManageIncomeSourceDetailsViewSpec extends TestSupport with ViewSpec {
       val TaxYear2 = "2026"
 
       val testViewModel = selfEmploymentViewModel.copy(
-        useMTDForTaxYear1 = Some(true),
-        useMTDForTaxYear2 = Some(false),
-        latencyYearsQuarterly = LatencyYearsQuarterly(Some(false), Some(false)),
+        latencyYearsQuarterly = LatencyYearsQuarterly(Some(true), Some(true)),
         latencyYearsCrystallised = LatencyYearsCrystallised(Some(false), Some(false)),
         latencyDetails = Some(testLatencyDetails3.copy(
-          taxYear1 = TaxYear1,
-          taxYear2 = TaxYear2
+          taxYear1 = "2025",
+          latencyIndicator1 = "Q",
+          taxYear2 = "2026",
+          latencyIndicator2 = "A"
         ))
       )
+
 
       val view = manageIncomeSourceDetailsView(
         testViewModel,
@@ -812,20 +813,20 @@ class ManageIncomeSourceDetailsViewSpec extends TestSupport with ViewSpec {
       actionLinks should contain("Sign up")
     }
 
-    "not render an MTD opt-in row if one of the useMTDForTaxYear value is None " in {
+    "not render an MTD opt-in row if one of the latency years is crystallised" in {
       val taxYear1 = "2025"
       val taxYear2 = "2026"
 
       val testViewModel = selfEmploymentViewModel.copy(
-        useMTDForTaxYear1 = Some(true),
-        useMTDForTaxYear2 = None,
-        latencyYearsQuarterly = LatencyYearsQuarterly(Some(false), Some(false)),
-        latencyYearsCrystallised = LatencyYearsCrystallised(Some(false), Some(false)),
+        latencyYearsQuarterly = LatencyYearsQuarterly(Some(true), Some(true)),
+        latencyYearsCrystallised = LatencyYearsCrystallised(Some(false), Some(true)),
         latencyDetails = Some(testLatencyDetails3.copy(
-          taxYear1 = taxYear1,
-          taxYear2 = taxYear2
+          taxYear1 = "2025", latencyIndicator1 = "Q",
+          taxYear2 = "2026", latencyIndicator2 = "A"
         ))
       )
+
+
 
       val view = manageIncomeSourceDetailsView(
         testViewModel,


### PR DESCRIPTION
- [x] Renamed "Quarterly period" to "Update period", now the row is always visible regardless of the `OptInOptOutContentUpdateR17` feature switch.

- [x] Updated MTD usage row logic to use `latencyIndicator1/2` to determine the displayed value (Yes/No) while keeping  existing row rendering logic (based on crystallisation and latency year checks)