### PR TITLE
MISUV-11656 Use session cookie instead of Referer to detect Triggered Migration confirmation

### DIFF
--- a/app/businessDetails/controllers/triggeredMigration/CheckActiveBusinessesConfirmController.scala
+++ b/app/businessDetails/controllers/triggeredMigration/CheckActiveBusinessesConfirmController.scala
@@ -28,6 +28,7 @@ import businessDetails.views.html.triggeredMigration.CheckActiveBusinessesConfir
 import common.auth.AuthActions
 import common.config.FrontendAppConfig
 import common.services.{AuditingService, CustomerFactsUpdateService}
+import common.utils.sessionUtils.SessionKeys
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -84,7 +85,15 @@ class CheckActiveBusinessesConfirmController @Inject()(
                 triggeredMigrationService.saveConfirmedData().flatMap {
                   _ => {
                     auditingService.extendedAudit(TriggeredMigrationCompleteAuditModel())
-                    Future.successful(Redirect(routes.CheckCompleteController.show(isAgent)))
+                    Future.successful(
+                      // Stores the confirmation in the session cookie so IncomeSourceConnector can send the Gov-Test-Scenario header
+                      // and retrieve post-migration stub data on subsequent requests in local and staging environments.
+                      // This has no effect in production.
+                      //
+                      // To test the post-migration stub data in QA, add Gov-Test-Scenario to QA's headersAllowlist.
+                      Redirect(routes.CheckCompleteController.show(isAgent))
+                        .addingToSession(SessionKeys.triggeredMigrationConfirmed -> "true")
+                    )
                   }
                 }
               }

--- a/app/common/config/FrontendAppConfig.scala
+++ b/app/common/config/FrontendAppConfig.scala
@@ -188,8 +188,6 @@ class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, val config
 
   def poaAdjustmentOverrides(): Option[Seq[String]] = config.getOptional[Seq[String]]("afterPoaAmountAdjusted")
 
-  def triggeredMigrationOverrides(): Option[Seq[String]] = config.getOptional[Seq[String]]("afterMigration")
-
   val cacheTtl: Int = config.get[Int]("mongodb.timeToLiveInSeconds")
 
   val encryptionIsEnabled: Boolean = config.get[Boolean]("encryption.isEnabled")

--- a/app/common/connectors/IncomeSourceConnector.scala
+++ b/app/common/connectors/IncomeSourceConnector.scala
@@ -21,9 +21,11 @@ import common.config.FrontendAppConfig
 import common.models.audit.IncomeSourceDetailsResponseAuditModel
 import common.models.incomeSourceDetails.{IncomeSourceDetailsError, IncomeSourceDetailsModel, IncomeSourceDetailsResponse}
 import common.services.AuditingService
+import common.utils.sessionUtils.SessionKeys
 import play.api.Logger
 import play.api.http.Status.OK
-import play.api.http.{HeaderNames, Status}
+import play.api.http.Status
+import play.api.mvc.Request
 import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
@@ -46,16 +48,17 @@ class IncomeSourceConnector @Inject()(
   def modifyHeaderCarrier(
                            path: String,
                            headerCarrier: HeaderCarrier
-                         )(implicit appConfig: FrontendAppConfig): HeaderCarrier = {
+                         )(implicit appConfig: FrontendAppConfig, request: Request[_]): HeaderCarrier = {
 
     val manageBusinessesPattern = """.*/manage-your-businesses/.*""".r
     val incomeSourcesPattern    = """.*/income-sources/.*""".r
-    val confirmTriggeredMigrationUrl   = "/check-your-active-businesses/confirm"
-    val completedTriggeredMigrationUrl = "/check-your-active-businesses/complete"
 
-    val refererOpt = headerCarrier.extraHeaders.find(_._1.equalsIgnoreCase(HeaderNames.REFERER)).map(_._2)
-
-    if (refererOpt.exists(ref => ref.contains(confirmTriggeredMigrationUrl) || ref.contains(completedTriggeredMigrationUrl))) {
+    // After the user confirms migration, send the Gov-Test-Scenario: afterMigration header so local and staging
+    // environments return the post-migration stub data instead of the default response.
+    // The header is not included in production's headersAllowlist, so it is never forwarded downstream in production.
+    //
+    // To test the post-migration stub data in QA, add Gov-Test-Scenario to QA's headersAllowlist.
+    if (request.session.get(SessionKeys.triggeredMigrationConfirmed).contains("true")) {
       return checkAndAddTestHeader(path, headerCarrier, appConfig.triggeredMigrationOverrides(), "afterMigration")
     }
 
@@ -71,7 +74,7 @@ class IncomeSourceConnector @Inject()(
     val url = getIncomeSourcesUrl(mtdItUser.mtditId)
     Logger("application").debug(s"GET $url")
 
-    val hc: HeaderCarrier = modifyHeaderCarrier(mtdItUser.path, headerCarrier)(appConfig)
+    val hc: HeaderCarrier = modifyHeaderCarrier(mtdItUser.path, headerCarrier)(appConfig, mtdItUser)
 
     httpClient
       .get(url"$url")

--- a/app/common/connectors/IncomeSourceConnector.scala
+++ b/app/common/connectors/IncomeSourceConnector.scala
@@ -53,13 +53,11 @@ class IncomeSourceConnector @Inject()(
     val manageBusinessesPattern = """.*/manage-your-businesses/.*""".r
     val incomeSourcesPattern    = """.*/income-sources/.*""".r
 
-    // After the user confirms migration, send the Gov-Test-Scenario: afterMigration header so local and staging
-    // environments return the post-migration stub data instead of the default response.
-    // The header is not included in production's headersAllowlist, so it is never forwarded downstream in production.
-    //
-    // To test the post-migration stub data in QA, add Gov-Test-Scenario to QA's headersAllowlist.
+    // Once the user has confirmed migration, send Gov-Test-Scenario: afterMigration on every request for the rest
+    // of the session. Local and staging environments keep returning the post-migration stub data no matter which page is requested.
+    // The header is not in production's QA headersAllowlist, so it is never forwarded downstream in production.
     if (request.session.get(SessionKeys.triggeredMigrationConfirmed).contains("true")) {
-      return checkAndAddTestHeader(path, headerCarrier, appConfig.triggeredMigrationOverrides(), "afterMigration")
+      return headerCarrier.withExtraHeaders("Gov-Test-Scenario" -> "afterMigration")
     }
 
     if (manageBusinessesPattern.matches(path) || incomeSourcesPattern.matches(path)) {

--- a/app/common/utils/sessionUtils/SessionKeys.scala
+++ b/app/common/utils/sessionUtils/SessionKeys.scala
@@ -26,5 +26,9 @@ object SessionKeys {
   val isSupportingAgent: String = "isSupportingAgent"
   val confirmedClient: String = "ConfirmedClient"
   val mandationStatus: String = "mandation_status"
+  // Set after a user confirms Triggered Migration. IncomeSourceConnector uses it to request the
+  // "afterMigration" stub response in local and staging environments.
+  // To test this response in QA, add Gov-Test-Scenario to QA's headersAllowlist.
+  val triggeredMigrationConfirmed: String = "TriggeredMigrationConfirmed"
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -410,7 +410,9 @@ afterMigration = [
     "client-income-tax",
     "income-tax",
     "overview",
-    "help"
+    "help",
+    "your-tasks",
+    "recent-activity"
 ]
 
 bootstrap.http.headersAllowlist = [ "Gov-Test-Scenario", "Location", "X-Request-Timestamp", "X-Session-Id" ]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -404,17 +404,6 @@ afterPoaAmountAdjusted = [
     "success"
 ]
 
-afterMigration = [
-    "complete",
-    "view",
-    "client-income-tax",
-    "income-tax",
-    "overview",
-    "help",
-    "your-tasks",
-    "recent-activity"
-]
-
 bootstrap.http.headersAllowlist = [ "Gov-Test-Scenario", "Location", "X-Request-Timestamp", "X-Session-Id" ]
 
 internalServiceHostPatterns = [ "localhost" ]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -407,7 +407,10 @@ afterPoaAmountAdjusted = [
 afterMigration = [
     "complete",
     "view",
-    "client-income-tax"
+    "client-income-tax",
+    "income-tax",
+    "overview",
+    "help"
 ]
 
 bootstrap.http.headersAllowlist = [ "Gov-Test-Scenario", "Location", "X-Request-Timestamp", "X-Session-Id" ]

--- a/test/businessDetails/controllers/triggeredMigration/CheckActiveBusinessesConfirmControllerSpec.scala
+++ b/test/businessDetails/controllers/triggeredMigration/CheckActiveBusinessesConfirmControllerSpec.scala
@@ -24,9 +24,10 @@ import common.models.admin.TriggeredMigration
 import common.services.{CustomerFactsUpdateService, DateServiceInterface}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
+import common.utils.sessionUtils.SessionKeys
 import play.api
 import play.api.Application
-import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout, redirectLocation, status}
+import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout, redirectLocation, session, status}
 import common.testConstants.IncomeSourceDetailsTestConstants.singleBusinessIncome
 
 import scala.concurrent.Future
@@ -105,6 +106,7 @@ class CheckActiveBusinessesConfirmControllerSpec extends MockAuthActions with Mo
           redirectLocation(result).value should include(
             routes.CheckCompleteController.show(isAgent).url
           )
+          session(result).get(SessionKeys.triggeredMigrationConfirmed) shouldBe Some("true")
         }
 
         "redirect back to the Check HMRC Records page when form is valid and 'No' is selected" in {
@@ -122,6 +124,7 @@ class CheckActiveBusinessesConfirmControllerSpec extends MockAuthActions with Mo
           redirectLocation(result).value should include(
             routes.CheckHmrcRecordsController.show(isAgent).url
           )
+          session(result).get(SessionKeys.triggeredMigrationConfirmed) shouldBe None
         }
 
         "return BadRequest when no option is selected" in {

--- a/test/common/connectors/IncomeSourceConnectorSpec.scala
+++ b/test/common/connectors/IncomeSourceConnectorSpec.scala
@@ -33,10 +33,12 @@
 package common.connectors
 
 import common.auth.AuthorisedAndEnrolledRequest
+import common.auth.actions.AuthActionsTestData.defaultAuthorisedAndEnrolledRequest
 import common.config.FrontendAppConfig
 import common.models.audit.{ExtendedAuditModel, IncomeSourceDetailsResponseAuditModel}
 import common.models.incomeSourceDetails.{IncomeSourceDetailsError, IncomeSourceDetailsResponse}
 import common.services.AuditingService
+import common.utils.sessionUtils.SessionKeys
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, reset, verify, when}
 import org.mockito.{AdditionalMatchers, ArgumentMatchers}
@@ -45,9 +47,11 @@ import org.scalatest.prop.Tables.Table
 import play.api.Configuration
 import play.api.libs.json.Json
 import play.api.mvc.Request
+import play.api.test.FakeRequest
 import play.mvc.Http.Status
 import common.testConstants.BaseTestConstants.*
 import common.testConstants.IncomeSourceDetailsTestConstants.singleBusinessAndPropertyMigrat2019
+import common.enums.MTDIndividual
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse, SessionId}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
@@ -216,6 +220,40 @@ class IncomeSourceConnectorSpec extends BaseConnectorSpec {
 
           modifiedHeaderCarrier.extraHeaders.toMap.get("Gov-Test-Scenario") shouldBe expectedHeader
         }
+      }
+    }
+
+    "the triggered migration session flag is set" should {
+
+      val scenarios = Table(
+        ("scenarioName", "path", "expectedHeader"),
+        ("Home, which is on the allow-list", "/income-tax", Some("afterMigration")),
+        ("Complete, which is on the allow-list", "/check-your-active-businesses/complete", Some("afterMigration")),
+        ("Overview, which is on the allow-list", "/overview", Some("afterMigration")),
+        ("Help, which is on the allow-list", "/help", Some("afterMigration")),
+        ("a page not on the allow-list", "/some-other-page", Some(""))
+      )
+
+      forAll(scenarios) { (scenarioName: String, path: String, expectedHeader: Option[String]) =>
+        s"add the migration test header based on the allow-list, not the referer, for $scenarioName with path: $path" in new Setup {
+          implicit val appConfig: FrontendAppConfig = getAppConfig
+          implicit val request: AuthorisedAndEnrolledRequest[_] =
+            defaultAuthorisedAndEnrolledRequest(MTDIndividual, FakeRequest().withSession(SessionKeys.triggeredMigrationConfirmed -> "true"))
+
+          val modifiedHeaderCarrier: HeaderCarrier = connector.modifyHeaderCarrier(path, hc)
+
+          modifiedHeaderCarrier.extraHeaders.toMap.get("Gov-Test-Scenario") shouldBe expectedHeader
+        }
+      }
+    }
+
+    "the triggered migration session flag is not set" should {
+
+      "not add the migration test header, even for a page on the allow-list" in new Setup {
+        implicit val appConfig: FrontendAppConfig = getAppConfig
+        val modifiedHeaderCarrier: HeaderCarrier = connector.modifyHeaderCarrier("/income-tax", hc)
+
+        modifiedHeaderCarrier.extraHeaders.toMap.get("Gov-Test-Scenario") shouldBe None
       }
     }
   }

--- a/test/common/connectors/IncomeSourceConnectorSpec.scala
+++ b/test/common/connectors/IncomeSourceConnectorSpec.scala
@@ -226,30 +226,34 @@ class IncomeSourceConnectorSpec extends BaseConnectorSpec {
     "the triggered migration session flag is set" should {
 
       val scenarios = Table(
-        ("scenarioName", "path", "expectedHeader"),
-        ("Home, which is on the allow-list", "/income-tax", Some("afterMigration")),
-        ("Complete, which is on the allow-list", "/check-your-active-businesses/complete", Some("afterMigration")),
-        ("Overview, which is on the allow-list", "/overview", Some("afterMigration")),
-        ("Help, which is on the allow-list", "/help", Some("afterMigration")),
-        ("a page not on the allow-list", "/some-other-page", Some(""))
+        ("scenarioName", "path"),
+        ("Home", "/income-tax"),
+        ("Complete", "/check-your-active-businesses/complete"),
+        ("Overview", "/overview"),
+        ("Help", "/help"),
+        ("Your tasks", "/your-tasks"),
+        ("Recent activity", "/recent-activity"),
+        ("Reporting frequency", "/reporting-frequency"),
+        ("any other page", "/some-other-page")
       )
 
-      forAll(scenarios) { (scenarioName: String, path: String, expectedHeader: Option[String]) =>
-        s"add the migration test header based on the allow-list, not the referer, for $scenarioName with path: $path" in new Setup {
+      forAll(scenarios) { (scenarioName: String, path: String) =>
+        s"add the migration test header for $scenarioName with path: $path" in new Setup {
           implicit val appConfig: FrontendAppConfig = getAppConfig
           implicit val request: AuthorisedAndEnrolledRequest[_] =
             defaultAuthorisedAndEnrolledRequest(MTDIndividual, FakeRequest().withSession(SessionKeys.triggeredMigrationConfirmed -> "true"))
 
           val modifiedHeaderCarrier: HeaderCarrier = connector.modifyHeaderCarrier(path, hc)
 
-          modifiedHeaderCarrier.extraHeaders.toMap.get("Gov-Test-Scenario") shouldBe expectedHeader
+
+          modifiedHeaderCarrier.extraHeaders.toMap.get("Gov-Test-Scenario") shouldBe Some("afterMigration")
         }
       }
     }
 
     "the triggered migration session flag is not set" should {
 
-      "not add the migration test header, even for a page on the allow-list" in new Setup {
+      "not add the migration test header for any page" in new Setup {
         implicit val appConfig: FrontendAppConfig = getAppConfig
         val modifiedHeaderCarrier: HeaderCarrier = connector.modifyHeaderCarrier("/income-tax", hc)
 


### PR DESCRIPTION
- Re-enabled acceptance tests assertions for this journey: https://github.com/hmrc/income-tax-view-change-frontend-acceptance-test/pull/1467

- To test mannually in your local en, please user the TR000001A user:

<img width="1920" height="1728" alt="image" src="https://github.com/user-attachments/assets/1572a3b7-a763-4987-b2d9-e83cd43167bd" />

