### PR TITLE
MISUV-11145: Add conditional logic for help link and hiding help link in NoIncomeSources page

### DIFF
--- a/app/views/NoIncomeSourcesView.scala.html
+++ b/app/views/NoIncomeSourcesView.scala.html
@@ -36,6 +36,7 @@
     backUrl = Some("#"),
     isAgent = isAgent,
     btaNavPartial = user.btaNavPartial,
+    showGetHelpLink = false,
     btaAndPtaServiceNavigation = user.serviceNavigationPartial
 ) {
 

--- a/app/views/layouts/unifiedLayout.scala.html
+++ b/app/views/layouts/unifiedLayout.scala.html
@@ -63,7 +63,8 @@
     useFallbackBackLink: Boolean = true,
     showServiceName: Boolean = true,
     isErrorPage: Boolean = false,
-    gatewayPage: Option[GatewayPage] = None
+    gatewayPage: Option[GatewayPage] = None,
+    showGetHelpLink: Boolean = true
 )(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
 
 
@@ -196,12 +197,14 @@
         @contentBlock
     </div>
 
-    <div class="govuk-body app-get-help-link">
-        <a lang="en" hreflang="en" class="govuk-link" rel="noreferrer noopener" target="_blank" href="@{appConfig.reportAProblemNonJSUrl}">
-            @messages("getpagehelp.linkText")
-            @messages("pagehelp.opensInNewTabText")
-        </a>
-    </div>
+    @if(showGetHelpLink) {
+        <div class="govuk-body app-get-help-link">
+            <a lang="en" hreflang="en" class="govuk-link" rel="noreferrer noopener" target="_blank" href="@{appConfig.reportAProblemNonJSUrl}">
+                @messages("getpagehelp.linkText")
+                @messages("pagehelp.opensInNewTabText")
+            </a>
+        </div>
+    }
 
 }
 

--- a/conf/messages
+++ b/conf/messages
@@ -213,7 +213,7 @@ noIncomeSources.error.p1 = A change is required before you can access the Manage
 noIncomeSources.error.contact.heading = To contact us:
 noIncomeSources.error.step1 = Open the contact us form.
 noIncomeSources.error.step2 = Fill in your name and email address.
-noIncomeSources.error.step3 = In the box labelled "What do you need help with?", type "I need help accessing the Manage your Self Assessment service".
+noIncomeSources.error.step3 = In the box labelled ''What do you need help with?'', type "I need help accessing the Manage your Self Assessment service".
 noIncomeSources.error.p2 = We’ll contact you with any updates and let you know how you can access this service.
 noIncomeSources.error.button = Contact us form
 


### PR DESCRIPTION
The help link is not required on this page, as the Contact us button leads to the same destination.

To manually test this page  you need to log in using the test user : NA000001A - Newly registered user with no income sources


<img width="1920" height="1323" alt="image" src="https://github.com/user-attachments/assets/ef13cbcb-d904-409c-93cb-3d710d16e81a" />

