### PR TITLE
MIPR 2784

### DIFF
--- a/app/common/config/FrontendAppConfig.scala
+++ b/app/common/config/FrontendAppConfig.scala
@@ -50,6 +50,9 @@ class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, val config
   //Income tax business details service
   lazy val incomeTaxBusinessDetailsBaseUrl: String = servicesConfig.baseUrl("income-tax-business-details")
 
+  lazy val incomeTaxBusinessDetailsFrontendBaseUrl: String =
+    servicesConfig.baseUrl("income-tax-business-details-frontend")
+ 
   //Income tax calculation service
   lazy val incomeTaxCalculationService: String = servicesConfig.baseUrl("income-tax-calculation")
 

--- a/app/common/models/admin/FeatureSwitchName.scala
+++ b/app/common/models/admin/FeatureSwitchName.scala
@@ -77,6 +77,8 @@ object FeatureSwitchName {
       JsSuccess(IdempotencyKeyForCreateIncomeSource)
     case JsString(NoIncomeSourcesRedirect.name) =>
       JsSuccess(NoIncomeSourcesRedirect)
+    case JsString(BusinessDetailsFrontend.name) =>
+      JsSuccess(BusinessDetailsFrontend)
     case invalidName =>
       Logger("application").error(s"Invalid feature switch Json found: $invalidName")
       JsSuccess(InvalidFS)
@@ -120,7 +122,8 @@ object FeatureSwitchName {
       RecentActivity,
       MortgageEvidence,
       IdempotencyKeyForCreateIncomeSource,
-      NoIncomeSourcesRedirect
+      NoIncomeSourcesRedirect,
+      BusinessDetailsFrontend
     )
 
   def get(str: String): Option[FeatureSwitchName] = allFeatureSwitches find (_.name == str)
@@ -234,4 +237,10 @@ case object NoIncomeSourcesRedirect extends FeatureSwitchName {
   override val name: String = "no-income-sources-redirect"
   override val toString: String = "No Income Sources Redirect"
 }
+
+case object BusinessDetailsFrontend extends FeatureSwitchName {
+  override val name: String = "business-details-frontend"
+  override val toString: String = "Business Details Frontend"
+}
+
 

--- a/app/hub/controllers/HomeController.scala
+++ b/app/hub/controllers/HomeController.scala
@@ -16,6 +16,7 @@
 
 package hub.controllers
 
+import common.models.admin.BusinessDetailsFrontend
 import businessDetails.auth.AuthActionsWithTriggeredMigrationCheck
 import common.auth.MtdItUser
 import common.config.*
@@ -104,6 +105,26 @@ class HomeController @Inject()(val homeView: hub.views.html.HomeView,
     }
   }
 
+  private def manageBusinessesUrl(isAgent: Boolean)(implicit user: MtdItUser[_]): String = {
+    val enabled = isEnabled(BusinessDetailsFrontend)
+
+    if (enabled) {
+      val path = if (isAgent) {
+        "/manage-self-assessment/businesses/agents/manage-your-businesses"
+      } else {
+        "/manage-self-assessment/businesses/manage-your-businesses"
+      }
+
+      s"${appConfig.incomeTaxBusinessDetailsFrontendBaseUrl}$path"
+    } else {
+      if (isAgent) {
+        businessDetails.controllers.manageBusinesses.routes.ManageYourBusinessesController.showAgent().url
+      } else {
+        businessDetails.controllers.manageBusinesses.routes.ManageYourBusinessesController.show().url
+      }
+    }
+  }
+
   private def buildHomePageForSupportingAgent(nextUpdatesDueDates: Seq[LocalDate])
                                              (implicit user: MtdItUser[_]): Future[Result] = {
 
@@ -121,7 +142,7 @@ class HomeController @Inject()(val homeView: hub.views.html.HomeView,
         nextQuarterlyUpdateDueDate = nextQuarterlyUpdateDueDate,
         nextTaxReturnDueDate = nextTaxReturnDueDate)
 
-      val yourBusinessesTileViewModel = YourBusinessesTileViewModel(user.incomeSources.hasOngoingBusinessOrPropertyIncome)
+      val yourBusinessesTileViewModel = YourBusinessesTileViewModel(user.incomeSources.hasOngoingBusinessOrPropertyIncome, Some(manageBusinessesUrl(user.isAgent)))
       val yourReportingObligationsTileViewModel = YourReportingObligationsTileViewModel(currentTaxYear, currentITSAStatus)
       val userIsCYPlusOne = currentITSAStatus == ITSAStatus.NoStatus
 
@@ -184,7 +205,7 @@ class HomeController @Inject()(val homeView: hub.views.html.HomeView,
         PaymentCreditAndRefundHistoryTileViewModel(credits, isEnabled(CreditsRefundsRepay), isEnabled(PaymentHistoryRefunds), user.incomeSources.yearOfMigration.isDefined)
 
       val yourBusinessesTileViewModel =
-        YourBusinessesTileViewModel(user.incomeSources.hasOngoingBusinessOrPropertyIncome)
+        YourBusinessesTileViewModel(user.incomeSources.hasOngoingBusinessOrPropertyIncome, Some(manageBusinessesUrl(user.isAgent)))
 
       val returnsTileViewModel =
         ReturnsTileViewModel(currentTaxYear, isEnabled(ITSASubmissionIntegration))
@@ -291,7 +312,8 @@ class HomeController @Inject()(val homeView: hub.views.html.HomeView,
         Ok(newHomeOverviewView(origin, user.isSupportingAgent, dateService.getCurrentTaxYear,
           yourTasksUrl(origin, isAgent), recentActivityUrl(origin, isAgent), overviewUrl(origin, isAgent),
           helpUrl(origin, isAgent), unpaidCharges.isEmpty, credits.availableCreditInAccount, ctaViewModel, chargeItem,
-          isEnabled(PenaltiesAndAppeals), isEnabled(RecentActivity), isEnabled(CreditsRefundsRepay), isEnabled(MortgageEvidence)))
+          isEnabled(PenaltiesAndAppeals), isEnabled(RecentActivity), isEnabled(CreditsRefundsRepay), isEnabled(MortgageEvidence),
+          Some(manageBusinessesUrl(user.isAgent))))
       }
     }
   }

--- a/app/hub/models/homePage/HomePageViewModel.scala
+++ b/app/hub/models/homePage/HomePageViewModel.scala
@@ -59,7 +59,7 @@ object NextPaymentsTileViewModel {
 
 case class ReturnsTileViewModel(currentTaxYear: TaxYear, iTSASubmissionIntegrationEnabled: Boolean)
 
-case class YourBusinessesTileViewModel(displayCeaseAnIncome: Boolean)
+case class YourBusinessesTileViewModel(displayCeaseAnIncome: Boolean, manageBusinessesUrl: Option[String] = None)
 
 case class YourReportingObligationsTileViewModel(currentTaxYear: TaxYear, currentYearITSAStatus: ITSAStatus)
 

--- a/app/hub/views/helpers/injected/home/IncomeSourcesTile.scala.html
+++ b/app/hub/views/helpers/injected/home/IncomeSourcesTile.scala.html
@@ -29,10 +29,12 @@
 @(yourBusinessesTileViewModel: YourBusinessesTileViewModel, isAgent: Boolean)(implicit messages: Messages)
 
 @manageBusinessesControllerURL = @{
-    if(isAgent) {
-        manageBusinessRoutes.ManageYourBusinessesController.showAgent().url
-    } else {
-        manageBusinessRoutes.ManageYourBusinessesController.show().url
+    yourBusinessesTileViewModel.manageBusinessesUrl.getOrElse {
+        if(isAgent) {
+            manageBusinessRoutes.ManageYourBusinessesController.showAgent().url
+        } else {
+            manageBusinessRoutes.ManageYourBusinessesController.show().url
+        }
     }
 }
 

--- a/app/hub/views/newHomePage/NewHomeOverviewView.scala.html
+++ b/app/hub/views/newHomePage/NewHomeOverviewView.scala.html
@@ -52,7 +52,8 @@
         penaltiesAndAppealsEnabled: Boolean,
         isRecentActivityEnabled: Boolean,
         creditsRefundsRepayEnabled: Boolean,
-        mortgageEvidenceEnabled: Boolean)(
+        mortgageEvidenceEnabled: Boolean,
+        manageBusinessesUrl: Option[String] = None)(
         implicit messages: Messages, appConfig: FrontendAppConfig, request: RequestHeader, user: common.auth.MtdItUser[_]
 )
 
@@ -121,7 +122,7 @@
     @deadlinesSection(isAgent = false)
     @SectionBreak
 
-    @incomeSection(isAgent = false)
+    @incomeSection(isAgent = false, manageBusinessesUrl = manageBusinessesUrl)
     @SectionBreak
 
 @taxYearSection(isAgent = false, taxYear = currentTaxYear, mortgageEvidenceEnabled = mortgageEvidenceEnabled)    @SectionBreak
@@ -143,7 +144,7 @@
     @deadlinesSection(isAgent = true)
     @SectionBreak
 
-    @incomeSection(isAgent = true)
+    @incomeSection(isAgent = true, manageBusinessesUrl = manageBusinessesUrl)
     @SectionBreak
 
 @taxYearSection(isAgent = true, taxYear = currentTaxYear, mortgageEvidenceEnabled = mortgageEvidenceEnabled)    @SectionBreak
@@ -159,7 +160,7 @@
     @deadlinesSection(isAgent = true)
     @SectionBreak
 
-    @incomeSection(isAgent = true)
+    @incomeSection(isAgent = true, manageBusinessesUrl = manageBusinessesUrl)
 }
 
 

--- a/app/hub/views/partials/newHome/overview/IncomeSection.scala.html
+++ b/app/hub/views/partials/newHome/overview/IncomeSection.scala.html
@@ -16,18 +16,18 @@
 
 @import hub.views.html.partials.newHome.overview.OverviewCard
 @import businessDetails.controllers.manageBusinesses.routes.{ManageYourBusinessesController}
-
-
 @this(overviewCard: OverviewCard)
 
 
-@(isAgent: Boolean)(implicit messages: Messages)
+@(isAgent: Boolean, manageBusinessesUrl: Option[String] = None)(implicit messages: Messages)
 
 @manageBusinessUrl = @{
-    if(isAgent){
-        ManageYourBusinessesController.showAgent().url
-    } else {
-        ManageYourBusinessesController.show().url
+    manageBusinessesUrl.getOrElse {
+        if(isAgent){
+            ManageYourBusinessesController.showAgent().url
+        } else {
+            ManageYourBusinessesController.show().url
+        }
     }
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -201,7 +201,6 @@ microservice {
       income-tax-business-details-frontend {
         host = localhost
         port = 9088
-        protocol = "http"
       }
 
     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -198,6 +198,12 @@ microservice {
         port = 9089
       }
 
+      income-tax-business-details-frontend {
+        host = localhost
+        port = 9088
+        protocol = "http"
+      }
+
     }
 }
 
@@ -228,6 +234,7 @@ feature-switch {
   enable-mortgage-evidence = false
   enable-idempotency-key-for-create-income-source = false
   enable-no-income-sources-redirect = false
+  enable-business-details-frontend = false
 }
 
 #  Keep this false for local environment

--- a/test/common/config/featureswitch/FeatureSwitchingSpec.scala
+++ b/test/common/config/featureswitch/FeatureSwitchingSpec.scala
@@ -62,7 +62,8 @@ class FeatureSwitchingSpec extends TestSupport with MockitoSugar {
     RecentActivity,
     MortgageEvidence,
     IdempotencyKeyForCreateIncomeSource,
-    NoIncomeSourcesRedirect
+    NoIncomeSourcesRedirect,
+        BusinessDetailsFrontend
   )
 
   "FeatureSwitchName" when {


### PR DESCRIPTION
Objective: Add the BusinessDetails feature switch so when enabled it redirects to the BusinessDetails service

Acceptance Criteria

When enabled the BusinessDetails to BusinessDetails service happen
When disabled stays in V&C frontend.




Steps to implement:{}

 add a new feature switch to list of feature switches in view-change-frontend and the stub
On the home page where links to the business details service are update so it is feature switched to go to business details when enabled




Useful documentation




Copy

TBC

Prototype

TBC

Testing strategy
Integration
Unit
Acceptance criteria




Known dependencies

TBC

Outstanding unknowns/work

TBC

DoR/DoD