### PR TITLE
MISUV-9295 Updating view files to use p component

### DIFF
--- a/app/views/ForecastTaxCalcSummary.scala.html
+++ b/app/views/ForecastTaxCalcSummary.scala.html
@@ -17,7 +17,8 @@
 @import implicits.ImplicitCurrencyFormatter._
 @import models.liabilitycalculation.{EndOfYearEstimate, IncomeSource}
 @import views.html.layouts.unifiedLayout
-@import views.html.components._
+@import views.html.components.h1WithCaption
+@import views.html.components.p
 @import exceptions.MissingFieldException
 
 

--- a/app/views/ForecastTaxCalcSummary.scala.html
+++ b/app/views/ForecastTaxCalcSummary.scala.html
@@ -15,16 +15,13 @@
  *@
 
 @import implicits.ImplicitCurrencyFormatter._
-@import models.liabilitycalculation.{EndOfYearEstimate, IncomeSource}
-@import views.html.layouts.unifiedLayout
+@import models.liabilitycalculation.EndOfYearEstimate
 @import views.html.components.h1WithCaption
-@import views.html.components.p
-@import exceptions.MissingFieldException
+@import views.html.layouts.unifiedLayout
 
 
 @this(mainTemplate: unifiedLayout,
-    h1WithCaption: h1WithCaption,
-    p: p
+    h1WithCaption: h1WithCaption
 )
 
 @(endOfYearEstimateModel: EndOfYearEstimate, taxYear: Int, backUrl: String, isAgent: Boolean = false, btaNavPartial: Option[Html] = None)(implicit request: Request[_], messages: Messages)

--- a/app/views/claimToAdjustPoa/CheckYourAnswers.scala.html
+++ b/app/views/claimToAdjustPoa/CheckYourAnswers.scala.html
@@ -24,6 +24,7 @@
 @import models.claimToAdjustPoa.SelectYourReason
 @import models.claimToAdjustPoa.Increase
 @import views.html.components.link
+@import views.html.components.p
 @import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 
 @this(
@@ -31,6 +32,7 @@
         mainTemplate: unifiedLayout,
         hmrcPageHeading: HmrcPageHeading,
         link: link,
+        p: p,
         govukSummaryList : GovukSummaryList,
         formWithCSRF: FormWithCSRF
 )
@@ -76,6 +78,16 @@
     }
 }
 
+@content = {
+        @p(){
+            @getMessage("summary-list-1.value", adjustedFirstPoaAmount.toCurrencyString)
+        }
+
+        @p(){
+            @getMessage("summary-list-2.value", adjustedSecondPoaAmount.toCurrencyString)
+        }
+    }
+
 @mainTemplate(
     pageTitle = getMessage("heading"),
     backUrl = Some("/"),
@@ -109,11 +121,7 @@
         } ++ Seq(
             SummaryListRow(
                 key = Key(Text(getMessage("summary-list-2.key"))),
-                value = Value(HtmlContent(s"""
-                    |<p class=govuk-body>${getMessage("summary-list-1.value", adjustedFirstPoaAmount.toCurrencyString)}</p>
-                    |<p class=govuk-body>${getMessage("summary-list-2.value", adjustedSecondPoaAmount.toCurrencyString)}</p>
-                    |""".stripMargin
-                )),
+                value = Value(HtmlContent(content)),
                 actions = Some(Actions(
                     items = Seq(ActionItem(
                         href = changePoaAmountUrl,

--- a/app/views/claimToAdjustPoa/EnterPoaAmountView.scala.html
+++ b/app/views/claimToAdjustPoa/EnterPoaAmountView.scala.html
@@ -105,6 +105,26 @@
     }
 }
 
+@insetTextContentFirstAttempt = {
+    @h2(getMessage("insetText.h2"), classes = "govuk-heading-s")
+    @p(){
+        @getMessage("insetText.firstAttempt.para1")
+    }
+    @p(){
+        @getMessage("insetText.firstAttempt.para2")
+    }
+}
+
+@insetTextContentSecondAttempt = {
+    @h2(getMessage("insetText.h2"), classes = "govuk-heading-s")
+    @p(){
+        @getMessage("insetText.secondAttempt.para1")
+    }
+    @p(){
+        @getMessage("insetText.secondAttempt.para2")
+    }
+}
+
 
 @mainTemplate(pageTitle = getMessage("heading"),
     backUrl = Some("/"),
@@ -166,20 +186,12 @@
     @if(viewModel.partiallyPaidAndNotAdjusted) {
         @govukInsetText(InsetText(
             id = Some("insetText-firstAttempt"),
-            content = HtmlContent(s"""
-                    |<h2 class=govuk-heading-s>${getMessage("insetText.h2")}</h2>
-                    |<p class=govuk-body>${getMessage("insetText.firstAttempt.para1")}</p>
-                    |<p class=govuk-body>${getMessage("insetText.firstAttempt.para2")}</p>
-                    |""".stripMargin)
+            content = HtmlContent(insetTextContentFirstAttempt)
         ))
     } else { @if(viewModel.partiallyPaidAndPreviouslyAdjusted) {
         @govukInsetText(InsetText(
             id = Some("insetText-secondAttempt"),
-            content = HtmlContent(s"""
-                    |<h2 class=govuk-heading-s>${getMessage("insetText.h2")}</h2>
-                    |<p class=govuk-body>${getMessage("insetText.secondAttempt.para1")}</p>
-                    |<p class=govuk-body>${getMessage("insetText.secondAttempt.para2")}</p>
-                    |""".stripMargin)
+            content = HtmlContent(insetTextContentSecondAttempt)
         ))
     }}
 

--- a/app/views/incomeSources/add/IncomeSourceAddedObligations.scala.html
+++ b/app/views/incomeSources/add/IncomeSourceAddedObligations.scala.html
@@ -164,16 +164,16 @@
         @if(sources.showPrevTaxYears) {
             <div class="box-simple" id="prevYears">
                 <div class="page_headers govuk-heading-m"> @getMessage("previous.tax.years.heading") </div>
-                <p class="govuk-body">
-                @{
-                    val head = getMessage("previous.tax.years.t1")
-                    val to = getMessage("to")
-                    val fromYear = sources.currentTaxYear - 1
-                    val toYear = sources.currentTaxYear
+                @p(){
+                    @{
+                        val head = getMessage("previous.tax.years.t1")
+                        val to = getMessage("to")
+                        val fromYear = sources.currentTaxYear - 1
+                        val toYear = sources.currentTaxYear
 
-                    s"""$head $fromYear $to $toYear."""
+                        s"""$head $fromYear $to $toYear."""
+                    }
                 }
-                </p>
             </div>
         }
 

--- a/app/views/optOut/ConfirmedOptOut.scala.html
+++ b/app/views/optOut/ConfirmedOptOut.scala.html
@@ -100,7 +100,10 @@
 @revisedDeadlinesBlock = {
     <div id="revised-deadlines" class="govuk-!-margin-bottom-7 govuk-!-margin-top-8">
         @h2(msg = "optout.confirmedOptOut.yourRevisedDeadlines.h2", optId = Some("revised-deadlines-heading"))
-        <p id="revised-deadlines-p1" class="govuk-body">@Html(messages("optout.confirmedOptOut.yourRevisedDeadlines.desc1", viewModel.startYear, viewModel.endYear, viewModel.nextYear))</p>
+@*        <p id="revised-deadlines-p1" class="govuk-body">@Html(messages("optout.confirmedOptOut.yourRevisedDeadlines.desc1", viewModel.startYear, viewModel.endYear, viewModel.nextYear))</p>*@
+        @p(id = Some("revised-deadlines-p1")){
+            @Html(messages("optout.confirmedOptOut.yourRevisedDeadlines.desc1", viewModel.startYear, viewModel.endYear, viewModel.nextYear))
+        }
         @p(id = Some("view-upcoming-updates")) {
             @link(
                 id = Some("view-upcoming-updates-link"),

--- a/app/views/optOut/ConfirmedOptOut.scala.html
+++ b/app/views/optOut/ConfirmedOptOut.scala.html
@@ -100,7 +100,6 @@
 @revisedDeadlinesBlock = {
     <div id="revised-deadlines" class="govuk-!-margin-bottom-7 govuk-!-margin-top-8">
         @h2(msg = "optout.confirmedOptOut.yourRevisedDeadlines.h2", optId = Some("revised-deadlines-heading"))
-@*        <p id="revised-deadlines-p1" class="govuk-body">@Html(messages("optout.confirmedOptOut.yourRevisedDeadlines.desc1", viewModel.startYear, viewModel.endYear, viewModel.nextYear))</p>*@
         @p(id = Some("revised-deadlines-p1")){
             @Html(messages("optout.confirmedOptOut.yourRevisedDeadlines.desc1", viewModel.startYear, viewModel.endYear, viewModel.nextYear))
         }

--- a/app/views/partials/chargeSummary/ChargeSummaryCodingOut.scala.html
+++ b/app/views/partials/chargeSummary/ChargeSummaryCodingOut.scala.html
@@ -14,12 +14,12 @@
  * limitations under the License.
  *@
 
-@import _root_.implicits.ImplicitCurrencyFormatter.CurrencyFormatter
-@import exceptions.MissingFieldException
 @import models.financialDetails.FullyCollected
 @import models.financialDetails.Accepted
+@import implicits.ImplicitCurrencyFormatter.CurrencyFormatter
+@import views.html.components.p
 
-@this()
+@this(p: p)
 
 @(
     chargeItem: models.financialDetails.ChargeItem,
@@ -28,20 +28,20 @@
     latePaymentInterestCharge: Boolean
 )(implicit messages: Messages)
 
-<p id="paymentAmount" class="govuk-body govuk-!-margin-bottom-1 govuk-!-margin-top-5">
+@p(id = Some("paymentAmount"), classes = "govuk-body govuk-!-margin-bottom-1 govuk-!-margin-top-5"){
     <strong class="govuk-body govuk-!-font-weight-bold govuk-!-margin-right-8">
         @messages("chargeSummary.paymentAmountCodingOut")
     </strong>
     @{
         chargeItem.originalAmount.toCurrency
     }
-</p>
+}
 
-<p id = "codingOutRemainingToPay" class="govuk-body govuk-!-margin-bottom-6" style="color:#505a5f;">
+@p(id = Some("codingOutRemainingToPay"), classes = "govuk-body govuk-!-margin-bottom-6"){
     @{
         if (chargeItem.codedOutStatus.exists(Seq(Accepted, FullyCollected).contains)) {
             messages("chargeSummary.codingOutRemainingToPay", taxYearFromCodingOut, taxYearToCodingOut)
         } else if (latePaymentInterestCharge) chargeItem.interestRemainingToPay.toCurrency
         else chargeItem.remainingToPay.toCurrency
     }
-</p>
+}


### PR DESCRIPTION
Updating view files to use components instead of the '<p>' tag.

There were a few files which have been left out such as the StubDataView and StubSchemaView. This was due to running into errors when changing these files to use the component. As these files are testOnly files, I think it's okay to leave as is.