### PR TITLE
MISUV-11601: Remove stale TODO comments

### DIFF
--- a/app/businessDetails/controllers/manageBusinesses/add/AddIncomeSourceStartDateController.scala
+++ b/app/businessDetails/controllers/manageBusinesses/add/AddIncomeSourceStartDateController.scala
@@ -55,7 +55,6 @@ class AddIncomeSourceStartDateController @Inject()(val authActions: AuthActionsW
                                                    val ec: ExecutionContext)
   extends FrontendController(mcc) with JourneyCheckerManageBusinesses with I18nSupport {
 
-  //TODO: Redirect the user back to the triggered migration page if they access the page with triggered migration as false and they are unconfirmed
   def show(isAgent: Boolean, mode: Mode, incomeSourceType: IncomeSourceType, isTriggeredMigration: Boolean = false): Action[AnyContent] =
     authActions.asMTDIndividualOrAgentWithClient(isAgent, isTriggeredMigration).async { implicit user =>
       handleShowRequest(

--- a/app/connectors/FinancialDetailsConnector.scala
+++ b/app/connectors/FinancialDetailsConnector.scala
@@ -140,7 +140,6 @@ class FinancialDetailsConnector @Inject()(
       }
   }
 
-  // TODO: MFA Credits
   def getFinancialDetails(taxYear: Int, nino: String)
                          (implicit headerCarrier: HeaderCarrier, mtdItUser: MtdItUser[_]): Future[FinancialDetailsResponseModel] = {
 

--- a/app/financials/controllers/MoneyInYourAccountController.scala
+++ b/app/financials/controllers/MoneyInYourAccountController.scala
@@ -89,7 +89,7 @@ class MoneyInYourAccountController @Inject()(val authActions: AuthActions,
       implicit user =>
         if (isEnabled(CreditsRefundsRepay)) {
           handleRefundRequest(
-            backUrl = "", // TODO: do we need a backUrl
+            backUrl = "",
             isAgent = false
           ) recover logAndRedirect
         } else {
@@ -102,7 +102,7 @@ class MoneyInYourAccountController @Inject()(val authActions: AuthActions,
       implicit user =>
         if (isEnabled(CreditsRefundsRepay)) {
           handleRefundRequest(
-            backUrl = "", // TODO: do we need a backUrl
+            backUrl = "",
             isAgent = true
           ) recover logAndRedirect
         } else {

--- a/app/financials/models/nrs/NrsMetadata.scala
+++ b/app/financials/models/nrs/NrsMetadata.scala
@@ -42,7 +42,6 @@ case class NrsMetadata(
 object NrsMetadata extends InstantFormatter {
   implicit val writes: Writes[NrsMetadata] = Json.writes[NrsMetadata]
 
-  // TODO: Could be required to populate this in the future - but not required as part of MISUV-10030
   private val emptyIdentityData = IdentityData(
     confidenceLevel = ConfidenceLevel.L250,
     agentInformation = AgentInformation(None, None, None),


### PR DESCRIPTION
- MoneyInYourAccountController: backUrl is never forwarded to any view,redirect or external call
- NrsMetadata: emptyIdentityData is never used. RecalculatePoaHelperal already passes real identity data from user.authUserDetails
- FinancialDetailsConnector: MFA credit handling is complete
- AddIncomeSourceStartDateController: redirect for unconfirmed triggered-migration users is already handled in TriggeredMigrationRetrievalAction before reaching the controller