### PR TITLE
MISUV-11273: Updated the ItsaHomePage audit event to match the approved TXM audit change for CY+1

### DIFF
--- a/app/audit/models/HomeAudit.scala
+++ b/app/audit/models/HomeAudit.scala
@@ -42,7 +42,8 @@ case class HomeAudit(mtdItUser: MtdItUser[_],
 
   override val detail: JsValue = Json.obj(
     "mtditid" -> mtdItUser.mtditid,
-    "nino" -> mtdItUser.nino
+    "nino" -> mtdItUser.nino,
+    "userIsCYPlusOne" -> mtdItUser.incomeSources.yearOfMigration.isDefined
   ) ++ userType(mtdItUser.userType, mtdItUser.isSupportingAgent) ++ paymentsInformation ++ updatesInformation ++
     Json.obj("saUtr"-> mtdItUser.saUtr) ++
     Json.obj("credId"-> mtdItUser.credId) ++

--- a/app/audit/models/HomeAudit.scala
+++ b/app/audit/models/HomeAudit.scala
@@ -16,16 +16,17 @@
 
 package audit.models
 
-import audit.Utilities._
+import audit.Utilities.*
 import auth.MtdItUser
 import models.homePage.NextUpdatesTileViewModel
 import play.api.libs.json.{JsObject, JsValue, Json}
 
 import java.time.LocalDate
 
-case class HomeAudit(mtdItUser: MtdItUser[_],
+case class HomeAudit(mtdItUser: MtdItUser[?],
                      nextPaymentOrOverdue: Option[Either[(LocalDate, Boolean), Int]],
-                     nextUpdateOrOverdue: Either[(LocalDate, Boolean), Int]) extends ExtendedAuditModel {
+                     nextUpdateOrOverdue: Either[(LocalDate, Boolean), Int],
+                     userIsCYPlusOne: Boolean) extends ExtendedAuditModel {
 
   private val paymentsInformation: JsObject = nextPaymentOrOverdue match {
     case Some(Right(count)) => Json.obj("overduePayments" -> count)
@@ -43,7 +44,7 @@ case class HomeAudit(mtdItUser: MtdItUser[_],
   override val detail: JsValue = Json.obj(
     "mtditid" -> mtdItUser.mtditid,
     "nino" -> mtdItUser.nino,
-    "userIsCYPlusOne" -> mtdItUser.incomeSources.yearOfMigration.isDefined
+    "userIsCYPlusOne" -> userIsCYPlusOne
   ) ++ userType(mtdItUser.userType, mtdItUser.isSupportingAgent) ++ paymentsInformation ++ updatesInformation ++
     Json.obj("saUtr"-> mtdItUser.saUtr) ++
     Json.obj("credId"-> mtdItUser.credId) ++
@@ -54,10 +55,11 @@ case class HomeAudit(mtdItUser: MtdItUser[_],
 }
 
 object HomeAudit {
-  def apply(mtdItUser: MtdItUser[_],
+  def apply(mtdItUser: MtdItUser[?],
             nextPaymentDueDate: Option[LocalDate],
             overduePaymentsCount: Int,
-            nextUpdatesTileViewModel: NextUpdatesTileViewModel): HomeAudit = {
+            nextUpdatesTileViewModel: NextUpdatesTileViewModel,
+            userIsCYPlusOne: Boolean): HomeAudit = {
 
     val overdueUpdatesCount: Int = nextUpdatesTileViewModel.getNumberOfOverdueObligations
     val nextUpdateDueDate: Option[LocalDate] = nextUpdatesTileViewModel.getNextDeadline
@@ -79,12 +81,14 @@ object HomeAudit {
     HomeAudit(
       mtdItUser,
       nextPaymentOrOverdue = nextPaymentOrOverdue,
-      nextUpdateOrOverdue = nextUpdateOrOverdue
+      nextUpdateOrOverdue = nextUpdateOrOverdue,
+      userIsCYPlusOne = userIsCYPlusOne
     )
   }
 
-  def applySupportingAgent(mtdItUser: MtdItUser[_],
-                           nextUpdatesTileViewModel: NextUpdatesTileViewModel): HomeAudit = {
+  def applySupportingAgent(mtdItUser: MtdItUser[?],
+                           nextUpdatesTileViewModel: NextUpdatesTileViewModel,
+                           userIsCYPlusOne: Boolean): HomeAudit = {
     val overdueUpdatesCount: Int = nextUpdatesTileViewModel.getNumberOfOverdueObligations
     val nextUpdateDueDate: Option[LocalDate] = nextUpdatesTileViewModel.getNextDeadline
     val nextUpdateOrOverdue: Either[(LocalDate, Boolean), Int] = {
@@ -97,7 +101,8 @@ object HomeAudit {
     HomeAudit(
       mtdItUser,
       nextPaymentOrOverdue = None,
-      nextUpdateOrOverdue = nextUpdateOrOverdue
+      nextUpdateOrOverdue = nextUpdateOrOverdue,
+      userIsCYPlusOne = userIsCYPlusOne
     )
   }
 }

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -124,7 +124,7 @@ class HomeController @Inject()(val homeView: views.html.HomeView,
 
       val yourBusinessesTileViewModel = YourBusinessesTileViewModel(user.incomeSources.hasOngoingBusinessOrPropertyIncome)
       val yourReportingObligationsTileViewModel = YourReportingObligationsTileViewModel(currentTaxYear, currentITSAStatus)
-      val userIsCYPlusOne = currentITSAStatus != ITSAStatus.NoStatus
+      val userIsCYPlusOne = currentITSAStatus == ITSAStatus.NoStatus
       
       auditingService.extendedAudit(HomeAudit.applySupportingAgent(user, nextUpdatesTileViewModel, userIsCYPlusOne))
       Ok(
@@ -208,7 +208,7 @@ class HomeController @Inject()(val homeView: views.html.HomeView,
             if (mandation) SessionKeys.mandationStatus -> "on"
             else SessionKeys.mandationStatus -> "off"
 
-          val userIsCYPlusOne = currentITSAStatus != ITSAStatus.NoStatus
+          val userIsCYPlusOne = currentITSAStatus == ITSAStatus.NoStatus
 
           auditingService.extendedAudit(
             HomeAudit(

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -124,8 +124,9 @@ class HomeController @Inject()(val homeView: views.html.HomeView,
 
       val yourBusinessesTileViewModel = YourBusinessesTileViewModel(user.incomeSources.hasOngoingBusinessOrPropertyIncome)
       val yourReportingObligationsTileViewModel = YourReportingObligationsTileViewModel(currentTaxYear, currentITSAStatus)
-
-      auditingService.extendedAudit(HomeAudit.applySupportingAgent(user, nextUpdatesTileViewModel))
+      val userIsCYPlusOne = currentITSAStatus != ITSAStatus.NoStatus
+      
+      auditingService.extendedAudit(HomeAudit.applySupportingAgent(user, nextUpdatesTileViewModel, userIsCYPlusOne))
       Ok(
         supportingAgentHomeView(
           yourBusinessesTileViewModel,
@@ -207,7 +208,17 @@ class HomeController @Inject()(val homeView: views.html.HomeView,
             if (mandation) SessionKeys.mandationStatus -> "on"
             else SessionKeys.mandationStatus -> "off"
 
-          auditingService.extendedAudit(HomeAudit(user, paymentsDueMerged, overDuePaymentsCount, nextUpdatesTileViewModel))
+          val userIsCYPlusOne = currentITSAStatus != ITSAStatus.NoStatus
+
+          auditingService.extendedAudit(
+            HomeAudit(
+              user,
+              paymentsDueMerged,
+              overDuePaymentsCount,
+              nextUpdatesTileViewModel,
+              userIsCYPlusOne
+            )
+          )
 
           if (user.isAgent) {
             Ok(primaryAgentHomeView(homeViewModel)).addingToSession(mandationStatus)

--- a/it/test/controllers/HomeControllerISpec.scala
+++ b/it/test/controllers/HomeControllerISpec.scala
@@ -27,17 +27,17 @@ import models.admin.NavBarFs
 import models.core.{AccountingPeriodModel, CessationModel}
 import models.financialDetails.*
 import models.incomeSourceDetails.{BusinessDetailsModel, IncomeSourceDetailsModel, TaxYear}
+import obligations.models.*
 import obligations.models.audit.NextUpdatesResponseAuditModel
+import obligations.testConstants.NextUpdatesIntegrationTestConstants.*
 import play.api.http.Status.*
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import testConstants.BaseIntegrationTestConstants.*
 import testConstants.BusinessDetailsIntegrationTestConstants.{address, b2CessationDate, b2TradingStart}
-import obligations.testConstants.NextUpdatesIntegrationTestConstants.*
 import testConstants.OutstandingChargesIntegrationTestConstants.{validOutStandingChargeResponseJsonWithAciAndBcdCharges, validOutStandingChargeResponseJsonWithoutAciAndBcdCharges}
 import testConstants.messages.HomeMessages.*
-import obligations.models.*
 
 import java.time.LocalDate
 
@@ -143,7 +143,7 @@ class HomeControllerISpec extends ControllerISpecHelper {
               elementTextBySelector("#payments-tile p:nth-child(2)")(currentDate.toLongDate)
             )
 
-            verifyAuditContainsDetail(HomeAudit(testUser, Some(Left(currentDate -> false)), Left(currentDate -> false)).detail)
+            verifyAuditContainsDetail(HomeAudit(testUser, Some(Left(currentDate -> false)), Left(currentDate -> false), userIsCYPlusOne = false).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
         }
@@ -216,7 +216,7 @@ class HomeControllerISpec extends ControllerISpecHelper {
               elementTextBySelector("#payments-tile p:nth-child(2)")(noPaymentsDue)
             )
 
-            verifyAuditContainsDetail(HomeAudit(testUser, None, Left(currentDate -> false)).detail)
+            verifyAuditContainsDetail(HomeAudit(testUser, None, Left(currentDate -> false), userIsCYPlusOne = false).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
         }
@@ -291,7 +291,11 @@ class HomeControllerISpec extends ControllerISpecHelper {
               elementTextBySelector("#payments-tile p:nth-child(2)")(s"$overdue ${currentDate.minusDays(1).toLongDate}")
             )
 
-            verifyAuditContainsDetail(HomeAudit(testUser, Some(Left(currentDate.minusDays(1) -> true)), Left(currentDate.minusDays(1) -> true)).detail)
+            verifyAuditContainsDetail(HomeAudit(
+              testUser,
+              Some(Left(currentDate.minusDays(1) -> true)),
+              Left(currentDate.minusDays(1) -> true),
+              userIsCYPlusOne = false).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
 
@@ -364,7 +368,11 @@ class HomeControllerISpec extends ControllerISpecHelper {
               elementTextBySelector("#payments-tile p:nth-child(2)")(overduePayments(numberOverdue = "2"))
             )
 
-            verifyAuditContainsDetail(HomeAudit(testUser, Some(Right(2)), Left(currentDate.minusDays(1) -> true)).detail)
+            verifyAuditContainsDetail(HomeAudit(
+              testUser,
+              Some(Right(2)),
+              Left(currentDate.minusDays(1) -> true),
+              userIsCYPlusOne = false).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
         }
@@ -459,7 +467,7 @@ class HomeControllerISpec extends ControllerISpecHelper {
               elementTextBySelector("#payments-tile p:nth-child(2)")(overduePayments(numberOverdue = "2"))
             )
 
-            verifyAuditContainsDetail(HomeAudit(testUser, Some(Right(2)), Right(2)).detail)
+            verifyAuditContainsDetail(HomeAudit(testUser, Some(Right(2)), Right(2), userIsCYPlusOne = false).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
         }

--- a/it/test/controllers/HomeControllerISpec.scala
+++ b/it/test/controllers/HomeControllerISpec.scala
@@ -143,7 +143,7 @@ class HomeControllerISpec extends ControllerISpecHelper {
               elementTextBySelector("#payments-tile p:nth-child(2)")(currentDate.toLongDate)
             )
 
-            verifyAuditContainsDetail(HomeAudit(testUser, Some(Left(currentDate -> false)), Left(currentDate -> false), userIsCYPlusOne = true).detail)
+            verifyAuditContainsDetail(HomeAudit(testUser, Some(Left(currentDate -> false)), Left(currentDate -> false), userIsCYPlusOne = false).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
         }
@@ -216,7 +216,7 @@ class HomeControllerISpec extends ControllerISpecHelper {
               elementTextBySelector("#payments-tile p:nth-child(2)")(noPaymentsDue)
             )
 
-            verifyAuditContainsDetail(HomeAudit(testUser, None, Left(currentDate -> false), userIsCYPlusOne = true).detail)
+            verifyAuditContainsDetail(HomeAudit(testUser, None, Left(currentDate -> false), userIsCYPlusOne = false).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
         }
@@ -295,7 +295,7 @@ class HomeControllerISpec extends ControllerISpecHelper {
               testUser,
               Some(Left(currentDate.minusDays(1) -> true)),
               Left(currentDate.minusDays(1) -> true),
-              userIsCYPlusOne = true).detail)
+              userIsCYPlusOne = false).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
 
@@ -372,7 +372,7 @@ class HomeControllerISpec extends ControllerISpecHelper {
               testUser,
               Some(Right(2)),
               Left(currentDate.minusDays(1) -> true),
-              userIsCYPlusOne = true).detail)
+              userIsCYPlusOne = false).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
         }
@@ -467,7 +467,7 @@ class HomeControllerISpec extends ControllerISpecHelper {
               elementTextBySelector("#payments-tile p:nth-child(2)")(overduePayments(numberOverdue = "2"))
             )
 
-            verifyAuditContainsDetail(HomeAudit(testUser, Some(Right(2)), Right(2), userIsCYPlusOne = true).detail)
+            verifyAuditContainsDetail(HomeAudit(testUser, Some(Right(2)), Right(2), userIsCYPlusOne = false).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
         }

--- a/it/test/controllers/HomeControllerISpec.scala
+++ b/it/test/controllers/HomeControllerISpec.scala
@@ -143,7 +143,7 @@ class HomeControllerISpec extends ControllerISpecHelper {
               elementTextBySelector("#payments-tile p:nth-child(2)")(currentDate.toLongDate)
             )
 
-            verifyAuditContainsDetail(HomeAudit(testUser, Some(Left(currentDate -> false)), Left(currentDate -> false), userIsCYPlusOne = false).detail)
+            verifyAuditContainsDetail(HomeAudit(testUser, Some(Left(currentDate -> false)), Left(currentDate -> false), userIsCYPlusOne = true).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
         }
@@ -216,7 +216,7 @@ class HomeControllerISpec extends ControllerISpecHelper {
               elementTextBySelector("#payments-tile p:nth-child(2)")(noPaymentsDue)
             )
 
-            verifyAuditContainsDetail(HomeAudit(testUser, None, Left(currentDate -> false), userIsCYPlusOne = false).detail)
+            verifyAuditContainsDetail(HomeAudit(testUser, None, Left(currentDate -> false), userIsCYPlusOne = true).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
         }
@@ -295,7 +295,7 @@ class HomeControllerISpec extends ControllerISpecHelper {
               testUser,
               Some(Left(currentDate.minusDays(1) -> true)),
               Left(currentDate.minusDays(1) -> true),
-              userIsCYPlusOne = false).detail)
+              userIsCYPlusOne = true).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
 
@@ -372,7 +372,7 @@ class HomeControllerISpec extends ControllerISpecHelper {
               testUser,
               Some(Right(2)),
               Left(currentDate.minusDays(1) -> true),
-              userIsCYPlusOne = false).detail)
+              userIsCYPlusOne = true).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
         }
@@ -467,7 +467,7 @@ class HomeControllerISpec extends ControllerISpecHelper {
               elementTextBySelector("#payments-tile p:nth-child(2)")(overduePayments(numberOverdue = "2"))
             )
 
-            verifyAuditContainsDetail(HomeAudit(testUser, Some(Right(2)), Right(2), userIsCYPlusOne = false).detail)
+            verifyAuditContainsDetail(HomeAudit(testUser, Some(Right(2)), Right(2), userIsCYPlusOne = true).detail)
             verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
           }
         }

--- a/it/test/controllers/agent/HomeControllerPrimaryAgentISpec.scala
+++ b/it/test/controllers/agent/HomeControllerPrimaryAgentISpec.scala
@@ -23,20 +23,19 @@ import enums.MTDPrimaryAgent
 import helpers.servicemocks.AuditStub.verifyAuditContainsDetail
 import helpers.servicemocks.{ITSAStatusDetailsStub, IncomeTaxViewChangeStub}
 import implicits.{ImplicitDateFormatter, ImplicitDateFormatterImpl}
-import models.admin.NavBarFs
 import models.core.{AccountingPeriodModel, CessationModel}
-import models.financialDetails._
+import models.financialDetails.*
 import models.incomeSourceDetails.{BusinessDetailsModel, IncomeSourceDetailsModel, TaxYear}
 import obligations.models.audit.NextUpdatesResponseAuditModel
 import obligations.models.{GroupedObligationsModel, ObligationsModel, SingleObligationModel, StatusFulfilled}
+import obligations.testConstants.NextUpdatesIntegrationTestConstants.currentDate
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK}
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
-import testConstants.BaseIntegrationTestConstants._
+import testConstants.BaseIntegrationTestConstants.*
 import testConstants.BusinessDetailsIntegrationTestConstants.{address, b2CessationDate, b2TradingStart}
-import obligations.testConstants.NextUpdatesIntegrationTestConstants.currentDate
-import testConstants.OutstandingChargesIntegrationTestConstants._
+import testConstants.OutstandingChargesIntegrationTestConstants.*
 import testConstants.messages.HomeMessages.{noPaymentsDue, overdue, overduePayments, overdueUpdates}
 
 import java.time.LocalDate
@@ -142,7 +141,11 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   elementTextBySelector("#payments-tile p:nth-child(2)")(currentDate.toLongDate)
                 )
 
-                verifyAuditContainsDetail(HomeAudit(testUser, Some(Left(currentDate -> false)), Left(currentDate -> false)).detail)
+                verifyAuditContainsDetail(HomeAudit(
+                  testUser,
+                  Some(Left(currentDate -> false)),
+                  Left(currentDate -> false),
+                  userIsCYPlusOne = false).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
             }
@@ -212,7 +215,11 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   elementTextBySelector("#payments-tile p:nth-child(2)")(noPaymentsDue)
                 )
 
-                verifyAuditContainsDetail(HomeAudit(testUser, None, Left(currentDate -> false)).detail)
+                verifyAuditContainsDetail(HomeAudit(
+                  testUser,
+                  None,
+                  Left(currentDate -> false),
+                  userIsCYPlusOne = false).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
             }
@@ -284,7 +291,11 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   elementTextBySelector("#payments-tile p:nth-child(2)")(s"$overdue ${currentDate.minusDays(1).toLongDate}")
                 )
 
-                verifyAuditContainsDetail(HomeAudit(testUser, Some(Left(currentDate.minusDays(1) -> true)), Left(currentDate.minusDays(1) -> true)).detail)
+                verifyAuditContainsDetail(HomeAudit(
+                  testUser,
+                  Some(Left(currentDate.minusDays(1) -> true)),
+                  Left(currentDate.minusDays(1) -> true),
+                  userIsCYPlusOne = false).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
 
@@ -354,7 +365,11 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   elementTextBySelector("#payments-tile p:nth-child(2)")(overduePayments(numberOverdue = "2"))
                 )
 
-                verifyAuditContainsDetail(HomeAudit(testUser, Some(Right(2)), Left(currentDate.minusDays(1) -> true)).detail)
+                verifyAuditContainsDetail(HomeAudit(
+                  testUser,
+                  Some(Right(2)),
+                  Left(currentDate.minusDays(1) -> true),
+                  userIsCYPlusOne = false).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
             }
@@ -446,7 +461,11 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   elementTextBySelector("#payments-tile p:nth-child(2)")(overduePayments(numberOverdue = "2"))
                 )
 
-                verifyAuditContainsDetail(HomeAudit(testUser, Some(Right(2)), Right(2)).detail)
+                verifyAuditContainsDetail(HomeAudit(
+                  testUser,
+                  Some(Right(2)),
+                  Right(2),
+                  userIsCYPlusOne = false).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
             }

--- a/it/test/controllers/agent/HomeControllerPrimaryAgentISpec.scala
+++ b/it/test/controllers/agent/HomeControllerPrimaryAgentISpec.scala
@@ -145,7 +145,7 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   testUser,
                   Some(Left(currentDate -> false)),
                   Left(currentDate -> false),
-                  userIsCYPlusOne = false).detail)
+                  userIsCYPlusOne = true).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
             }
@@ -219,7 +219,7 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   testUser,
                   None,
                   Left(currentDate -> false),
-                  userIsCYPlusOne = false).detail)
+                  userIsCYPlusOne = true).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
             }
@@ -295,7 +295,7 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   testUser,
                   Some(Left(currentDate.minusDays(1) -> true)),
                   Left(currentDate.minusDays(1) -> true),
-                  userIsCYPlusOne = false).detail)
+                  userIsCYPlusOne = true).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
 
@@ -369,7 +369,7 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   testUser,
                   Some(Right(2)),
                   Left(currentDate.minusDays(1) -> true),
-                  userIsCYPlusOne = false).detail)
+                  userIsCYPlusOne = true).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
             }
@@ -465,7 +465,7 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   testUser,
                   Some(Right(2)),
                   Right(2),
-                  userIsCYPlusOne = false).detail)
+                  userIsCYPlusOne = true).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
             }

--- a/it/test/controllers/agent/HomeControllerPrimaryAgentISpec.scala
+++ b/it/test/controllers/agent/HomeControllerPrimaryAgentISpec.scala
@@ -145,7 +145,7 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   testUser,
                   Some(Left(currentDate -> false)),
                   Left(currentDate -> false),
-                  userIsCYPlusOne = true).detail)
+                  userIsCYPlusOne = false).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
             }
@@ -219,7 +219,7 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   testUser,
                   None,
                   Left(currentDate -> false),
-                  userIsCYPlusOne = true).detail)
+                  userIsCYPlusOne = false).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
             }
@@ -295,7 +295,7 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   testUser,
                   Some(Left(currentDate.minusDays(1) -> true)),
                   Left(currentDate.minusDays(1) -> true),
-                  userIsCYPlusOne = true).detail)
+                  userIsCYPlusOne = false).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
 
@@ -369,7 +369,7 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   testUser,
                   Some(Right(2)),
                   Left(currentDate.minusDays(1) -> true),
-                  userIsCYPlusOne = true).detail)
+                  userIsCYPlusOne = false).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
             }
@@ -465,7 +465,7 @@ class HomeControllerPrimaryAgentISpec extends ControllerISpecHelper {
                   testUser,
                   Some(Right(2)),
                   Right(2),
-                  userIsCYPlusOne = true).detail)
+                  userIsCYPlusOne = false).detail)
                 verifyAuditContainsDetail(NextUpdatesResponseAuditModel(testUser, "testId", currentObligations.obligations.flatMap(_.obligations)).detail)
               }
             }

--- a/test/audit/models/HomeAuditSpec.scala
+++ b/test/audit/models/HomeAuditSpec.scala
@@ -76,7 +76,8 @@ class HomeAuditSpec extends AnyWordSpecLike with Matchers {
             nextUpdateOrOverdue = Right(2)
           ).detail mustBe commonAuditDetails(Agent) ++ Json.obj(
             "overduePayments" -> 2,
-            "overdueUpdates" -> 2
+            "overdueUpdates" -> 2,
+            "userIsCYPlusOne" -> false
           )
         }
         "there is are payments and updates due which are not overdue" in {
@@ -86,7 +87,8 @@ class HomeAuditSpec extends AnyWordSpecLike with Matchers {
             nextUpdateOrOverdue = Left(fixedDate -> false)
           ).detail, commonAuditDetails(Individual) ++ Json.obj(
             "nextPaymentDeadline" -> fixedDate.toString,
-            "nextUpdateDeadline" -> fixedDate.toString
+            "nextUpdateDeadline" -> fixedDate.toString,
+            "userIsCYPlusOne" -> false
           ))
         }
       }
@@ -94,7 +96,24 @@ class HomeAuditSpec extends AnyWordSpecLike with Matchers {
         assertJsonEquals(homeAuditMin.detail, Json.obj(
           "nino" -> testNino,
           "mtditid" -> testMtditid,
-          "overdueUpdates" -> 2
+          "overdueUpdates" -> 2,
+          "userIsCYPlusOne" -> false
+        ))
+      }
+
+      "the user is a CY+1 user" in {
+        val homeAudit = HomeAudit(
+          defaultMTDITUser(
+            Some(Individual),
+            IncomeSourceDetailsModel("nino", "mtditid", Some("2025"), Nil, Nil, "1")
+          ),
+          nextPaymentOrOverdue = None,
+          nextUpdateOrOverdue = Right(2)
+        )
+
+        assertJsonEquals(homeAudit.detail, commonAuditDetails(Individual) ++ Json.obj(
+          "overdueUpdates" -> 2,
+          "userIsCYPlusOne" -> true
         ))
       }
     }
@@ -113,7 +132,8 @@ class HomeAuditSpec extends AnyWordSpecLike with Matchers {
             nextQuarterlyUpdateDueDate = None,
             nextTaxReturnDueDate = None)
           HomeAudit.applySupportingAgent(user, nextDetailsTile).detail shouldBe commonAuditDetails(Agent, true) ++ Json.obj(
-            "nextUpdateDeadline" -> fixedDate.toString
+            "nextUpdateDeadline" -> fixedDate.toString,
+            "userIsCYPlusOne" -> false
           )
         }
 
@@ -126,7 +146,8 @@ class HomeAuditSpec extends AnyWordSpecLike with Matchers {
             nextQuarterlyUpdateDueDate = None,
             nextTaxReturnDueDate = None)
           HomeAudit.applySupportingAgent(user, nextDetailsTile).detail shouldBe commonAuditDetails(Agent, true) ++ Json.obj(
-            "nextUpdateDeadline" -> fixedDate.toString
+            "nextUpdateDeadline" -> fixedDate.toString,
+            "userIsCYPlusOne" -> false
           )
         }
       }
@@ -140,7 +161,8 @@ class HomeAuditSpec extends AnyWordSpecLike with Matchers {
           nextQuarterlyUpdateDueDate = None,
           nextTaxReturnDueDate = None)
         HomeAudit.applySupportingAgent(user, nextDetailsTile).detail shouldBe commonAuditDetails(Agent, true) ++ Json.obj(
-          "overdueUpdates" -> 2
+          "overdueUpdates" -> 2,
+          "userIsCYPlusOne" -> false
         )
       }
     }

--- a/test/audit/models/HomeAuditSpec.scala
+++ b/test/audit/models/HomeAuditSpec.scala
@@ -24,7 +24,7 @@ import models.itsaStatus.ITSAStatus
 import org.scalatest.Assertion
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import play.api.libs.json.{JsArray, JsNull, JsNumber, JsObject, JsValue, Json}
+import play.api.libs.json.*
 import testConstants.BaseTestConstants.*
 import uk.gov.hmrc.auth.core.AffinityGroup
 import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Individual}
@@ -37,18 +37,23 @@ class HomeAuditSpec extends AnyWordSpecLike with Matchers {
   val auditType: String = "ItsaHomePage"
   lazy val fixedDate : LocalDate = LocalDate.of(2022, 1, 7)
 
-  def homeAuditFull(userType: Option[AffinityGroup] = Some(Agent),
+  def homeAuditFull(
+                    userType: Option[AffinityGroup] = Some(Agent),
                     nextPaymentOrOverdue: Either[(LocalDate, Boolean), Int],
-                    nextUpdateOrOverdue: Either[(LocalDate, Boolean), Int]): HomeAudit = HomeAudit(
+                    nextUpdateOrOverdue: Either[(LocalDate, Boolean), Int],
+                    userIsCYPlusOne: Boolean = false
+                   ): HomeAudit = HomeAudit(
     defaultMTDITUser(userType, IncomeSourceDetailsModel("nino", "mtditid", None, Nil, Nil, "1")),
     nextPaymentOrOverdue = Some(nextPaymentOrOverdue),
-    nextUpdateOrOverdue = nextUpdateOrOverdue
+    nextUpdateOrOverdue = nextUpdateOrOverdue,
+    userIsCYPlusOne = userIsCYPlusOne
   )
 
   val homeAuditMin: HomeAudit = HomeAudit(
     getMinimalMTDITUser(None, IncomeSourceDetailsModel("nino", "mtditid", None, Nil, Nil, "1")),
     nextPaymentOrOverdue = None,
-    nextUpdateOrOverdue = Right(2)
+    nextUpdateOrOverdue = Right(2),
+    userIsCYPlusOne = false
   )
 
   "HomeAudit(mtdItUser, nextPaymentOrOverdue, nextUpdateOrOverdue, agentReferenceNumber)" should {
@@ -105,10 +110,11 @@ class HomeAuditSpec extends AnyWordSpecLike with Matchers {
         val homeAudit = HomeAudit(
           defaultMTDITUser(
             Some(Individual),
-            IncomeSourceDetailsModel("nino", "mtditid", Some("2025"), Nil, Nil, "1")
+            IncomeSourceDetailsModel("nino", "mtditid", None, Nil, Nil, "1")
           ),
           nextPaymentOrOverdue = None,
-          nextUpdateOrOverdue = Right(2)
+          nextUpdateOrOverdue = Right(2),
+          userIsCYPlusOne = true
         )
 
         assertJsonEquals(homeAudit.detail, commonAuditDetails(Individual) ++ Json.obj(
@@ -131,7 +137,9 @@ class HomeAuditSpec extends AnyWordSpecLike with Matchers {
             currentYearITSAStatus = ITSAStatus.NoStatus,
             nextQuarterlyUpdateDueDate = None,
             nextTaxReturnDueDate = None)
-          HomeAudit.applySupportingAgent(user, nextDetailsTile).detail shouldBe commonAuditDetails(Agent, true) ++ Json.obj(
+          HomeAudit.applySupportingAgent(user,
+            nextDetailsTile,
+            userIsCYPlusOne = false).detail shouldBe commonAuditDetails(Agent, true) ++ Json.obj(
             "nextUpdateDeadline" -> fixedDate.toString,
             "userIsCYPlusOne" -> false
           )
@@ -145,7 +153,11 @@ class HomeAuditSpec extends AnyWordSpecLike with Matchers {
             currentYearITSAStatus = ITSAStatus.NoStatus,
             nextQuarterlyUpdateDueDate = None,
             nextTaxReturnDueDate = None)
-          HomeAudit.applySupportingAgent(user, nextDetailsTile).detail shouldBe commonAuditDetails(Agent, true) ++ Json.obj(
+          HomeAudit.applySupportingAgent(
+            user,
+            nextDetailsTile,
+            userIsCYPlusOne = false
+          ).detail shouldBe commonAuditDetails(Agent, true) ++ Json.obj(
             "nextUpdateDeadline" -> fixedDate.toString,
             "userIsCYPlusOne" -> false
           )
@@ -160,7 +172,11 @@ class HomeAuditSpec extends AnyWordSpecLike with Matchers {
           currentYearITSAStatus = ITSAStatus.NoStatus,
           nextQuarterlyUpdateDueDate = None,
           nextTaxReturnDueDate = None)
-        HomeAudit.applySupportingAgent(user, nextDetailsTile).detail shouldBe commonAuditDetails(Agent, true) ++ Json.obj(
+        HomeAudit.applySupportingAgent(
+          user,
+          nextDetailsTile,
+          userIsCYPlusOne = false
+        ).detail shouldBe commonAuditDetails(Agent, true) ++ Json.obj(
           "overdueUpdates" -> 2,
           "userIsCYPlusOne" -> false
         )


### PR DESCRIPTION
Note: The approved Confluence text has a typo saying `userIsCYPlusOneUser`, but the JSON and Jira ticket say `userIsCYPlusOne` which is what I used in this PR.

Confluence page: https://confluence.tools.tax.service.gov.uk/spaces/CIP/pages/245531673/MTD+ITSA+-+View+Change+-+October+2021+plus#MTDITSAView&ChangeOctober2021plus-ItsaHomePage

<img width="790" height="780" alt="image" src="https://github.com/user-attachments/assets/c42b2f8c-8b9d-4399-8857-f0b8ab09be36" />
