### PR TITLE
Removal of TODOs as no longer valid

### DIFF
--- a/app/financials/models/DocumentDetail.scala
+++ b/app/financials/models/DocumentDetail.scala
@@ -119,7 +119,7 @@ case class DocumentDetail(taxYear: Int,
     case _ => false
   }
 
-  def isBalancingCharge: Boolean = getDocumentChargeTypeKey == "balancingCharge.text" 
+  def isBalancingCharge: Boolean = getDocumentChargeTypeKey == "balancingCharge.text"
 
   def isBalancingChargeZero: Boolean = {
     (isBalancingCharge, this.originalAmount) match {

--- a/app/financials/models/DocumentDetail.scala
+++ b/app/financials/models/DocumentDetail.scala
@@ -119,7 +119,7 @@ case class DocumentDetail(taxYear: Int,
     case _ => false
   }
 
-  def isBalancingCharge: Boolean = getChargeTypeKey == "balancingCharge.text"
+  def isBalancingCharge: Boolean = getDocumentChargeTypeKey == "balancingCharge.text" 
 
   def isBalancingChargeZero: Boolean = {
     (isBalancingCharge, this.originalAmount) match {
@@ -145,7 +145,7 @@ case class DocumentDetail(taxYear: Int,
     }
   }
 
-  def getChargeTypeKey: String = documentDescription match {
+  def getDocumentChargeTypeKey: String = documentDescription match {
     case Some(poa1) if poa1.replace(" ", "") == Poa1Charge.key.replace(" ", "") => "paymentOnAccount1.text"
     case Some(poa2) if poa2.replace(" ", "") == Poa2Charge.key.replace(" ", "") => "paymentOnAccount2.text"
     case Some(Poa1ReconciliationDebit.key) => "poa1ExtraCharge.text"

--- a/app/financials/models/DocumentDetail.scala
+++ b/app/financials/models/DocumentDetail.scala
@@ -145,7 +145,6 @@ case class DocumentDetail(taxYear: Int,
     }
   }
 
-  // TODO: duplicate logic, in scope of => https://jira.tools.tax.service.gov.uk/browse/MISUV-8557
   def getChargeTypeKey: String = documentDescription match {
     case Some(poa1) if poa1.replace(" ", "") == Poa1Charge.key.replace(" ", "") => "paymentOnAccount1.text"
     case Some(poa2) if poa2.replace(" ", "") == Poa2Charge.key.replace(" ", "") => "paymentOnAccount2.text"

--- a/app/financials/models/TransactionItem.scala
+++ b/app/financials/models/TransactionItem.scala
@@ -44,9 +44,7 @@ trait TransactionItem {
       case _ => true
     }
   }
-
-  // TODO: duplicate logic, in scope of => https://jira.tools.tax.service.gov.uk/browse/MISUV-8557
-  // TODO: We should remove DocumentDetail.getChargeTypeKey and keep this method below as it is tied to ChargeItem
+  
   def getChargeTypeKey: String =
     (transactionType, codedOutStatus) match {
       case (PoaOneDebit, Some(Accepted))        => "poa1CodedOut.text"

--- a/app/financials/models/audit/PaymentAllocationsResponseAuditModel.scala
+++ b/app/financials/models/audit/PaymentAllocationsResponseAuditModel.scala
@@ -85,7 +85,7 @@ case class PaymentAllocationsResponseAuditModel(mtdItUser: MtdItUser[_],
       Json.obj("paymentAllocations" -> Json.arr(
         paymentAllocations.latePaymentInterestPaymentAllocationDetails.map { lpiad =>
           Json.obj() ++
-            Json.obj("paymentAllocationDescription"-> Some(getAllocationDescriptionFromKey(lpiad.documentDetail.getChargeTypeKey))) ++
+            Json.obj("paymentAllocationDescription"-> Some(getAllocationDescriptionFromKey(lpiad.documentDetail.getDocumentChargeTypeKey))) ++
             Json.obj("amount"-> Some(lpiad.amount)) ++
             Json.obj("taxYear"-> Some(getTaxYearString(LocalDate.parse(s"${lpiad.documentDetail.taxYear}-04-05"))))
         }

--- a/app/financials/views/partials/paymentAllocations/PaymentAllocationsForLpi.scala.html
+++ b/app/financials/views/partials/paymentAllocations/PaymentAllocationsForLpi.scala.html
@@ -31,10 +31,10 @@
             <td class="govuk-table__cell" id="payment-allocation-0">
                 @if(user.isAgent){
                     <a class="govuk-link" style="display:block" href="@{financialsRoutes.ChargeSummaryController.showAgent(lpiAllocationDetails.documentDetail.taxYear.toInt, lpiAllocationDetails.documentDetail.transactionId, true)}" class="govuk-link">
-                    @messages(s"paymentAllocation.paymentAllocations.${lpiAllocationDetails.documentDetail.getChargeTypeKey}")
+                    @messages(s"paymentAllocation.paymentAllocations.${lpiAllocationDetails.documentDetail.getDocumentChargeTypeKey}")
                 } else {
                     <a class="govuk-link" style="display:block" href="@{financialsRoutes.ChargeSummaryController.show(lpiAllocationDetails.documentDetail.taxYear.toInt, lpiAllocationDetails.documentDetail.transactionId, true, origin)}" class="govuk-link">
-                    @messages(s"paymentAllocation.paymentAllocations.${lpiAllocationDetails.documentDetail.getChargeTypeKey}")
+                    @messages(s"paymentAllocation.paymentAllocations.${lpiAllocationDetails.documentDetail.getDocumentChargeTypeKey}")
                 }
                 </a>
             </td>

--- a/app/returns/models/TransactionItem.scala
+++ b/app/returns/models/TransactionItem.scala
@@ -44,7 +44,7 @@ trait TransactionItem {
       case _ => true
     }
   }
-  
+
   def getChargeTypeKey: String =
     (transactionType, codedOutStatus) match {
       case (PoaOneDebit, Some(Accepted))        => "poa1CodedOut.text"

--- a/app/returns/models/TransactionItem.scala
+++ b/app/returns/models/TransactionItem.scala
@@ -44,9 +44,7 @@ trait TransactionItem {
       case _ => true
     }
   }
-
-  // TODO: duplicate logic, in scope of => https://jira.tools.tax.service.gov.uk/browse/MISUV-8557
-  // TODO: We should remove DocumentDetail.getChargeTypeKey and keep this method below as it is tied to ChargeItem
+  
   def getChargeTypeKey: String =
     (transactionType, codedOutStatus) match {
       case (PoaOneDebit, Some(Accepted))        => "poa1CodedOut.text"

--- a/test/financials/models/DocumentDetailSpec.scala
+++ b/test/financials/models/DocumentDetailSpec.scala
@@ -97,91 +97,91 @@ class DocumentDetailSpec extends UnitSpec {
       }
     }
 
-    "getChargeTypeKey" should {
+    "getDocumentChargeTypeKey" should {
 
       "return POA1" when {
         "when document description is ITSA- POA 1" in {
-          fullDocumentDetailModel.copy(documentDescription = Some("ITSA- POA 1")).getChargeTypeKey shouldBe "paymentOnAccount1.text"
+          fullDocumentDetailModel.copy(documentDescription = Some("ITSA- POA 1")).getDocumentChargeTypeKey shouldBe "paymentOnAccount1.text"
 
         }
       }
       "return POA2" when {
         "when document description is ITSA - POA 2" in {
-          fullDocumentDetailModel.copy(documentDescription = Some("ITSA- POA 2")).getChargeTypeKey shouldBe "paymentOnAccount2.text"
+          fullDocumentDetailModel.copy(documentDescription = Some("ITSA- POA 2")).getDocumentChargeTypeKey shouldBe "paymentOnAccount2.text"
 
         }
       }
       "return unknown charge" when {
         "when document description is ITSA- XYZ" in {
-          fullDocumentDetailModel.copy(documentDescription = Some("ITSA- XYZ")).getChargeTypeKey shouldBe "unknownCharge"
+          fullDocumentDetailModel.copy(documentDescription = Some("ITSA- XYZ")).getDocumentChargeTypeKey shouldBe "unknownCharge"
         }
       }
       "return BCD" when {
         "when document description is TRM New Charge and is not coding out" in {
-          fullDocumentDetailModel.copy(documentDescription = Some("TRM New Charge")).getChargeTypeKey shouldBe "balancingCharge.text"
+          fullDocumentDetailModel.copy(documentDescription = Some("TRM New Charge")).getDocumentChargeTypeKey shouldBe "balancingCharge.text"
         }
         "when document description is TRM Amend Charge and is not coding out" in {
-          fullDocumentDetailModel.copy(documentDescription = Some("TRM Amend Charge")).getChargeTypeKey shouldBe "balancingCharge.text"
+          fullDocumentDetailModel.copy(documentDescription = Some("TRM Amend Charge")).getDocumentChargeTypeKey shouldBe "balancingCharge.text"
         }
       }
       "return class 2 nics or BCD charge" when {
         "when document description is TRM New Charge and is class 2 nics" in {
           fullDocumentDetailModel.copy(documentDescription = Some("TRM New Charge"),
-            documentText = Some(CODING_OUT_CLASS2_NICS)).getChargeTypeKey shouldBe "class2Nic.text"
+            documentText = Some(CODING_OUT_CLASS2_NICS)).getDocumentChargeTypeKey shouldBe "class2Nic.text"
         }
         "when document description is TRM Amend Charge, coding out is enabled and is class 2 nics" in {
           fullDocumentDetailModel.copy(documentDescription = Some("TRM Amend Charge"),
-            documentText = Some(CODING_OUT_CLASS2_NICS)).getChargeTypeKey shouldBe "class2Nic.text"
+            documentText = Some(CODING_OUT_CLASS2_NICS)).getDocumentChargeTypeKey shouldBe "class2Nic.text"
         }
       }
       "return coding out text or BCD charge" when {
         "when document description is TRM New Charge and is paye self assessment" in {
           fullDocumentDetailModel.copy(documentDescription = Some("TRM New Charge"),
-            documentText = Some(CODING_OUT_ACCEPTED)).getChargeTypeKey shouldBe "codingOut.text"
+            documentText = Some(CODING_OUT_ACCEPTED)).getDocumentChargeTypeKey shouldBe "codingOut.text"
         }
         "when document description is TRM Amend Charge, coding out is enabled and is paye self assessment" in {
           fullDocumentDetailModel.copy(documentDescription = Some("TRM Amend Charge"),
-            documentText = Some(CODING_OUT_ACCEPTED)).getChargeTypeKey shouldBe "codingOut.text"
+            documentText = Some(CODING_OUT_ACCEPTED)).getDocumentChargeTypeKey shouldBe "codingOut.text"
         }
       }
       "return cancelled paye self assessment text or BCD charge" when {
         "when document description is TRM New Charge and is cancelled paye self assessment" in {
           fullDocumentDetailModel.copy(documentDescription = Some("TRM New Charge"),
-            documentText = Some(CODING_OUT_CANCELLED)).getChargeTypeKey shouldBe "cancelledPayeSelfAssessment.text"
+            documentText = Some(CODING_OUT_CANCELLED)).getDocumentChargeTypeKey shouldBe "cancelledPayeSelfAssessment.text"
         }
         "when document description is TRM Amend Charge, coding out is enabled and is cancelled paye self assessment" in {
           fullDocumentDetailModel.copy(documentDescription = Some("TRM Amend Charge"),
-            documentText = Some(CODING_OUT_CANCELLED)).getChargeTypeKey shouldBe "cancelledPayeSelfAssessment.text"
+            documentText = Some(CODING_OUT_CANCELLED)).getDocumentChargeTypeKey shouldBe "cancelledPayeSelfAssessment.text"
         }
       }
       "return POA 1 Reconciliation Debit" when {
         "document description is POA 1 Reconciliation Debit" in {
-          fullDocumentDetailModel.copy(documentDescription = Some("POA 1 Reconciliation Debit")).getChargeTypeKey shouldBe "poa1ExtraCharge.text"
+          fullDocumentDetailModel.copy(documentDescription = Some("POA 1 Reconciliation Debit")).getDocumentChargeTypeKey shouldBe "poa1ExtraCharge.text"
         }
       }
       "return POA 2 Reconciliation Debit" when {
         "document description is POA 2 Reconciliation Debit" in {
-          fullDocumentDetailModel.copy(documentDescription = Some("POA 2 Reconciliation Debit")).getChargeTypeKey shouldBe "poa2ExtraCharge.text"
+          fullDocumentDetailModel.copy(documentDescription = Some("POA 2 Reconciliation Debit")).getDocumentChargeTypeKey shouldBe "poa2ExtraCharge.text"
         }
       }
       "return Late submission penalty" when {
         "document description is LSP" in {
-          fullDocumentDetailModel.copy(documentDescription = Some("LSP")).getChargeTypeKey shouldBe "lateSubmissionPenalty.text"
+          fullDocumentDetailModel.copy(documentDescription = Some("LSP")).getDocumentChargeTypeKey shouldBe "lateSubmissionPenalty.text"
         }
       }
       "return Balancing charge" when {
         "document description is ITSA BCD" in {
-          fullDocumentDetailModel.copy(documentDescription = Some("ITSA BCD")).getChargeTypeKey shouldBe "balancingCharge.text"
+          fullDocumentDetailModel.copy(documentDescription = Some("ITSA BCD")).getDocumentChargeTypeKey shouldBe "balancingCharge.text"   
         }
       }
       "return First late payment penalty" when {
         "document description is LPP1" in {
-          fullDocumentDetailModel.copy(documentDescription = Some("LPP1")).getChargeTypeKey shouldBe "firstLatePaymentPenalty.text"
+          fullDocumentDetailModel.copy(documentDescription = Some("LPP1")).getDocumentChargeTypeKey shouldBe "firstLatePaymentPenalty.text"
         }
       }
       "return Second late payment penalty" when {
         "document description is LPP2" in {
-          fullDocumentDetailModel.copy(documentDescription = Some("LPP2")).getChargeTypeKey shouldBe "secondLatePaymentPenalty.text"
+          fullDocumentDetailModel.copy(documentDescription = Some("LPP2")).getDocumentChargeTypeKey shouldBe "secondLatePaymentPenalty.text"
         }
       }
     }


### PR DESCRIPTION
DocumentDetails is still being used for LPI calls and uses a different input to TransactionItem so it is best to keep them as separate functions.